### PR TITLE
RATIS-1356. NotifyInstallSnapshot during SetConfiguration has leader …

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -557,7 +557,7 @@ public interface RaftServerConfigKeys {
     }
 
     String PRE_VOTE_KEY = PREFIX + ".pre-vote";
-    boolean PRE_VOTE_DEFAULT = true;
+    boolean PRE_VOTE_DEFAULT = false;
     static boolean preVote(RaftProperties properties) {
       return getBoolean(properties::getBoolean, PRE_VOTE_KEY, PRE_VOTE_DEFAULT, getDefaultLog());
     }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -557,7 +557,7 @@ public interface RaftServerConfigKeys {
     }
 
     String PRE_VOTE_KEY = PREFIX + ".pre-vote";
-    boolean PRE_VOTE_DEFAULT = false;
+    boolean PRE_VOTE_DEFAULT = true;
     static boolean preVote(RaftProperties properties) {
       return getBoolean(properties::getBoolean, PRE_VOTE_KEY, PRE_VOTE_DEFAULT, getDefaultLog());
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -512,6 +512,22 @@ class RaftServerImpl implements RaftServer.Division,
         getGroup(), getRoleInfoProto(), state.getStorage().getStorageDir().isHealthy());
   }
 
+  private RoleInfoProto getRoleInfoProto(RaftPeer leaderPeerInfo) {
+	  RaftPeerRole currentRole = role.getCurrentRole();
+	  RoleInfoProto.Builder roleInfo = RoleInfoProto.newBuilder()
+		  .setSelf(getPeer().getRaftPeerProto())
+		  .setRole(currentRole)
+		  .setRoleElapsedTimeMs(role.getRoleElapsedTimeMs());
+	  final Optional<FollowerState> fs = role.getFollowerState();
+	  final ServerRpcProto leaderInfo =
+		  ServerProtoUtils.toServerRpcProto(leaderPeerInfo,
+			  fs.map(FollowerState::getLastRpcTime).map(Timestamp::elapsedTimeMs).orElse(0L));
+	  roleInfo.setFollowerInfo(FollowerInfoProto.newBuilder()
+		  .setLeaderInfo(leaderInfo)
+		  .setOutstandingOp(fs.map(FollowerState::getOutstandingOp).orElse(0)));
+	  return roleInfo.build();
+  }
+
   RoleInfoProto getRoleInfoProto() {
     RaftPeerRole currentRole = role.getCurrentRole();
     RoleInfoProto.Builder roleInfo = RoleInfoProto.newBuilder()
@@ -1418,6 +1434,8 @@ class RaftServerImpl implements RaftServer.Division,
     CodeInjectionForTesting.execute(INSTALL_SNAPSHOT, getId(),
         leaderId, request);
 
+
+
     assertLifeCycleState(LifeCycle.States.STARTING_OR_RUNNING);
     assertGroup(leaderId, leaderGroupId);
 
@@ -1545,13 +1563,27 @@ class RaftServerImpl implements RaftServer.Division,
           return reply;
         }
 
+        Optional<RaftPeerProto> leaderPeerInfo = null;
+        if (request.hasLastRaftConfigurationLogEntryProto()) {
+          List<RaftPeerProto> peerList = request.getLastRaftConfigurationLogEntryProto().getConfigurationEntry()
+              .getPeersList();
+          leaderPeerInfo = peerList.stream().filter(p -> RaftPeerId.valueOf(p.getId()).equals(leaderId)).findFirst();
+          Preconditions.assertTrue(leaderPeerInfo.isPresent());
+        }
+
+        // For the cases where RaftConf is empty on newly started peer with
+        // empty peer list, we retrieve leader info from
+        // installSnapShotRequestProto.
+        RoleInfoProto roleInfoProto =
+            getRaftConf().getPeer(state.getLeaderId()) == null ?
+                getRoleInfoProto(ProtoUtils.toRaftPeer(leaderPeerInfo.get())) :
+                getRoleInfoProto();
         // This is the first installSnapshot notify request for this term and
         // index. Notify the state machine to install the snapshot.
         LOG.info("{}: notifyInstallSnapshot: nextIndex is {} but the leader's first available index is {}.",
             getMemberId(), state.getLog().getNextIndex(), firstAvailableLogIndex);
-
         try {
-          stateMachine.followerEvent().notifyInstallSnapshotFromLeader(getRoleInfoProto(), firstAvailableLogTermIndex)
+          stateMachine.followerEvent().notifyInstallSnapshotFromLeader(roleInfoProto, firstAvailableLogTermIndex)
               .whenComplete((reply, exception) -> {
                 if (exception != null) {
                   LOG.warn("{}: Failed to notify StateMachine to InstallSnapshot. Exception: {}",
@@ -1585,6 +1617,8 @@ class RaftServerImpl implements RaftServer.Division,
           currentTerm, InstallSnapshotResult.IN_PROGRESS, -1);
     }
   }
+
+
 
   void submitUpdateCommitEvent() {
     role.getLeaderState().ifPresent(LeaderStateImpl::submitUpdateCommitEvent);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1434,8 +1434,6 @@ class RaftServerImpl implements RaftServer.Division,
     CodeInjectionForTesting.execute(INSTALL_SNAPSHOT, getId(),
         leaderId, request);
 
-
-
     assertLifeCycleState(LifeCycle.States.STARTING_OR_RUNNING);
     assertGroup(leaderId, leaderGroupId);
 
@@ -1617,8 +1615,6 @@ class RaftServerImpl implements RaftServer.Division,
           currentTerm, InstallSnapshotResult.IN_PROGRESS, -1);
     }
   }
