### PR TITLE
RATIS-1322. Cannot build from source without repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -884,6 +884,7 @@
             <configuration>
               <outputDirectory>target/classes</outputDirectory>
               <outputName>ratis-version.properties</outputName>
+              <revisionOnScmFailure>Unknown</revisionOnScmFailure>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the build error that occurs if Ratis directory is not a git repo (which would happen when building from release source artifact):

```
[INFO] Apache Ratis ....................................... FAILURE [  0.819 s]
...
[ERROR] Failed to execute goal org.codehaus.mojo:buildnumber-maven-plugin:1.4:create-metadata (default) on project ratis: Execution default of goal org.codehaus.mojo:buildnumber-maven-plugin:1.4:create-metadata failed.: NullPointerException -> [Help 1]
```

`revision` in `ratis-version.properties` is set to `Unknown` in this case.  This matches Ozone's properties for the same situation.

https://issues.apache.org/jira/browse/RATIS-1322

## How was this patch tested?

```
$ mvn -DskipTests clean verify; cat target/classes/ratis-version.properties
...
version=1.1.0-SNAPSHOT
revision=1ce8621b295678c780ad7adaf5621d8114fdefc3
name=Apache Ratis
timestamp=1614187092964

$ rm -fr .git
$ mvn -DskipTests clean verify; cat target/classes/ratis-version.properties
...
version=1.1.0-SNAPSHOT
revision=Unknown
name=Apache Ratis
timestamp=1614187444515
```