### PR TITLE
RATIS-1336. Update download page to link to artifacts at TLP path.

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -107,14 +107,14 @@ The binaries are also uploaded to the maven central for convenience. (See the ge
        <td>1.0.0</td>
        <td>2020 Jul 20 </td>
        <td>
-         <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/1.0.0/apache-ratis-incubating-1.0.0-src.tar.gz">source</a>
-         (<a href="https://downloads.apache.org/incubator/ratis/1.0.0/apache-ratis-incubating-1.0.0-src.tar.gz.mds">checksum</a>
-         <a href="https://downloads.apache.org/incubator/ratis/1.0.0/apache-ratis-incubating-1.0.0-src.tar.gz.asc">signature</a>)
+         <a href="https://www.apache.org/dyn/closer.cgi/ratis/1.0.0/apache-ratis-incubating-1.0.0-src.tar.gz">source</a>
+         (<a href="https://downloads.apache.org/ratis/1.0.0/apache-ratis-incubating-1.0.0-src.tar.gz.mds">checksum</a>
+         <a href="https://downloads.apache.org/ratis/1.0.0/apache-ratis-incubating-1.0.0-src.tar.gz.asc">signature</a>)
         </td>
         <td>
-          <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/1.0.0/apache-ratis-incubating-1.0.0-bin.tar.gz">binary</a>
-          (<a href="https://downloads.apache.org/incubator/ratis/1.0.0/apache-ratis-incubating-1.0.0-bin.tar.gz.mds">checksum</a>
-          <a href="https://downloads.apache.org/incubator/ratis/1.0.0/apache-ratis-incubating-1.0.0-bin.tar.gz.asc">signature</a>)
+          <a href="https://www.apache.org/dyn/closer.cgi/ratis/1.0.0/apache-ratis-incubating-1.0.0-bin.tar.gz">binary</a>
+          (<a href="https://downloads.apache.org/ratis/1.0.0/apache-ratis-incubating-1.0.0-bin.tar.gz.mds">checksum</a>
+          <a href="https://downloads.apache.org/ratis/1.0.0/apache-ratis-incubating-1.0.0-bin.tar.gz.asc">signature</a>)
          </td>
          <td>
            <a href="post/1.0.0.html">Announcement</a>
@@ -125,14 +125,14 @@ The binaries are also uploaded to the maven central for convenience. (See the ge
        <td>0.5.0</td>
        <td>2020 Feb 4 </td>
        <td>
-         <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/0.5.0/apache-ratis-incubating-0.5.0-src.tar.gz">source</a>
-         (<a href="https://downloads.apache.org/incubator/ratis/0.5.0/apache-ratis-incubating-0.5.0-src.tar.gz.mds">checksum</a>
-         <a href="https://downloads.apache.org/incubator/ratis/0.5.0/apache-ratis-incubating-0.5.0-src.tar.gz.asc">signature</a>)
+         <a href="https://www.apache.org/dyn/closer.cgi/ratis/0.5.0/apache-ratis-incubating-0.5.0-src.tar.gz">source</a>
+         (<a href="https://downloads.apache.org/ratis/0.5.0/apache-ratis-incubating-0.5.0-src.tar.gz.mds">checksum</a>
+         <a href="https://downloads.apache.org/ratis/0.5.0/apache-ratis-incubating-0.5.0-src.tar.gz.asc">signature</a>)
         </td>
         <td>
-          <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/0.5.0/apache-ratis-incubating-0.5.0-bin.tar.gz">binary</a>
-          (<a href="https://downloads.apache.org/incubator/ratis/0.5.0/apache-ratis-incubating-0.5.0-bin.tar.gz.mds">checksum</a>
-          <a href="https://downloads.apache.org/incubator/ratis/0.5.0/apache-ratis-incubating-0.5.0-bin.tar.gz.asc">signature</a>)
+          <a href="https://www.apache.org/dyn/closer.cgi/ratis/0.5.0/apache-ratis-incubating-0.5.0-bin.tar.gz">binary</a>
+          (<a href="https://downloads.apache.org/ratis/0.5.0/apache-ratis-incubating-0.5.0-bin.tar.gz.mds">checksum</a>
+          <a href="https://downloads.apache.org/ratis/0.5.0/apache-ratis-incubating-0.5.0-bin.tar.gz.asc">signature</a>)
          </td>
          <td>
            <a href="post/0.5.0.html">Announcement</a>
@@ -143,14 +143,14 @@ The binaries are also uploaded to the maven central for convenience. (See the ge
        <td>0.4.0</td>
        <td>2019 Sep 12 </td>
        <td>
-         <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-src.tar.gz">source</a>
-         (<a href="https://downloads.apache.org/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-src.tar.gz.mds">checksum</a>
-         <a href="https://downloads.apache.org/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-src.tar.gz.asc">signature</a>)
+         <a href="https://www.apache.org/dyn/closer.cgi/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-src.tar.gz">source</a>
+         (<a href="https://downloads.apache.org/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-src.tar.gz.mds">checksum</a>
+         <a href="https://downloads.apache.org/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-src.tar.gz.asc">signature</a>)
         </td>
         <td>
-          <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-bin.tar.gz">binary</a>
-          (<a href="https://downloads.apache.org/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-bin.tar.gz.mds">checksum</a>
-          <a href="https://downloads.apache.org/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-bin.tar.gz.asc">signature</a>)
+          <a href="https://www.apache.org/dyn/closer.cgi/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-bin.tar.gz">binary</a>
+          (<a href="https://downloads.apache.org/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-bin.tar.gz.mds">checksum</a>
+          <a href="https://downloads.apache.org/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-bin.tar.gz.asc">signature</a>)
          </td>
          <td>
            <a href="post/0.4.0.html">Announcement</a>
@@ -161,14 +161,14 @@ The binaries are also uploaded to the maven central for convenience. (See the ge
        <td>0.3.0</td>
        <td>2019 Apr 21 </td>
        <td>
-         <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/0.3.0/apache-ratis-incubating-0.3.0-src.tar.gz">source</a>
-         (<a href="https://downloads.apache.org/incubator/ratis/0.3.0/apache-ratis-incubating-0.3.0-src.tar.gz.mds">checksum</a>
-         <a href="https://downloads.apache.org/incubator/ratis/0.3.0/apache-ratis-incubating-0.3.0-src.tar.gz.asc">signature</a>)
+         <a href="https://www.apache.org/dyn/closer.cgi/ratis/0.3.0/apache-ratis-incubating-0.3.0-src.tar.gz">source</a>
+         (<a href="https://downloads.apache.org/ratis/0.3.0/apache-ratis-incubating-0.3.0-src.tar.gz.mds">checksum</a>
+         <a href="https://downloads.apache.org/ratis/0.3.0/apache-ratis-incubating-0.3.0-src.tar.gz.asc">signature</a>)
         </td>
         <td>
-          <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/0.3.0/apache-ratis-incubating-0.3.0-bin.tar.gz">binary</a>
-          (<a href="https://downloads.apache.org/incubator/ratis/0.3.0/apache-ratis-incubating-0.3.0-bin.tar.gz.mds">checksum</a>
-          <a href="https://downloads.apache.org/incubator/ratis/0.3.0/apache-ratis-incubating-0.3.0-bin.tar.gz.asc">signature</a>)
+          <a href="https://www.apache.org/dyn/closer.cgi/ratis/0.3.0/apache-ratis-incubating-0.3.0-bin.tar.gz">binary</a>
+          (<a href="https://downloads.apache.org/ratis/0.3.0/apache-ratis-incubating-0.3.0-bin.tar.gz.mds">checksum</a>
+          <a href="https://downloads.apache.org/ratis/0.3.0/apache-ratis-incubating-0.3.0-bin.tar.gz.asc">signature</a>)
          </td>
          <td>
            <a href="post/0.3.0.html">Announcement</a>
@@ -179,14 +179,14 @@ The binaries are also uploaded to the maven central for convenience. (See the ge
        <td>0.2.0</td>
        <td>2018 Jul 15 </td>
        <td>
-         <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/0.2.0/apache-ratis-incubating-0.2.0-src.tar.gz">source</a>
-         (<a href="https://downloads.apache.org/incubator/ratis/0.2.0/apache-ratis-incubating-0.2.0-src.tar.gz.mds">checksum</a>
-         <a href="https://downloads.apache.org/incubator/ratis/0.2.0/apache-ratis-incubating-0.2.0-src.tar.gz.asc">signature</a>)
+         <a href="https://www.apache.org/dyn/closer.cgi/ratis/0.2.0/apache-ratis-incubating-0.2.0-src.tar.gz">source</a>
+         (<a href="https://downloads.apache.org/ratis/0.2.0/apache-ratis-incubating-0.2.0-src.tar.gz.mds">checksum</a>
+         <a href="https://downloads.apache.org/ratis/0.2.0/apache-ratis-incubating-0.2.0-src.tar.gz.asc">signature</a>)
         </td>
         <td>
-          <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/0.2.0/apache-ratis-incubating-0.2.0-bin.tar.gz">binary</a>
-          (<a href="https://downloads.apache.org/incubator/ratis/0.2.0/apache-ratis-incubating-0.2.0-bin.tar.gz.mds">checksum</a>
-          <a href="https://downloads.apache.org/incubator/ratis/0.2.0/apache-ratis-incubating-0.2.0-bin.tar.gz.asc">signature</a>)
+          <a href="https://www.apache.org/dyn/closer.cgi/ratis/0.2.0/apache-ratis-incubating-0.2.0-bin.tar.gz">binary</a>
+          (<a href="https://downloads.apache.org/ratis/0.2.0/apache-ratis-incubating-0.2.0-bin.tar.gz.mds">checksum</a>
+          <a href="https://downloads.apache.org/ratis/0.2.0/apache-ratis-incubating-0.2.0-bin.tar.gz.asc">signature</a>)
          </td>
          <td>
            <a href="post/0.2.0.html">Announcement</a>
@@ -200,25 +200,25 @@ The binaries are also uploaded to the maven central for convenience. (See the ge
 
 <h2 id="to-verify-ratis-releases-using-gpg">To verify Ratis releases using GPG:</h2>
 <ol>
-<li>Download the release apache-ratis-incubating-X.Y.Z-src.tar.gz from a <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis">mirror
+<li>Download the release apache-ratis-X.Y.Z-src.tar.gz from a <a href="https://www.apache.org/dyn/closer.cgi/ratis">mirror
 site</a>.</li>
-<li>Download the signature file apache-ratis-incubating-X.Y.Z-src.tar.gz.asc from
-<a href="https://dist.apache.org/repos/dist/release/incubator/ratis/">Apache</a>.</li>
-<li>Download the <a href="https://dist.apache.org/repos/dist/release/incubator/ratis/KEYS">Ratis
+<li>Download the signature file apache-ratis-X.Y.Z-src.tar.gz.asc from
+<a href="https://dist.apache.org/repos/dist/release/ratis/">Apache</a>.</li>
+<li>Download the <a href="https://dist.apache.org/repos/dist/release/ratis/KEYS">Ratis
 KEYS</a>
 file.</li>
 <li>gpg &ndash;import KEYS</li>
-<li>gpg &ndash;verify apache-ratis-incubating-X.Y.Z-src.tar.gz</li>
+<li>gpg &ndash;verify apache-ratis-X.Y.Z-src.tar.gz</li>
 </ol>
 <h2 id="to-perform-a-quick-check-using-sha-256">To perform a quick check using SHA-256:</h2>
 <ol>
-<li>Download the release apache-ratis-incubating-X.Y.Z-src.tar.gz from a <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis">mirror
+<li>Download the release apache-ratis-X.Y.Z-src.tar.gz from a <a href="https://www.apache.org/dyn/closer.cgi/ratis">mirror
 site</a>.</li>
-<li>Download the checksum apache-ratis-incubating-X.Y.Z-src.tar.gz.mds from
-<a href="https://dist.apache.org/repos/dist/release/incubator/ratis/">Apache</a>.</li>
-<li>shasum -a 256 apache-ratis-incubating-X.Y.Z-src.tar.gz</li>
+<li>Download the checksum apache-ratis-X.Y.Z-src.tar.gz.mds from
+<a href="https://dist.apache.org/repos/dist/release/ratis/">Apache</a>.</li>
+<li>shasum -a 256 apache-ratis-X.Y.Z-src.tar.gz</li>
 </ol>
-<p>All previous releases of Ratis are available from the <a href="https://archive.apache.org/dist/incubator/ratis/">Apache release
+<p>All previous releases of Ratis are available from the <a href="https://archive.apache.org/dist/ratis/">Apache release
 archive</a> site.</p>
 <p>Ratis is also <a href="https://search.maven.org/search?q=ratis">available</a> from the Maven central repository.</p>
 <h2 id="license">License</h2>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The site still contains download links pointing to the distribution server at incubator sub-paths. Update these links to point to the new TLP location.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1336

## How was this patch tested?

Built site locally and verified changes.
Note in the screenshot at the bottom that it no longer shows the "/incubator" sub-path for the download link.![image](https://user-images.githubusercontent.com/227407/110893692-527eeb00-82ab-11eb-95fc-1cc7d5ef7e10.png)
