### PR TITLE
Ratis 1365 Add message for potential NPE in CombinedClientProtocolServerSideTranslatorPB

### DIFF
--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/client/CombinedClientProtocolServerSideTranslatorPB.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/client/CombinedClientProtocolServerSideTranslatorPB.java
@@ -41,11 +41,14 @@ import org.apache.ratis.proto.RaftProtos.GroupInfoRequestProto;
 import org.apache.ratis.proto.RaftProtos.GroupInfoReplyProto;
 import org.apache.ratis.proto.RaftProtos.TransferLeadershipRequestProto;
 import org.apache.ratis.thirdparty.com.google.protobuf.GeneratedMessageV3;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @InterfaceAudience.Private
 public class CombinedClientProtocolServerSideTranslatorPB
     implements CombinedClientProtocolPB {
+  private Logger log = LoggerFactory.getLogger(CombinedClientProtocolServerSideTranslatorPB.class);
   private final RaftServer impl;
 
   public CombinedClientProtocolServerSideTranslatorPB(RaftServer impl) {
@@ -79,6 +82,10 @@ public class CombinedClientProtocolServerSideTranslatorPB
         response = transferLeadership(TransferLeadershipRequestProto.parseFrom(buf));
         break;
       default:
+        String message = "Internal error, all response types are not being handled as expected. " +
+                         "Developer: check that all response types have appropriate handlers.";
+        log.error(message);
+        throw new ServiceException(message);
       }
     } catch(IOException ioe) {
       throw new ServiceException(ioe);


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is future potential NPE issue in CombinedClientProtocolServerSideTranslatorPB class. Add error notification for developers to make sure that this issue is not triggered accidentally in the future.

Was part of the https://github.com/apache/ratis/pull/461

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1365

## How was this patch tested?

This change should be very safe. It has only been tested using existing unit tests.
