### PR TITLE
RATIS-1326. NotifyInstallSnapshot during SetConfiguration has leader info missing.

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -86,7 +86,10 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
     public CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(
         RaftProtos.RoleInfoProto roleInfoProto,
         TermIndex termIndex) {
-
+      if (!roleInfoProto.getFollowerInfo().hasLeaderInfo()) {
+        return JavaUtils.completeExceptionally(new IOException("Failed " +
+          "notifyInstallSnapshotFromLeader due to missing leader info"));
+      }
       numSnapshotRequests.incrementAndGet();
 
       final SingleFileSnapshotInfo leaderSnapshotInfo = (SingleFileSnapshotInfo) leaderSnapshotInfoRef.get();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixed missing leader info during installSnapshot.
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1326

## How was this patch tested?
Modified existing unit tests.

