### PR TITLE
RATIS-753. Mark o.a.r.protocol.Message as @FunctionalInterface

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/Message.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/Message.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 /**
  * The information clients append to the raft ring.
  */
+@FunctionalInterface
 public interface Message {
   static Message valueOf(ByteString bytes, Supplier<String> stringSupplier) {
     return new Message() {


### PR DESCRIPTION
From the class name I used to think that it is a base class of POJOs. However, actually it works by its getContent method. It does no harm we mark it as @FunctionalInterface I think.

I'd like to provide a tiny PR to this issue if you think it is valid. Please assign the issue to me then.

FYI, I'm surprise the first time why a parameter Message looks like `() -> request`. Accurately, `FileStoreClient#L87`.

CC @szetszwo 