### PR TITLE
RATIS-1333. Add explicit thread names for FollowerState and LeaderState threads.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
@@ -65,6 +65,7 @@ class FollowerState extends Daemon {
 
   FollowerState(RaftServerImpl server, Object reason) {
     this.name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
+    this.setName(this.name);
     this.server = server;
     this.reason = reason;
   }
@@ -153,4 +154,6 @@ class FollowerState extends Daemon {
   public String toString() {
     return name;
   }
+
+
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
@@ -154,6 +154,4 @@ class FollowerState extends Daemon {
   public String toString() {
     return name;
   }
-
-
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -263,7 +263,7 @@ class LeaderStateImpl implements LeaderState {
     this.currentTerm = state.getCurrentTerm();
 
     this.eventQueue = new EventQueue();
-    processor = new EventProcessor();
+    processor = new EventProcessor(this.name);
     raftServerMetrics = server.getRaftServerMetrics();
     logAppenderMetrics = new LogAppenderMetrics(server.getMemberId());
     this.pendingRequests = new PendingRequests(server.getMemberId(), properties, raftServerMetrics);
@@ -575,6 +575,9 @@ class LeaderStateImpl implements LeaderState {
    * state, such as changing to follower, or updating the committed index.
    */
   private class EventProcessor extends Daemon {
+    public EventProcessor(String name) {
+      setName(name);
+    }
     @Override
     public void run() {
       // apply an empty message; check if necessary to replicate (new) conf


### PR DESCRIPTION
## What changes were proposed in this pull request?

A simple improvement to make make thread names more distinct, making troubleshooting easier. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1333

## How was this patch tested?
Confirmed with a VisualVM output that shows thread names.