### PR TITLE
RATIS-1335. Update project mailing lists to use TLP domain.

### DIFF
--- a/community.html
+++ b/community.html
@@ -94,23 +94,41 @@
 <h3 id="mailing-list">Mailing list</h3>
 <h4 id="developers">Developers</h4>
 <p>If you&rsquo;d like to contribute to Apache Ratis, please subscribe to the Ratis developer mailing list.</p>
-<p>The Ratis developer mailing list is: <a href="mailto:dev@ratis.incubator.apache.org">dev@ratis.incubator.apache.org</a>.</p>
+<p>The Ratis developer mailing list is: <a href="mailto:dev@ratis.apache.org">dev@ratis.apache.org</a>.</p>
 <ul>
-<li>[Subscribe to List](mailto: <a href="mailto:dev-subscribe@ratis.incubator.apache.org">dev-subscribe@ratis.incubator.apache.org</a>)</li>
-<li>[Unsubscribe from List](mailto: <a href="mailto:dev-unsubscribe@ratis.incubator.apache.org">dev-unsubscribe@ratis.incubator.apache.org</a>)</li>
+<li><a href="mailto:dev-subscribe@ratis.apache.org">Subscribe to List</a></li>
+<li><a href="mailto:dev-unsubscribe@ratis.apache.org">Unsubscribe from List</a></li>
 <li><a href="http://mail-archives.apache.org/mod_mbox/ratis-dev/">Archives</a></li>
 </ul>
 <h4 id="user">User</h4>
 <p>The user@ mailing list is the preferred mailing list for end-user
 questions and discussion.</p>
 <p>Please use  dev mailing list to address developers on a specific technical question.</p>
-<p>The Ratis user mailing list is: <a href="mailto:user@ratis.incubator.apache.org">user@ratis.incubator.apache.org</a>.</p>
+<p>The Ratis user mailing list is: <a href="mailto:user@ratis.apache.org">user@ratis.apache.org</a>.</p>
 <ul>
-<li>[Subscribe to List](mailto: <a href="mailto:user-subscribe@ratis.incubator.apache.org">user-subscribe@ratis.incubator.apache.org</a>)</li>
-<li>[Unsubscribe from List](mailto: <a href="mailto:user-unsubscribe@ratis.incubator.apache.org">user-unsubscribe@ratis.incubator.apache.org</a>)</li>
+<li><a href="mailto:user-subscribe@ratis.apache.org">Subscribe to List</a></li>
+<li><a href="mailto:user-unsubscribe@ratis.apache.org">Unsubscribe from List</a></li>
 <li><a href="http://mail-archives.apache.org/mod_mbox/ratis-user/">Archives</a></li>
 </ul>
 <p>To post to the list, it is necessary to subscribe to it.</p>
+<h4 id="commits">Commits</h4>
+<p>If you&rsquo;d like to see changes made in the Ratis version control system, please subscribe to the Ratis
+commits mailing list.</p>
+<p>The Ratis commits mailing list is: <a href="mailto:commits@ratis.apache.org">commits@ratis.apache.org</a>.</p>
+<ul>
+<li><a href="mailto:commits-subscribe@ratis.apache.org">Subscribe to List</a></li>
+<li><a href="mailto:commits-unsubscribe@ratis.apache.org">Unsubscribe from List</a></li>
+<li><a href="http://mail-archives.apache.org/mod_mbox/ratis-commits/">Archives</a></li>
+</ul>
+<h4 id="issues">Issues</h4>
+<p>If you&rsquo;d like to see changes made in the Ratis issue tracking system, please subscribe to the Ratis
+issues mailing list.</p>
+<p>The Ratis issues mailing list is: <a href="mailto:issues@ratis.apache.org">issues@ratis.apache.org</a>.</p>
+<ul>
+<li><a href="mailto:issues-subscribe@ratis.apache.org">Subscribe to List</a></li>
+<li><a href="mailto:issues-unsubscribe@ratis.apache.org">Unsubscribe from List</a></li>
+<li><a href="http://mail-archives.apache.org/mod_mbox/ratis-issues/">Archives</a></li>
+</ul>
 <h3 id="slack">Slack</h3>
 <p>You can join the #ratis channel in Apache slack workspace <a href="http://s.apache.org/slack-invite">http://s.apache.org/slack-invite</a> for any discussions.</p>
 

--- a/index.html
+++ b/index.html
@@ -226,23 +226,41 @@
 <h3 id="mailing-list">Mailing list</h3>
 <h4 id="developers">Developers</h4>
 <p>If you&rsquo;d like to contribute to Apache Ratis, please subscribe to the Ratis developer mailing list.</p>
-<p>The Ratis developer mailing list is: <a href="mailto:dev@ratis.incubator.apache.org">dev@ratis.incubator.apache.org</a>.</p>
+<p>The Ratis developer mailing list is: <a href="mailto:dev@ratis.apache.org">dev@ratis.apache.org</a>.</p>
 <ul>
