### PR TITLE
RATIS-1330. fix ratis-examples SubCommand parsePeers method ArrayIndexOutOfBounds exception

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
@@ -43,6 +43,11 @@ public abstract class SubCommandBase {
   public static RaftPeer[] parsePeers(String peers) {
     return Stream.of(peers.split(",")).map(address -> {
       String[] addressParts = address.split(":");
+      if (addressParts.length < 3) {
+        throw new IllegalArgumentException(
+            "Raft peer " + address + " is not a legitimate format. "
+                + "(format: name:host:port:dataStreamPort:clientPort:adminPort)");
+      }
       RaftPeer.Builder builder = RaftPeer.newBuilder();
       builder.setId(addressParts[0]).setAddress(addressParts[1] + ":" + addressParts[2]);
       if (addressParts.length >= 4) {
@@ -96,7 +101,8 @@ public abstract class SubCommandBase {
         return p;
       }
     }
-    throw new IllegalArgumentException("Raft peer id " + raftPeerId + " is not part of the raft group definitions " +
+    throw new IllegalArgumentException(
+        "Raft peer id " + raftPeerId + " is not part of the raft group definitions " +
             this.peers);
   }
 }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
@@ -101,8 +101,7 @@ public abstract class SubCommandBase {
         return p;
       }
     }
-    throw new IllegalArgumentException(
-        "Raft peer id " + raftPeerId + " is not part of the raft group definitions " +
+    throw new IllegalArgumentException("Raft peer id " + raftPeerId + " is not part of the raft group definitions " +
             this.peers);
   }
 }

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/common/TestSubCommand.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/common/TestSubCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ratis.examples.common;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestSubCommand {
+
+  @Parameterized.Parameters
+  public static Collection<String> data() {
+    return Collections.singleton("127.0.0.1:6667");
+  }
+
+  @Parameterized.Parameter
+  public String peers;
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParsePeers() {
+    SubCommandBase.parsePeers(peers);
+  }
+
+}


### PR DESCRIPTION
Hi, I am a ratis novice and found an array out of bounds issue during testing

I added a check on the data where I manipulated array subscripts and threw an expected exception and hint