### PR TITLE
RATIS-1291. Send heartbeat when there is no reply

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
@@ -71,11 +71,14 @@ public interface FollowerInfo {
   Timestamp getLastRpcResponseTime();
 
   /** Update lastRpcResponseTime to the current time. */
-  void updateLastRpcResponseTime();
+  void updateLastRpcResponseTime(Timestamp sendTime);
 
-  /** Update lastRpcSendTime to the current time. */
-  void updateLastRpcSendTime();
+  /** Update lastHeartBeatSendTime to the current time. */
+  void updateLastHeartBeatSendTime();
 
-  /** @return the latest of the lastRpcSendTime and the lastRpcResponseTime . */
-  Timestamp getLastRpcTime();
+  /** @return the lastRpcSendTimeWithResponse . */
+  Timestamp getLastRpcSendTimeWithResponse();
+
+  /** @return the lastHeartBeatSendTime . */
+  Timestamp getLastHeartBeatSendTime();
 }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -152,7 +152,9 @@ public interface LogAppender {
    * @return the time in milliseconds that the leader should send a heartbeat.
    */
   default long getHeartbeatRemainingTimeMs() {
-    return getServer().properties().minRpcTimeoutMs()/2 - getFollower().getLastRpcTime().elapsedTimeMs();
+    return getServer().properties().minRpcTimeoutMs()/2 -
+       Math.min(getFollower().getLastRpcSendTimeWithResponse().elapsedTimeMs(),
+           getFollower().getLastHeartBeatSendTime().elapsedTimeMs());
   }
 
   /** Handle the event that the follower has replied a term. */

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -34,7 +34,8 @@ class FollowerInfoImpl implements FollowerInfo {
 
   private final RaftPeer peer;
   private final AtomicReference<Timestamp> lastRpcResponseTime;
-  private final AtomicReference<Timestamp> lastRpcSendTime;
+  private final AtomicReference<Timestamp> lastRpcSendTimeWithResponse;
+  private final AtomicReference<Timestamp> lastHeartBeatSendTime;
   private final RaftLogIndex nextIndex;
   private final RaftLogIndex matchIndex = new RaftLogIndex("matchIndex", 0L);
   private final RaftLogIndex commitIndex = new RaftLogIndex("commitIndex", RaftLog.INVALID_LOG_INDEX);
@@ -48,7 +49,8 @@ class FollowerInfoImpl implements FollowerInfo {
 
     this.peer = peer;
     this.lastRpcResponseTime = new AtomicReference<>(lastRpcTime);
-    this.lastRpcSendTime = new AtomicReference<>(lastRpcTime);
+    this.lastRpcSendTimeWithResponse = new AtomicReference<>(lastRpcTime);
+    this.lastHeartBeatSendTime = new AtomicReference<>(lastRpcTime);
     this.nextIndex = new RaftLogIndex("nextIndex", nextIndex);
     this.attendVote = attendVote;
   }
@@ -119,7 +121,8 @@ class FollowerInfoImpl implements FollowerInfo {
   public String toString() {
     return name + "(c" + getCommitIndex() + ",m" + getMatchIndex() + ",n" + getNextIndex()
         + ", attendVote=" + attendVote +
-        ", lastRpcSendTime=" + lastRpcSendTime.get().elapsedTimeMs() +
+        ", lastHeartBeatSendTime=" + lastHeartBeatSendTime.get().elapsedTimeMs() +
+        ", lastRpcSendTimeWithResponse=" + lastRpcSendTimeWithResponse.get().elapsedTimeMs() +
         ", lastRpcResponseTime=" + lastRpcResponseTime.get().elapsedTimeMs() + ")";
   }
 
@@ -137,8 +140,11 @@ class FollowerInfoImpl implements FollowerInfo {
   }
 
   @Override
-  public void updateLastRpcResponseTime() {
+  public void updateLastRpcResponseTime(Timestamp sendTime) {
     lastRpcResponseTime.set(Timestamp.currentTime());
+    if (sendTime.compareTo(lastRpcSendTimeWithResponse.get()) > 0) {
+      lastRpcSendTimeWithResponse.set(sendTime);
+    }
   }
 
   @Override
@@ -147,12 +153,17 @@ class FollowerInfoImpl implements FollowerInfo {
   }
 
   @Override
-  public void updateLastRpcSendTime() {
-    lastRpcSendTime.set(Timestamp.currentTime());
+  public Timestamp getLastRpcSendTimeWithResponse() {
+    return lastRpcSendTimeWithResponse.get();
   }
 
   @Override
-  public Timestamp getLastRpcTime() {
-    return Timestamp.latest(lastRpcResponseTime.get(), lastRpcSendTime.get());
+  public void updateLastHeartBeatSendTime() {
+    lastHeartBeatSendTime.set(Timestamp.currentTime());
+  }
+
+  @Override
+  public Timestamp getLastHeartBeatSendTime() {
+    return lastHeartBeatSendTime.get();
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -482,7 +482,8 @@ class LeaderStateImpl implements LeaderState {
           LogAppender logAppender = server.newLogAppender(this, f);
           peerIdFollowerInfoMap.put(peer.getId(), f);
           raftServerMetrics.addFollower(peer.getId());
-          logAppenderMetrics.addFollowerGauges(peer.getId(), f::getNextIndex, f::getMatchIndex, f::getLastRpcTime);
+          logAppenderMetrics.addFollowerGauges(
+              peer.getId(), f::getNextIndex, f::getMatchIndex, f::getLastRpcResponseTime);
           return logAppender;
         }).collect(Collectors.toList());
     senders.addAll(newAppenders);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, when there always exist log, leader only send log, and will not send heartbeat. The problem is if follower need a 
long time to process log, leader maybe receives response from follower after a long time.
```
  default long getHeartbeatRemainingTimeMs() {
    return getServer().properties().minRpcTimeoutMs()/2 - getFollower().getLastRpcTime().elapsedTimeMs();
  }
```

In this pr, I record lastRpcSendTimeWithResponse, i.e. when leader receive response of request1, leader record the send time of request1. Besides, I record lastHeartBeatSendTime, i.e. the send time of heartbeat.

Use this two timestamp, leader send heartbeat when can not receive response after minRpcTimeoutMs()/2. If log cost a 
short time from request to reply, leader also does not need to send heartbeat.

```
  default long getHeartbeatRemainingTimeMs() {
    return getServer().properties().minRpcTimeoutMs()/2 -
       Math.min(getFollower().getLastRpcSendTimeWithResponse().elapsedTimeMs(),
           getFollower().getLastHeartBeatSendTime().elapsedTimeMs());
  }
```




## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1291

## How was this patch tested?

no need new ut
