### PR TITLE
RATIS-1364 Fix Sonar Qube issues in IOUtils

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/IOUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/IOUtils.java
@@ -98,10 +98,9 @@ public interface IOUtils {
 
   static void readFully(InputStream in, int buffSize) throws IOException {
     final byte [] buf = new byte[buffSize];
-    int read;
-    do {
-      read = in.read(buf);
-    } while(read >= 0);
+    for(int bytesRead = in.read(buf); bytesRead >= 0; ) {
+      bytesRead = in.read(buf);
+    }
   }
 
   /**
@@ -116,8 +115,7 @@ public interface IOUtils {
    */
   static void readFully(InputStream in, byte[] buf, int off, int len)
       throws IOException {
-    int toRead = len;
-    while (toRead > 0) {
+    for(int toRead = len; toRead > 0; ) {
       final int ret = in.read(buf, off, toRead);
       if (ret < 0) {
         final int read = len - toRead;
@@ -150,7 +148,7 @@ public interface IOUtils {
     final int remaining = fill.remaining();
 
     long allocated = 0;
-    while (allocated < size) {
+    for(; allocated < size; ) {
       final long required = size - allocated;
       final int n = remaining < required? remaining: Math.toIntExact(required);
       final ByteBuffer buffer = fill.slice();

--- a/ratis-common/src/main/java/org/apache/ratis/util/IOUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/IOUtils.java
@@ -33,6 +33,7 @@ import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -51,9 +52,8 @@ public interface IOUtils {
   }
 
   static IOException asIOException(Throwable t) {
-    return t == null? null
-        : t instanceof IOException? (IOException)t
-        : new IOException(t);
+    Objects.requireNonNull(t, "t == null");
+    return t instanceof IOException? (IOException)t : new IOException(t);
   }
 
   static IOException toIOException(ExecutionException e) {
@@ -98,9 +98,10 @@ public interface IOUtils {
 
   static void readFully(InputStream in, int buffSize) throws IOException {
     final byte [] buf = new byte[buffSize];
-    for(int bytesRead = in.read(buf); bytesRead >= 0; ) {
-      bytesRead = in.read(buf);
-    }
+    int read;
+    do {
+      read = in.read(buf);
+    } while(read >= 0);
   }
 
   /**
@@ -115,7 +116,8 @@ public interface IOUtils {
    */
   static void readFully(InputStream in, byte[] buf, int off, int len)
       throws IOException {
-    for(int toRead = len; toRead > 0; ) {
+    int toRead = len;
+    while (toRead > 0) {
       final int ret = in.read(buf, off, toRead);
       if (ret < 0) {
         final int read = len - toRead;
@@ -148,7 +150,7 @@ public interface IOUtils {
     final int remaining = fill.remaining();
 
     long allocated = 0;
-    for(; allocated < size; ) {
+    while (allocated < size) {
       final long required = size - allocated;
       final int n = remaining < required? remaining: Math.toIntExact(required);
       final ByteBuffer buffer = fill.slice();
@@ -215,16 +217,13 @@ public interface IOUtils {
   }
 
   static <T> T readObject(InputStream in, Class<T> clazz) {
+    Object obj = null;
     try(ObjectInputStream oin = new ObjectInputStream(in)) {
-      final Object obj = oin.readObject();
-      try {
-        return clazz.cast(obj);
-      } catch (ClassCastException e) {
-        throw new IllegalStateException("Failed to cast to " + clazz + ", object="
-            + (obj instanceof Throwable? StringUtils.stringifyException((Throwable) obj): obj), e);
-      }
+      obj = oin.readObject();
+      return clazz.cast(obj);
     } catch (IOException | ClassNotFoundException e) {
-      throw new IllegalStateException("Failed to read an object.", e);
+      throw new IllegalStateException("Failed to cast to " + clazz + ", object="
+              + (obj instanceof Throwable? StringUtils.stringifyException((Throwable) obj): obj), e);
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes problems related by Sonar Qube including two NPE issues. Bellow more comprehensive list of changes:
- Fix asIOException function NPE
- Reaorganize readFully function for better readability
- Change while-loop like for-loops to actual while-loops
- Fix readObject function NPE

Was part of the https://github.com/apache/ratis/pull/461

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1364

## How was this patch tested?

Change has been tested using existing unit tests.
