### PR TITLE
RATIS-1360. Upgrade Ratis Thirdparty to 0.7.0-a398b19-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
     <maven.min.version>3.3.9</maven.min.version>
 
     <!-- Contains all shaded thirdparty dependencies -->
-    <ratis.thirdparty.version>0.6.0</ratis.thirdparty.version>
+    <ratis.thirdparty.version>0.7.0-a398b19-SNAPSHOT</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
     <shaded.protobuf.version>3.12.0</shaded.protobuf.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Ratis Third-party to latest 0.7.0 snapshot to pick up Netty fixes.

https://issues.apache.org/jira/browse/RATIS-1360

## How was this patch tested?

Only some apparently broken tests are failing in CI (same as on `master`):

https://github.com/adoroszlai/incubator-ratis/actions/runs/759205721
https://github.com/adoroszlai/incubator-ratis/actions/runs/762953972
https://github.com/adoroszlai/incubator-ratis/actions/runs/763381680