### PR TITLE
RATIS-1361. Connection errors in tests

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -88,6 +88,11 @@ jobs:
           - misc
       fail-fast: ${{ github.event_name == 'pull_request' }}
     steps:
+        # TEMPORARY WHILE GITHUB FIXES https://github.com/actions/virtual-environments/issues/3185
+        - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+          run: |
+            echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+        # REMOVE CODE ABOVE WHEN ISSUE IS ADDRESSED!
         - uses: actions/checkout@master
         - name: Cache for maven dependencies
           uses: actions/cache@v2


### PR DESCRIPTION
## What changes were proposed in this pull request?

Few tests started failing recently in CI with errors like:

```
org.apache.ratis.thirdparty.io.netty.channel.ConnectTimeoutException: connection timed out: /0.0.0.0:33307
```

without any code change.  [First failed](https://github.com/apache/ratis/runs/2329275686#step:5:4) on `master` for a simple [version number update](https://github.com/apache/ratis/commit/bd3f36bd324257d5898d59f203f7d19c1405a26c).

Also:
https://github.com/apache/ratis/runs/2379889361#step:5:4
https://github.com/apache/ratis/runs/2368524547?check_suite_focus=true#step:5:4
https://github.com/apache/ratis/runs/2379594469?check_suite_focus=true#step:5:4

They pass locally.

It seems likely that this is a side-effect of https://github.com/actions/virtual-environments/issues/3185.  So apply the suggested workaround.

https://issues.apache.org/jira/browse/RATIS-1361

## How was this patch tested?

https://github.com/adoroszlai/incubator-ratis/runs/2390542556
https://github.com/adoroszlai/incubator-ratis/runs/2390604259
https://github.com/adoroszlai/incubator-ratis/runs/2390644384
https://github.com/adoroszlai/incubator-ratis/runs/2390646532
https://github.com/adoroszlai/incubator-ratis/runs/2390993603
https://github.com/adoroszlai/incubator-ratis/runs/2391175338
https://github.com/adoroszlai/incubator-ratis/runs/2391286417