### PR TITLE
RATIS-1337. Update release posts to use download links from TLP path.

### DIFF
--- a/index.xml
+++ b/index.xml
@@ -15,7 +15,7 @@
       <guid>https://ratis.apache.org/post/1.0.0.html</guid>
       <description>Download
 It contains around 119 improvements and bug fixes based on various Apache Hadoop Ozone use cases. See the changes between 0.5.0 and 1.0.0 releases.
-It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replicate raw data and to provide high availability.</description>
+It has been tested with Apache Ozone where Apache Ratis is used to replicate raw data and to provide high availability.</description>
     </item>
     
     <item>
@@ -26,7 +26,7 @@ It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replic
       <guid>https://ratis.apache.org/post/0.5.0.html</guid>
       <description>Download
 It contains more than 94 improvements and bug fixes based on various Apache Hadoop Ozone use cases. See the changes between 0.4.0 and 0.5.0 releases.
-It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replicate raw data.</description>
+It has been tested with Apache Ozone where Apache Ratis is used to replicate raw data.</description>
     </item>
     
     <item>
@@ -37,7 +37,7 @@ It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replic
       <guid>https://ratis.apache.org/post/0.4.0.html</guid>
       <description>Download
 It contains more than 89 improvements and bug fixes based on various Apache Hadoop Ozone use cases. See the changes between 0.3.0 and 0.4.0 releases.
-It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replicate raw data.</description>
+It has been tested with Apache Ozone where Apache Ratis is used to replicate raw data.</description>
     </item>
     
     <item>
@@ -48,7 +48,7 @@ It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replic
       <guid>https://ratis.apache.org/post/0.3.0.html</guid>
       <description>Download
 It contains new features such as multi-raft and watch request, as well contains 73 improvements and 72 bug fixes. See the changes between 0.2.0 and 0.3.0 releases.
-It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replicate raw data.</description>
+It has been tested with Apache Ozone where Apache Ratis is used to replicate raw data.</description>
     </item>
     
     <item>
@@ -59,7 +59,7 @@ It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replic
       <guid>https://ratis.apache.org/post/0.2.0.html</guid>
       <description>0.2.0 is the second Apache release and the first release which provides binary release with example Raft applications.
 It contains more than 130 bug fixes and features since the previous release.
-This version also heavily tested with Apache Hadoop Ozone where Apache Ratis is used to replicate raw Hadoop data.
+This version also heavily tested with Apache Ozone where Apache Ratis is used to replicate raw Hadoop data.
 The release is available from the downloaded section or (as Ratis is a java library) from the Apache and Maven central maven repositories.</description>
     </item>
     

--- a/post.html
+++ b/post.html
@@ -99,10 +99,10 @@
 
             <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p><a href="https://ratis.incubator.apache.org/downloads.html">Download</a></p>
+<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
 <p>It contains around 119 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
-See the <a href="https://github.com/apache/incubator-ratis/compare/ratis-0.5.0-rc0...ratis-1.0.0-rc0">changes between 0.5.0 and 1.0.0</a> releases.</p>
-<p>It has been tested with <a href="https://hadoop.apache.org/ozone/">Apache Hadoop Ozone</a> where Apache Ratis is used to replicate raw data and to provide high availability.</p>
+See the <a href="https://github.com/apache/ratis/compare/ratis-0.5.0-rc0...ratis-1.0.0">changes between 0.5.0 and 1.0.0</a> releases.</p>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data and to provide high availability.</p>
 
 
             
@@ -111,10 +111,10 @@ See the <a href="https://github.com/apache/incubator-ratis/compare/ratis-0.5.0-r
 
             <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p><a href="https://ratis.incubator.apache.org/downloads.html">Download</a></p>
+<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
 <p>It contains more than 94 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
-See the <a href="https://github.com/apache/incubator-ratis/compare/0.4.0-rc4...ratis-0.5.0-rc0">changes between 0.4.0 and 0.5.0</a> releases.</p>
-<p>It has been tested with <a href="https://hadoop.apache.org/ozone/">Apache Hadoop Ozone</a> where Apache Ratis is used to replicate raw data.</p>
+See the <a href="https://github.com/apache/ratis/compare/0.4.0-rc4...ratis-0.5.0-rc0">changes between 0.4.0 and 0.5.0</a> releases.</p>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data.</p>
 
 
             
@@ -123,10 +123,10 @@ See the <a href="https://github.com/apache/incubator-ratis/compare/0.4.0-rc4...r
 
             <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p><a href="https://ratis.incubator.apache.org/downloads.html">Download</a></p>
+<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
 <p>It contains more than 89 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
