### PR TITLE
RATIS-1338. Update information on source, getting started and testing…

### DIFF
--- a/content/getting_started.md
+++ b/content/getting_started.md
@@ -21,14 +21,14 @@ Ratis is a [Raft](https://raft.github.io/) protocol *library* in Java. It's not 
 
 To demonstrate how to use Ratis from the code, Please look at the following examples.
 
- * [Arithmetic example](https://github.com/apache/incubator-ratis/tree/master/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic): This is a simple distributed calculator that replicates the values defined and allows user to perform arithmetic operations on these replicated values.
+ * [Arithmetic example](https://github.com/apache/ratis/tree/master/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic): This is a simple distributed calculator that replicates the values defined and allows user to perform arithmetic operations on these replicated values.
 
- * [FileStore example](https://github.com/apache/incubator-ratis/tree/master/ratis-examples/src/main/java/org/apache/ratis/examples/filestore): This is an example of using Ratis for reading and writing files.
+ * [FileStore example](https://github.com/apache/ratis/tree/master/ratis-examples/src/main/java/org/apache/ratis/examples/filestore): This is an example of using Ratis for reading and writing files.
 
 <!-- TODO: We should have the following as documentation in the github.  -->
 
 The source code of the examples could be found in the
-[ratis-examples](https://github.com/apache/incubator-ratis/blob/master/ratis-examples/) sub-project.
+[ratis-examples](https://github.com/apache/ratis/blob/master/ratis-examples/) sub-project.
 
 ### Maven usage
 

--- a/content/logservice/testing/vagrant.md
+++ b/content/logservice/testing/vagrant.md
@@ -15,7 +15,7 @@ title: Vagrant Testing
   limitations under the License. See accompanying LICENSE file.
 -->
 
-Please refer to the [documentation](https://github.com/apache/incubator-ratis/blob/master/dev-support/vagrant/README.md) for instructions to use the Vagrant automation.
+Please refer to the [documentation](https://github.com/apache/ratis/blob/master/dev-support/vagrant/README.md) for instructions to use the Vagrant automation.
 
 Starting from the directory `dev-support/vagrant/`:
 

--- a/content/source.md
+++ b/content/source.md
@@ -17,6 +17,6 @@ title: Source
 
 Source code is part of every release, you can download the source bundles from download section and build the project according to the included instructions.
 
-The versioned source code history is available from the [Apache git](https://gitbox.apache.org/repos/asf?p=incubator-ratis.git) repository or 
-from the [github mirror](https://github.com/apache/incubator-ratis). It is only for development and not intended for use by the general public. 
+The versioned source code history is available from the [Apache git](https://gitbox.apache.org/repos/asf?p=ratis.git) repository or
+from the [github mirror](https://github.com/apache/ratis). It is only for development and not intended for use by the general public.
 Only the source code from the released artifacts are checked by the Project Management Committee.


### PR DESCRIPTION
… to reference TLP git repos.

## What changes were proposed in this pull request?

Various developer bootstrapping information on the site still points to incubator repos and locations. Update these to show the correct locations since graduation to TLP.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1338

## How was this patch tested?

Built site locally and confirmed changes.
Note "github mirror" link in below screenshot references correct TLP repo location.
![image](https://user-images.githubusercontent.com/227407/111260616-647bc900-85de-11eb-908a-33eda3546f22.png)
