### PR TITLE
RATIS-1337. Update release posts to use download links from TLP path.

### DIFF
--- a/content/post/0.2.0.md
+++ b/content/post/0.2.0.md
@@ -23,7 +23,7 @@ sourceonly: true
 
 It contains more than 130 bug fixes and features since the previous release.
 
-This version also heavily tested with [Apache Hadoop Ozone](http://ozone.hadoop.apache.org) where Apache Ratis is used to replicate raw Hadoop data.
+This version also heavily tested with [Apache Ozone](https://ozone.apache.org) where Apache Ratis is used to replicate raw Hadoop data.
 
 The release is available from the downloaded section or (as Ratis is a java library) from the Apache and Maven central maven repositories.
 

--- a/content/post/0.3.0.md
+++ b/content/post/0.3.0.md
@@ -18,10 +18,10 @@ sourceonly: true
   limitations under the License. See accompanying LICENSE file.
 -->
 
-[Download](https://ratis.incubator.apache.org/downloads.html)
+[Download](https://ratis.apache.org/downloads.html)
 
 It contains new features such as multi-raft and watch request, as well contains 73 improvements and 72 bug fixes.
-See the [changes between 0.2.0 and 0.3.0](https://github.com/apache/incubator-ratis/compare/ratis-0.2.0...ratis-0.3.0) releases. 
+See the [changes between 0.2.0 and 0.3.0](https://github.com/apache/ratis/compare/ratis-0.2.0...ratis-0.3.0) releases.
 
-It has been tested with [Apache Hadoop Ozone](https://hadoop.apache.org/ozone/) where Apache Ratis is used to replicate raw data. 
+It has been tested with [Apache Ozone](https://ozone.apache.org) where Apache Ratis is used to replicate raw data. 
 

--- a/content/post/0.4.0.md
+++ b/content/post/0.4.0.md
@@ -18,10 +18,10 @@ sourceonly: true
   limitations under the License. See accompanying LICENSE file.
 -->
 
-[Download](https://ratis.incubator.apache.org/downloads.html)
+[Download](https://ratis.apache.org/downloads.html)
 
 It contains more than 89 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
-See the [changes between 0.3.0 and 0.4.0](https://github.com/apache/incubator-ratis/compare/0.3.0...ratis-0.4.0-rc4) releases. 
+See the [changes between 0.3.0 and 0.4.0](https://github.com/apache/ratis/compare/ratis-0.3.0...0.4.0-rc4) releases.
 
-It has been tested with [Apache Hadoop Ozone](https://hadoop.apache.org/ozone/) where Apache Ratis is used to replicate raw data. 
+It has been tested with [Apache Ozone](https://ozone.apache.org) where Apache Ratis is used to replicate raw data. 
 

--- a/content/post/0.5.0.md
+++ b/content/post/0.5.0.md
@@ -18,10 +18,10 @@ linked: true
   limitations under the License. See accompanying LICENSE file.
 -->
 
-[Download](https://ratis.incubator.apache.org/downloads.html)
+[Download](https://ratis.apache.org/downloads.html)
 
 It contains more than 94 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
-See the [changes between 0.4.0 and 0.5.0](https://github.com/apache/incubator-ratis/compare/0.4.0-rc4...ratis-0.5.0-rc0) releases. 
+See the [changes between 0.4.0 and 0.5.0](https://github.com/apache/ratis/compare/0.4.0-rc4...ratis-0.5.0-rc0) releases.
 
-It has been tested with [Apache Hadoop Ozone](https://hadoop.apache.org/ozone/) where Apache Ratis is used to replicate raw data. 
+It has been tested with [Apache Ozone](https://ozone.apache.org) where Apache Ratis is used to replicate raw data. 
 

--- a/content/post/1.0.0.md
+++ b/content/post/1.0.0.md
@@ -18,10 +18,10 @@ linked: true
   limitations under the License. See accompanying LICENSE file.
 -->
 
-[Download](https://ratis.incubator.apache.org/downloads.html)
+[Download](https://ratis.apache.org/downloads.html)
 
 It contains around 119 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
-See the [changes between 0.5.0 and 1.0.0](https://github.com/apache/incubator-ratis/compare/ratis-0.5.0-rc0...ratis-1.0.0-rc0) releases. 
+See the [changes between 0.5.0 and 1.0.0](https://github.com/apache/ratis/compare/ratis-0.5.0-rc0...ratis-1.0.0) releases.
 
-It has been tested with [Apache Hadoop Ozone](https://hadoop.apache.org/ozone/) where Apache Ratis is used to replicate raw data and to provide high availability. 
+It has been tested with [Apache Ozone](https://ozone.apache.org) where Apache Ratis is used to replicate raw data and to provide high availability. 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The site has posts for release announcements with download links pointing to an old incubator location. Update these links to point to the new TLP location.

While working on this, I also noticed there were links to Ozone documentation at the old location under the hadoop sub-domain.  I updated all of those to use Ozone's TLP site: ozone.apache.org.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1337

## How was this patch tested?

Built site locally and verified all links point to the correct locations.  (Note link target displayed at bottom of screenshot.)
![image](https://user-images.githubusercontent.com/227407/110980876-2dc25c00-831b-11eb-8381-6effc16dd2f2.png)
