### PR TITLE
add start and stop script for Counter example 

### DIFF
--- a/ratis-examples/src/main/bin/start-counter-server.sh
+++ b/ratis-examples/src/main/bin/start-counter-server.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source $DIR/common.sh
+
+# One of the examples, e.g. "filestore" or "arithmetic"
+example="$1"
+shift
+
+subcommand="$1"
+shift
+
+# Find a tmpdir, defaulting to what the environment tells us
+tmp="${TMPDIR:-/tmp}"
+
+echo "Starting 3 Ratis servers with Counter with directories in '${tmp}' as local storage"
+
+for((i=1;i<=3;i++));  
+do   
+java -cp $ARTIFACT org.apache.ratis.examples.counter.server.CounterServer $i &
+done 
+
+
+echo "Waiting for the servers"

--- a/ratis-examples/src/main/bin/stop-counter-server.sh
+++ b/ratis-examples/src/main/bin/stop-counter-server.sh
@@ -1,0 +1,18 @@
+ #!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ kill $(jps -lv | grep 'ratis' | grep 'CounterServer' | grep -v 'grep' | awk '{print $1}')
+ echo "All Ratis examples have been stopped."


### PR DESCRIPTION
## Add handy tool for start or stop three Ratis server at once
Hello, 
I am a new user for Ratis.
I found that in example module, there is no convenient method to start three Ratis server for testing, user have to specified one by one in terminal or IDE.

So, the scripts can be a handy tool for new user testing.
Hope it helpful.

Shucheng Hou