### PR TITLE
Ratis 1363 Intermittent failure in TestInstallSnapshotNotificationWithGrpc

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -337,14 +337,10 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
 
       // Make sure leader and followers are still up to date.
       for (RaftServer.Division follower : cluster.getFollowers()) {
-        long leaderIndex = leader.getRaftLog().getNextIndex();
         // Give follower slightly time to catch up
         RaftTestUtil.waitFor(
-                () -> leaderIndex == follower.getRaftLog().getNextIndex(),
+                () -> leader.getRaftLog().getNextIndex() == follower.getRaftLog().getNextIndex(),
                 300, 15000);
-        Assert.assertEquals(
-            leader.getRaftLog().getNextIndex(),
-            follower.getRaftLog().getNextIndex());
       }
 
       // Make sure each new peer got one snapshot notification.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `org.apache.ratis.grpc.TestInstallSnapshotNotificationWithGrpc` testcase using following methods:

- Make sure that all clients has been created fully before taking a snapshot
- Add poll based wait to make sure that follower's have enough time to catch up

Was part of the https://github.com/apache/ratis/pull/461

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1363

## How was this patch tested?

This is a fix for a automated test case, so no particularly special testing have been made. Fix has been tested manually using mvn test and Ratis CI.
