### PR TITLE
RATIS-1332. Always remove raft-meta.tmp to clean uncommitted changes

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/server/storage/TestRaftStorage.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/storage/TestRaftStorage.java
@@ -162,16 +162,10 @@ public class TestRaftStorage extends BaseTest {
 
     Assert.assertEquals(StorageState.NOT_FORMATTED, sd.analyzeStorage(false));
 
-    try {
-      newRaftStorage(storageDir);
-      Assert.fail("should throw IOException since storage dir is not formatted");
-    } catch (IOException e) {
-      Assert.assertTrue(
-          e.getMessage().contains(StorageState.NOT_FORMATTED.name()));
-    }
+    // RaftStorage initialization should succeed as the raft-meta.tmp is
+    // always cleaned.
+    newRaftStorage(storageDir).close();
 
-    // let the storage dir contain both raft-meta and raft-meta.tmp
-    formatRaftStorage(storageDir).close();
     Assert.assertTrue(sd.getMetaFile().exists());
     Assert.assertTrue(sd.getMetaTmpFile().createNewFile());
     Assert.assertTrue(sd.getMetaTmpFile().exists());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Always remove raft-meta.tmp to clean uncommitted changes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1332

## How was this patch tested?

unit tests.
