### PR TITLE
RATIS-1325. Change 2020 to 2021 in NOTICE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -237,7 +237,7 @@ OF SUCH DAMAGE.
 
 --
 
-Bootstrap
+Bootstrap v3.4.1
 ---------
 The product bundles Bootstrap in these paths:
 
@@ -247,8 +247,8 @@ which is licensed under MIT
 
 The MIT License (MIT)
 
-Copyright (c) 2011-2020 Twitter, Inc.
-Copyright (c) 2011-2020 The Bootstrap Authors
+Copyright (c) 2011-2019 Twitter, Inc.
+Copyright (c) 2011-2019 The Bootstrap Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -270,7 +270,7 @@ THE SOFTWARE.
 
 --
 
-JQuery
+JQuery v3.4.1
 ------
 The product bundles JQuery in
 ratis-docs/themes/ratisdoc/static/js/jquery-3.4.1.min.js

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Ratis
-Copyright 2017-2020 The Apache Software Foundation
+Copyright 2017-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/ratis-assembly/src/main/resources/NOTICE
+++ b/ratis-assembly/src/main/resources/NOTICE
@@ -1,5 +1,5 @@
 Apache Ratis
-Copyright 2017-2020 The Apache Software Foundation
+Copyright 2017-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change 2020 to 2021 in NOTICE

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1325

## How was this patch tested?

No need new ut