-See the <a href="https://github.com/apache/incubator-ratis/compare/0.3.0...ratis-0.4.0-rc4">changes between 0.3.0 and 0.4.0</a> releases.</p>
-<p>It has been tested with <a href="https://hadoop.apache.org/ozone/">Apache Hadoop Ozone</a> where Apache Ratis is used to replicate raw data.</p>
+See the <a href="https://github.com/apache/ratis/compare/ratis-0.3.0...0.4.0-rc4">changes between 0.3.0 and 0.4.0</a> releases.</p>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data.</p>
 
 
             
@@ -135,10 +135,10 @@ See the <a href="https://github.com/apache/incubator-ratis/compare/0.3.0...ratis
 
             <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p><a href="https://ratis.incubator.apache.org/downloads.html">Download</a></p>
+<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
 <p>It contains new features such as multi-raft and watch request, as well contains 73 improvements and 72 bug fixes.
-See the <a href="https://github.com/apache/incubator-ratis/compare/ratis-0.2.0...ratis-0.3.0">changes between 0.2.0 and 0.3.0</a> releases.</p>
-<p>It has been tested with <a href="https://hadoop.apache.org/ozone/">Apache Hadoop Ozone</a> where Apache Ratis is used to replicate raw data.</p>
+See the <a href="https://github.com/apache/ratis/compare/ratis-0.2.0...ratis-0.3.0">changes between 0.2.0 and 0.3.0</a> releases.</p>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data.</p>
 
 
             
@@ -149,7 +149,7 @@ See the <a href="https://github.com/apache/incubator-ratis/compare/ratis-0.2.0..
 <!-- raw HTML omitted -->
 <p>0.2.0 is the second Apache release and the first release which provides binary release with example Raft applications.</p>
 <p>It contains more than 130 bug fixes and features since the previous release.</p>
-<p>This version also heavily tested with <a href="http://ozone.hadoop.apache.org">Apache Hadoop Ozone</a> where Apache Ratis is used to replicate raw Hadoop data.</p>
+<p>This version also heavily tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw Hadoop data.</p>
 <p>The release is available from the downloaded section or (as Ratis is a java library) from the Apache and Maven central maven repositories.</p>
 
 

--- a/post/0.2.0.html
+++ b/post/0.2.0.html
@@ -93,7 +93,7 @@
 <!-- raw HTML omitted -->
 <p>0.2.0 is the second Apache release and the first release which provides binary release with example Raft applications.</p>
 <p>It contains more than 130 bug fixes and features since the previous release.</p>
-<p>This version also heavily tested with <a href="http://ozone.hadoop.apache.org">Apache Hadoop Ozone</a> where Apache Ratis is used to replicate raw Hadoop data.</p>
+<p>This version also heavily tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw Hadoop data.</p>
 <p>The release is available from the downloaded section or (as Ratis is a java library) from the Apache and Maven central maven repositories.</p>
 
 </div>

--- a/post/0.3.0.html
+++ b/post/0.3.0.html
@@ -91,10 +91,10 @@
 <h1>Release 0.3.0 is available</h1>
 <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p><a href="https://ratis.incubator.apache.org/downloads.html">Download</a></p>
+<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
 <p>It contains new features such as multi-raft and watch request, as well contains 73 improvements and 72 bug fixes.
-See the <a href="https://github.com/apache/incubator-ratis/compare/ratis-0.2.0...ratis-0.3.0">changes between 0.2.0 and 0.3.0</a> releases.</p>
-<p>It has been tested with <a href="https://hadoop.apache.org/ozone/">Apache Hadoop Ozone</a> where Apache Ratis is used to replicate raw data.</p>
+See the <a href="https://github.com/apache/ratis/compare/ratis-0.2.0...ratis-0.3.0">changes between 0.2.0 and 0.3.0</a> releases.</p>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data.</p>
 
 </div>
 

--- a/post/0.4.0.html
+++ b/post/0.4.0.html
@@ -91,10 +91,10 @@
 <h1>Release 0.4.0 is available</h1>
 <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p><a href="https://ratis.incubator.apache.org/downloads.html">Download</a></p>
+<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
 <p>It contains more than 89 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
-See the <a href="https://github.com/apache/incubator-ratis/compare/0.3.0...ratis-0.4.0-rc4">changes between 0.3.0 and 0.4.0</a> releases.</p>
-<p>It has been tested with <a href="https://hadoop.apache.org/ozone/">Apache Hadoop Ozone</a> where Apache Ratis is used to replicate raw data.</p>
+See the <a href="https://github.com/apache/ratis/compare/ratis-0.3.0...0.4.0-rc4">changes between 0.3.0 and 0.4.0</a> releases.</p>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data.</p>
 
 </div>
 

--- a/post/0.5.0.html
+++ b/post/0.5.0.html
@@ -91,10 +91,10 @@
 <h1>Release 0.5.0 is available</h1>
 <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p><a href="https://ratis.incubator.apache.org/downloads.html">Download</a></p>
