### PR TITLE
RATIS-1361. Connection errors in Netty-based tests

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -89,6 +89,10 @@ public abstract class MiniRaftCluster implements Closeable {
   private static final TimeDuration RETRY_INTERVAL_DEFAULT =
       TimeDuration.valueOf(100, TimeUnit.MILLISECONDS);
 
+  static {
+    NetUtils.StaticResolution.put("0.0.0.0", "127.0.0.1");
+  }
+
   public static abstract class Factory<CLUSTER extends MiniRaftCluster> {
     public interface Get<CLUSTER extends MiniRaftCluster> {
       Supplier<RaftProperties> properties = JavaUtils.memoize(RaftProperties::new);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Few Netty-based tests started failing recently in CI with errors like:

```
org.apache.ratis.thirdparty.io.netty.channel.ConnectTimeoutException: connection timed out: /0.0.0.0:33307
```

without any code change.  [First failed](https://github.com/apache/ratis/runs/2329275686#step:5:4) on `master` for a simple [version number update](https://github.com/apache/ratis/commit/bd3f36bd324257d5898d59f203f7d19c1405a26c).

Also:
https://github.com/apache/ratis/runs/2379889361#step:5:4
https://github.com/apache/ratis/runs/2368524547?check_suite_focus=true#step:5:4
https://github.com/apache/ratis/runs/2379594469?check_suite_focus=true#step:5:4

They pass locally.

This PR attempts to fix these by resolving the "any local address" (0.0.0.0) specifically to the loopback address in the mini cluster.

https://issues.apache.org/jira/browse/RATIS-1359

## How was this patch tested?

The same set of tests passed 5x repeatedly:

https://github.com/adoroszlai/incubator-ratis/runs/2384632003#step:5:1
https://github.com/adoroszlai/incubator-ratis/runs/2388377845#step:5:1
https://github.com/adoroszlai/incubator-ratis/runs/2388513282#step:5:1
https://github.com/adoroszlai/incubator-ratis/runs/2388574384#step:5:1
https://github.com/adoroszlai/incubator-ratis/runs/2388605600#step:5:1