### PR TITLE
RATIS-1341. Fail-fast tests only for PRs

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -86,6 +86,7 @@ jobs:
           - grpc
           - server
           - misc
+      fail-fast: ${{ github.event_name == 'pull_request' }}
     steps:
         - uses: actions/checkout@master
         - name: Cache for maven dependencies


### PR DESCRIPTION
## What changes were proposed in this pull request?

#422 added matrix build for unit tests with 3 splits, with fail-fast behavior (if one split fails, other splits are cancelled).  @szetszwo [pointed out](https://github.com/apache/ratis/pull/422#issuecomment-801012525) that 

> better to always run all the tests since the overall running time is short. This is the reason that we moved the tests to the ratis-test module; see RATIS-399

I propose to run all tests for `push` builds, but keep fail-fast behavior for PRs.  The rationale is that PRs should be merged only after fully green build, so any failing test requires a new run.

https://issues.apache.org/jira/browse/RATIS-1341

## How was this patch tested?

Push build with failed _unit (grpc)_ check, but completed other _unit_ checks:
https://github.com/adoroszlai/incubator-ratis/actions/runs/660949453