-<li>[Subscribe to List](mailto: <a href="mailto:dev-subscribe@ratis.incubator.apache.org">dev-subscribe@ratis.incubator.apache.org</a>)</li>
-<li>[Unsubscribe from List](mailto: <a href="mailto:dev-unsubscribe@ratis.incubator.apache.org">dev-unsubscribe@ratis.incubator.apache.org</a>)</li>
+<li><a href="mailto:dev-subscribe@ratis.apache.org">Subscribe to List</a></li>
+<li><a href="mailto:dev-unsubscribe@ratis.apache.org">Unsubscribe from List</a></li>
 <li><a href="http://mail-archives.apache.org/mod_mbox/ratis-dev/">Archives</a></li>
 </ul>
 <h4 id="user">User</h4>
 <p>The user@ mailing list is the preferred mailing list for end-user
 questions and discussion.</p>
 <p>Please use  dev mailing list to address developers on a specific technical question.</p>
-<p>The Ratis user mailing list is: <a href="mailto:user@ratis.incubator.apache.org">user@ratis.incubator.apache.org</a>.</p>
+<p>The Ratis user mailing list is: <a href="mailto:user@ratis.apache.org">user@ratis.apache.org</a>.</p>
 <ul>
-<li>[Subscribe to List](mailto: <a href="mailto:user-subscribe@ratis.incubator.apache.org">user-subscribe@ratis.incubator.apache.org</a>)</li>
-<li>[Unsubscribe from List](mailto: <a href="mailto:user-unsubscribe@ratis.incubator.apache.org">user-unsubscribe@ratis.incubator.apache.org</a>)</li>
+<li><a href="mailto:user-subscribe@ratis.apache.org">Subscribe to List</a></li>
+<li><a href="mailto:user-unsubscribe@ratis.apache.org">Unsubscribe from List</a></li>
 <li><a href="http://mail-archives.apache.org/mod_mbox/ratis-user/">Archives</a></li>
 </ul>
 <p>To post to the list, it is necessary to subscribe to it.</p>
+<h4 id="commits">Commits</h4>
+<p>If you&rsquo;d like to see changes made in the Ratis version control system, please subscribe to the Ratis
+commits mailing list.</p>
+<p>The Ratis commits mailing list is: <a href="mailto:commits@ratis.apache.org">commits@ratis.apache.org</a>.</p>
+<ul>
+<li><a href="mailto:commits-subscribe@ratis.apache.org">Subscribe to List</a></li>
+<li><a href="mailto:commits-unsubscribe@ratis.apache.org">Unsubscribe from List</a></li>
+<li><a href="http://mail-archives.apache.org/mod_mbox/ratis-commits/">Archives</a></li>
+</ul>
+<h4 id="issues">Issues</h4>
+<p>If you&rsquo;d like to see changes made in the Ratis issue tracking system, please subscribe to the Ratis
+issues mailing list.</p>
+<p>The Ratis issues mailing list is: <a href="mailto:issues@ratis.apache.org">issues@ratis.apache.org</a>.</p>
+<ul>
+<li><a href="mailto:issues-subscribe@ratis.apache.org">Subscribe to List</a></li>
+<li><a href="mailto:issues-unsubscribe@ratis.apache.org">Unsubscribe from List</a></li>
+<li><a href="http://mail-archives.apache.org/mod_mbox/ratis-issues/">Archives</a></li>
+</ul>
 <h3 id="slack">Slack</h3>
 <p>You can join the #ratis channel in Apache slack workspace <a href="http://s.apache.org/slack-invite">http://s.apache.org/slack-invite</a> for any discussions.</p>
 

--- a/index.xml
+++ b/index.xml
@@ -90,10 +90,10 @@ Key features:
       
       <guid>https://ratis.apache.org/community.html</guid>
       <description>Mailing list Developers If you&amp;rsquo;d like to contribute to Apache Ratis, please subscribe to the Ratis developer mailing list.
-The Ratis developer mailing list is: dev@ratis.incubator.apache.org.
- [Subscribe to List](mailto: dev-subscribe@ratis.incubator.apache.org) [Unsubscribe from List](mailto: dev-unsubscribe@ratis.incubator.apache.org) Archives  User The user@ mailing list is the preferred mailing list for end-user questions and discussion.
+The Ratis developer mailing list is: dev@ratis.apache.org.
+ Subscribe to List Unsubscribe from List Archives  User The user@ mailing list is the preferred mailing list for end-user questions and discussion.
 Please use dev mailing list to address developers on a specific technical question.
-The Ratis user mailing list is: user@ratis.</description>
+The Ratis user mailing list is: user@ratis.apache.org.</description>
     </item>
     
     <item>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The site still documents the project mailing lists in the .incubator sub-domain. Now that the project has graduated to TLP, we can update documentation of the mailing lists.

I also noticed that we did not have documentation for the -commits and -issues lists, so I added those.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1335

## How was this patch tested?

Built site locally and verified changes.
![image](https://user-images.githubusercontent.com/227407/110826027-83c6cf00-8249-11eb-804d-2e055afd7d36.png)
