### PR TITLE
Fixes problems with large snapshots

### DIFF
--- a/ratis-proto/src/main/proto/Grpc.proto
+++ b/ratis-proto/src/main/proto/Grpc.proto
@@ -44,7 +44,7 @@ service RaftServerProtocolService {
       returns(stream ratis.common.AppendEntriesReplyProto) {}
 
   rpc installSnapshot(stream ratis.common.InstallSnapshotRequestProto)
-      returns(ratis.common.InstallSnapshotReplyProto) {}
+      returns(stream ratis.common.InstallSnapshotReplyProto) {}
 }
 
 service AdminProtocolService {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
@@ -206,7 +206,9 @@ class StateMachineUpdater implements Runnable {
   }
 
   private void reload() throws IOException {
-    Preconditions.assertTrue(stateMachine.getLifeCycleState() == LifeCycle.State.PAUSED);
+    LifeCycle.State current = stateMachine.getLifeCycleState();
+
+    Preconditions.assertTrue(current == LifeCycle.State.NEW || current == LifeCycle.State.PAUSED);
 
     stateMachine.reinitialize();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hi, 
I have been testing ratis for a solutions which uses rather largish snapshots for the state machine. Current implementation is not able to transfer files larger than 8Mb (I think), throwing all kinds of exceptions.  I guess this is something not really used by current users of ratis.

Here are the places I modified/found to be problematic (code is more precise than words):
FileChunkReader.readFileChunk uses ByteString.readFrom(in, chunkLength); which will fully load the input stream and not just a junk of size chunkLength

Grpc.proto service installSnapshot(stream ratis.common.InstallSnapshotRequestProto) should return a stream

Modifications to SnapshotManager so chunks for the same snapshot will be placed in the same directory 

Not sure if I need to create a jira issue (never used apache f. jira) I can  repro and create jiras with stacktraces etc. 
