### PR TITLE
RATIS-1350. One of raftgroup initraftlog fail due to raftlog IllegalStateException

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -104,15 +104,16 @@ class ServerState implements Closeable {
     LOG.info("{}: {}", getMemberId(), configurationManager);
 
     List<File> directories = RaftServerConfigKeys.storageDir(prop);
-    // use full uuid string to create a subdirectory
-    File dir = chooseStorageDir(RaftServerConfigKeys.storageDir(prop),
-            group.getGroupId().getUuid().toString());
-    try {
-      storage = new RaftStorageImpl(dir, RaftServerConfigKeys.Log.corruptionPolicy(prop));
-    } catch (IOException e) {
-      directories.remove(dir);
-      dir = chooseStorageDir(directories, group.getGroupId().getUuid().toString());
-      storage = new RaftStorageImpl(dir, RaftServerConfigKeys.Log.corruptionPolicy(prop));
+    boolean flag = false;
+    while (!flag) {
+      // use full uuid string to create a subdirectory
+      File dir = chooseStorageDir(directories, group.getGroupId().getUuid().toString());
+      try {
+        storage = new RaftStorageImpl(dir, RaftServerConfigKeys.Log.corruptionPolicy(prop));
+        flag = true;
+      } catch (IOException e) {
+        directories.remove(dir);
+      }
     }
     snapshotManager = new SnapshotManager(storage, id);
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -104,15 +104,23 @@ class ServerState implements Closeable {
     LOG.info("{}: {}", getMemberId(), configurationManager);
 
     List<File> directories = RaftServerConfigKeys.storageDir(prop);
-    boolean flag = false;
-    while (!flag) {
+    // the flag is true means the storagedir create successful or iterate all storagedir whill exit this loop
+    boolean Flag = false;
+    int FileCount = 0;
+    int FileSize = directories.size();
+    while (!Flag) {
       // use full uuid string to create a subdirectory
       File dir = chooseStorageDir(directories, group.getGroupId().getUuid().toString());
       try {
         storage = new RaftStorageImpl(dir, RaftServerConfigKeys.Log.corruptionPolicy(prop));
-        flag = true;
+        Flag = true;
       } catch (IOException e) {
         directories.remove(dir);
+      } finally {
+        FileCount = FileCount + 1;
+        if (FileCount == FileSize) {
+          Flag = true;
+        }
       }
     }
     snapshotManager = new SnapshotManager(storage, id);


### PR DESCRIPTION
## What changes were proposed in this pull request?
the one of raftgroup initraftlog fail will be skiped and will not affect the datanode on ozone
## What is the link to the Apache JIRA
RATIS-1350 one of raftgroup initraftlog fail due to raftlog IllegalStateException

## How was this patch tested?

