### PR TITLE
RATIS-1338. Update information on source, getting started and testing…

### DIFF
--- a/getting_started.html
+++ b/getting_started.html
@@ -96,15 +96,15 @@
 <p>To demonstrate how to use Ratis from the code, Please look at the following examples.</p>
 <ul>
 <li>
-<p><a href="https://github.com/apache/incubator-ratis/tree/master/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic">Arithmetic example</a>: This is a simple distributed calculator that replicates the values defined and allows user to perform arithmetic operations on these replicated values.</p>
+<p><a href="https://github.com/apache/ratis/tree/master/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic">Arithmetic example</a>: This is a simple distributed calculator that replicates the values defined and allows user to perform arithmetic operations on these replicated values.</p>
 </li>
 <li>
-<p><a href="https://github.com/apache/incubator-ratis/tree/master/ratis-examples/src/main/java/org/apache/ratis/examples/filestore">FileStore example</a>: This is an example of using Ratis for reading and writing files.</p>
+<p><a href="https://github.com/apache/ratis/tree/master/ratis-examples/src/main/java/org/apache/ratis/examples/filestore">FileStore example</a>: This is an example of using Ratis for reading and writing files.</p>
 </li>
 </ul>
 <!-- raw HTML omitted -->
 <p>The source code of the examples could be found in the
-<a href="https://github.com/apache/incubator-ratis/blob/master/ratis-examples/">ratis-examples</a> sub-project.</p>
+<a href="https://github.com/apache/ratis/blob/master/ratis-examples/">ratis-examples</a> sub-project.</p>
 <h3 id="maven-usage">Maven usage</h3>
 <p>To use in our project you can access the latest binaries from maven central:</p>
 <div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency&gt;</span>

--- a/index.html
+++ b/index.html
@@ -180,15 +180,15 @@
 <p>To demonstrate how to use Ratis from the code, Please look at the following examples.</p>
 <ul>
 <li>
-<p><a href="https://github.com/apache/incubator-ratis/tree/master/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic">Arithmetic example</a>: This is a simple distributed calculator that replicates the values defined and allows user to perform arithmetic operations on these replicated values.</p>
+<p><a href="https://github.com/apache/ratis/tree/master/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic">Arithmetic example</a>: This is a simple distributed calculator that replicates the values defined and allows user to perform arithmetic operations on these replicated values.</p>
 </li>
 <li>
-<p><a href="https://github.com/apache/incubator-ratis/tree/master/ratis-examples/src/main/java/org/apache/ratis/examples/filestore">FileStore example</a>: This is an example of using Ratis for reading and writing files.</p>
+<p><a href="https://github.com/apache/ratis/tree/master/ratis-examples/src/main/java/org/apache/ratis/examples/filestore">FileStore example</a>: This is an example of using Ratis for reading and writing files.</p>
 </li>
 </ul>
 <!-- raw HTML omitted -->
 <p>The source code of the examples could be found in the
-<a href="https://github.com/apache/incubator-ratis/blob/master/ratis-examples/">ratis-examples</a> sub-project.</p>
+<a href="https://github.com/apache/ratis/blob/master/ratis-examples/">ratis-examples</a> sub-project.</p>
 <h3 id="maven-usage">Maven usage</h3>
 <p>To use in our project you can access the latest binaries from maven central:</p>
 <div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency&gt;</span>
@@ -278,8 +278,8 @@ issues mailing list.</p>
             <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
 <p>Source code is part of every release, you can download the source bundles from download section and build the project according to the included instructions.</p>
-<p>The versioned source code history is available from the <a href="https://gitbox.apache.org/repos/asf?p=incubator-ratis.git">Apache git</a> repository or
-from the <a href="https://github.com/apache/incubator-ratis">github mirror</a>. It is only for development and not intended for use by the general public.
+<p>The versioned source code history is available from the <a href="https://gitbox.apache.org/repos/asf?p=ratis.git">Apache git</a> repository or
+from the <a href="https://github.com/apache/ratis">github mirror</a>. It is only for development and not intended for use by the general public.
 Only the source code from the released artifacts are checked by the Project Management Committee.</p>
 
             

--- a/logservice/testing.html
+++ b/logservice/testing.html
@@ -153,7 +153,7 @@ scenarios. Please find more on each using the below references.</p>
 
             <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p>Please refer to the <a href="https://github.com/apache/incubator-ratis/blob/master/dev-support/vagrant/README.md">documentation</a> for instructions to use the Vagrant automation.</p>
+<p>Please refer to the <a href="https://github.com/apache/ratis/blob/master/dev-support/vagrant/README.md">documentation</a> for instructions to use the Vagrant automation.</p>
 <p>Starting from the directory <code>dev-support/vagrant/</code>:</p>
 <ul>
 <li>To build all Vagrant boxes, invoke <code>./run_all_tests.sh build</code></li>

--- a/logservice/testing/vagrant.html
+++ b/logservice/testing/vagrant.html
@@ -91,7 +91,7 @@
 <h1>Vagrant Testing</h1>
 <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p>Please refer to the <a href="https://github.com/apache/incubator-ratis/blob/master/dev-support/vagrant/README.md">documentation</a> for instructions to use the Vagrant automation.</p>
+<p>Please refer to the <a href="https://github.com/apache/ratis/blob/master/dev-support/vagrant/README.md">documentation</a> for instructions to use the Vagrant automation.</p>
 <p>Starting from the directory <code>dev-support/vagrant/</code>:</p>
 <ul>
 <li>To build all Vagrant boxes, invoke <code>./run_all_tests.sh build</code></li>

--- a/source.html
+++ b/source.html
@@ -92,8 +92,8 @@
 <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
 <p>Source code is part of every release, you can download the source bundles from download section and build the project according to the included instructions.</p>
-<p>The versioned source code history is available from the <a href="https://gitbox.apache.org/repos/asf?p=incubator-ratis.git">Apache git</a> repository or
-from the <a href="https://github.com/apache/incubator-ratis">github mirror</a>. It is only for development and not intended for use by the general public.
+<p>The versioned source code history is available from the <a href="https://gitbox.apache.org/repos/asf?p=ratis.git">Apache git</a> repository or
+from the <a href="https://github.com/apache/ratis">github mirror</a>. It is only for development and not intended for use by the general public.
 Only the source code from the released artifacts are checked by the Project Management Committee.</p>
 
 </div>


### PR DESCRIPTION
… to reference TLP git repos.

## What changes were proposed in this pull request?

Various developer bootstrapping information on the site still points to incubator repos and locations. Update these to show the correct locations since graduation to TLP.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1338

## How was this patch tested?

Built site locally and confirmed changes.
Note "github mirror" link in below screenshot references correct TLP repo location.
![image](https://user-images.githubusercontent.com/227407/111260722-91c87700-85de-11eb-8525-a59d4e2124b0.png)