-
-
 
   void submitUpdateCommitEvent() {
     role.getLeaderState().ifPresent(LeaderStateImpl::submitUpdateCommitEvent);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -513,19 +513,18 @@ class RaftServerImpl implements RaftServer.Division,
   }
 
   private RoleInfoProto getRoleInfoProto(RaftPeer leaderPeerInfo) {
-	  RaftPeerRole currentRole = role.getCurrentRole();
-	  RoleInfoProto.Builder roleInfo = RoleInfoProto.newBuilder()
-		  .setSelf(getPeer().getRaftPeerProto())
-		  .setRole(currentRole)
-		  .setRoleElapsedTimeMs(role.getRoleElapsedTimeMs());
-	  final Optional<FollowerState> fs = role.getFollowerState();
-	  final ServerRpcProto leaderInfo =
-		  ServerProtoUtils.toServerRpcProto(leaderPeerInfo,
-			  fs.map(FollowerState::getLastRpcTime).map(Timestamp::elapsedTimeMs).orElse(0L));
-	  roleInfo.setFollowerInfo(FollowerInfoProto.newBuilder()
-		  .setLeaderInfo(leaderInfo)
-		  .setOutstandingOp(fs.map(FollowerState::getOutstandingOp).orElse(0)));
-	  return roleInfo.build();
+    RaftPeerRole currentRole = role.getCurrentRole();
+    RoleInfoProto.Builder roleInfo = RoleInfoProto.newBuilder()
+        .setSelf(getPeer().getRaftPeerProto())
+        .setRole(currentRole)
+        .setRoleElapsedTimeMs(role.getRoleElapsedTimeMs());
+    final Optional<FollowerState> fs = role.getFollowerState();
+    final ServerRpcProto leaderInfo =
+        ServerProtoUtils.toServerRpcProto(leaderPeerInfo,
+            fs.map(FollowerState::getLastRpcTime).map(Timestamp::elapsedTimeMs).orElse(0L));
+    roleInfo.setFollowerInfo(FollowerInfoProto.newBuilder().setLeaderInfo(leaderInfo)
+        .setOutstandingOp(fs.map(FollowerState::getOutstandingOp).orElse(0)));
+    return roleInfo.build();
   }
 
   RoleInfoProto getRoleInfoProto() {

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -175,7 +175,8 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
       Assert.assertTrue(set);
 
       // add two more peers
-      final MiniRaftCluster.PeerChanges change = cluster.addNewPeers(2, true);
+      final MiniRaftCluster.PeerChanges change = cluster.addNewPeers(2, true,
+          true);
       // trigger setConfiguration
       cluster.setConfiguration(change.allPeersInNewConf);
 
@@ -317,7 +318,8 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
       }
 
       // Add two more peers who will need snapshots from the leader.
-      final MiniRaftCluster.PeerChanges change = cluster.addNewPeers(2, true);
+      final MiniRaftCluster.PeerChanges change = cluster.addNewPeers(2, true,
+          true);
       // trigger setConfiguration
       cluster.setConfiguration(change.allPeersInNewConf);
       RaftServerTestUtil

--- a/ratis-server/src/test/java/org/apache/ratis/RaftExceptionBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftExceptionBaseTest.java
@@ -109,7 +109,8 @@ public abstract class RaftExceptionBaseTest<CLUSTER extends MiniRaftCluster>
       final RaftPeerId newLeader = RaftTestUtil.changeLeader(cluster, oldLeader);
 
       // add two more peers
-      MiniRaftCluster.PeerChanges change = cluster.addNewPeers(new String[]{"ss1", "ss2"}, true);
+      MiniRaftCluster.PeerChanges change = cluster.addNewPeers(new String[]{
+          "ss1", "ss2"}, true, false);
       // trigger setConfiguration
       LOG.info("Start changing the configuration: {}", Arrays.asList(change.allPeersInNewConf));
       try (final RaftClient c2 = cluster.createClient(newLeader)) {

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -361,7 +361,8 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
         }
         FIVE_SECONDS.sleep();
         LOG.info(cluster.printServers());
-        assertSuccess(success);
+
+        RaftTestUtil.waitFor(() -> success.get(), 300, 15000);
 
         final RaftLog leaderLog = cluster.getLeader().getRaftLog();
         for (RaftPeer newPeer : c1.newPeers) {
@@ -450,12 +451,6 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
         clientThread.interrupt();
       }
     }
-  }
-
-  static void assertSuccess(final AtomicReference<Boolean> success) {
-    final String s = "success=" + success;
-    Assert.assertNotNull(s, success.get());
-    Assert.assertTrue(s, success.get());
   }
 
   /**

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/RaftSnapshotBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/RaftSnapshotBaseTest.java
@@ -230,7 +230,7 @@ public abstract class RaftSnapshotBaseTest extends BaseTest {
       // add two more peers
       String[] newPeers = new String[]{"s3", "s4"};
       MiniRaftCluster.PeerChanges change = cluster.addNewPeers(
-          newPeers, true);
+          newPeers, true, false);
       // trigger setConfiguration
       cluster.setConfiguration(change.allPeersInNewConf);
 


### PR DESCRIPTION
…info missing.

## What changes were proposed in this pull request?

Use when raftconf does not have any peer info, use leader info from InstallSnapshotRequestProto.
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1356

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
Updated test to not pass peer info during raft server star in raftgroup.
Also tested SCM-HA with fix now installSnapshot which happens during setConf is getting correct leaderInfo, previously used to get "".