+<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
 <p>It contains more than 94 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
-See the <a href="https://github.com/apache/incubator-ratis/compare/0.4.0-rc4...ratis-0.5.0-rc0">changes between 0.4.0 and 0.5.0</a> releases.</p>
-<p>It has been tested with <a href="https://hadoop.apache.org/ozone/">Apache Hadoop Ozone</a> where Apache Ratis is used to replicate raw data.</p>
+See the <a href="https://github.com/apache/ratis/compare/0.4.0-rc4...ratis-0.5.0-rc0">changes between 0.4.0 and 0.5.0</a> releases.</p>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data.</p>
 
 </div>
 

--- a/post/1.0.0.html
+++ b/post/1.0.0.html
@@ -91,10 +91,10 @@
 <h1>GA Release 1.0.0 is available</h1>
 <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p><a href="https://ratis.incubator.apache.org/downloads.html">Download</a></p>
+<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
 <p>It contains around 119 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
-See the <a href="https://github.com/apache/incubator-ratis/compare/ratis-0.5.0-rc0...ratis-1.0.0-rc0">changes between 0.5.0 and 1.0.0</a> releases.</p>
-<p>It has been tested with <a href="https://hadoop.apache.org/ozone/">Apache Hadoop Ozone</a> where Apache Ratis is used to replicate raw data and to provide high availability.</p>
+See the <a href="https://github.com/apache/ratis/compare/ratis-0.5.0-rc0...ratis-1.0.0">changes between 0.5.0 and 1.0.0</a> releases.</p>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data and to provide high availability.</p>
 
 </div>
 

--- a/post/index.xml
+++ b/post/index.xml
@@ -15,7 +15,7 @@
       <guid>https://ratis.apache.org/post/1.0.0.html</guid>
       <description>Download
 It contains around 119 improvements and bug fixes based on various Apache Hadoop Ozone use cases. See the changes between 0.5.0 and 1.0.0 releases.
-It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replicate raw data and to provide high availability.</description>
+It has been tested with Apache Ozone where Apache Ratis is used to replicate raw data and to provide high availability.</description>
     </item>
     
     <item>
@@ -26,7 +26,7 @@ It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replic
       <guid>https://ratis.apache.org/post/0.5.0.html</guid>
       <description>Download
 It contains more than 94 improvements and bug fixes based on various Apache Hadoop Ozone use cases. See the changes between 0.4.0 and 0.5.0 releases.
-It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replicate raw data.</description>
+It has been tested with Apache Ozone where Apache Ratis is used to replicate raw data.</description>
     </item>
     
     <item>
@@ -37,7 +37,7 @@ It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replic
       <guid>https://ratis.apache.org/post/0.4.0.html</guid>
       <description>Download
 It contains more than 89 improvements and bug fixes based on various Apache Hadoop Ozone use cases. See the changes between 0.3.0 and 0.4.0 releases.
-It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replicate raw data.</description>
+It has been tested with Apache Ozone where Apache Ratis is used to replicate raw data.</description>
     </item>
     
     <item>
@@ -48,7 +48,7 @@ It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replic
       <guid>https://ratis.apache.org/post/0.3.0.html</guid>
       <description>Download
 It contains new features such as multi-raft and watch request, as well contains 73 improvements and 72 bug fixes. See the changes between 0.2.0 and 0.3.0 releases.
-It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replicate raw data.</description>
+It has been tested with Apache Ozone where Apache Ratis is used to replicate raw data.</description>
     </item>
     
     <item>
@@ -59,7 +59,7 @@ It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replic
       <guid>https://ratis.apache.org/post/0.2.0.html</guid>
       <description>0.2.0 is the second Apache release and the first release which provides binary release with example Raft applications.
 It contains more than 130 bug fixes and features since the previous release.
-This version also heavily tested with Apache Hadoop Ozone where Apache Ratis is used to replicate raw Hadoop data.
+This version also heavily tested with Apache Ozone where Apache Ratis is used to replicate raw Hadoop data.
 The release is available from the downloaded section or (as Ratis is a java library) from the Apache and Maven central maven repositories.</description>
     </item>
     


### PR DESCRIPTION
## What changes were proposed in this pull request?

The site has posts for release announcements with download links pointing to an old incubator location. Update these links to point to the new TLP location.

While working on this, I also noticed there were links to Ozone documentation at the old location under the hadoop sub-domain. I updated all of those to use Ozone's TLP site: ozone.apache.org.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1337

## How was this patch tested?

Built site locally and verified all links point to the correct locations. (Note link target displayed at bottom of screenshot.)
![image](https://user-images.githubusercontent.com/227407/110980976-4cc0ee00-831b-11eb-9507-5fcae6c6fd54.png)
