### PR TITLE
RATIS-1368 Fix server impl NPEs

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1579,10 +1579,12 @@ class RaftServerImpl implements RaftServer.Division,
         // installSnapShotRequestProto.
         RoleInfoProto roleInfoProto;
         RaftPeer raftPeer = getRaftConf().getPeer(state.getLeaderId());
-        if (raftPeer == null && leaderPeerInfo != null) {
-          roleInfoProto = getRoleInfoProto(ProtoUtils.toRaftPeer(leaderPeerInfo));
-        } else if (raftPeer == null) {
-          throw new IOException("Leader peer info is unknown.");
+        if (raftPeer == null) {
+          if (leaderPeerInfo != null) {
+            roleInfoProto = getRoleInfoProto(ProtoUtils.toRaftPeer(leaderPeerInfo));
+          } else {
+            throw new IOException("Leader peer info is unknown.");
+          }
         } else {
           roleInfoProto = getRoleInfoProto();
         }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RetryCacheImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RetryCacheImpl.java
@@ -181,13 +181,11 @@ class RetryCacheImpl implements RetryCache {
   }
 
   CacheEntry getOrCreateEntry(ClientInvocationId key) {
-    final CacheEntry entry;
     try {
-      entry = cache.get(key, () -> new CacheEntry(key));
+      return cache.get(key, () -> new CacheEntry(key));
     } catch (ExecutionException e) {
       throw new IllegalStateException(e);
     }
-    return entry;
   }
 
   CacheEntry refreshEntry(CacheEntry newEntry) {

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
@@ -20,10 +20,7 @@ package org.apache.ratis.server.impl;
 import org.apache.log4j.Level;
 import org.apache.ratis.RaftTestUtil;
 import org.apache.ratis.conf.RaftProperties;
-import org.apache.ratis.protocol.RaftGroupId;
-import org.apache.ratis.protocol.RaftGroupMemberId;
-import org.apache.ratis.protocol.RaftPeer;
-import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.protocol.*;
 import org.apache.ratis.server.DataStreamMap;
 import org.apache.ratis.server.DataStreamServer;
 import org.apache.ratis.server.DivisionInfo;
@@ -44,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 public class RaftServerTestUtil {
@@ -154,6 +152,10 @@ public class RaftServerTestUtil {
 
   public static DataStreamMap newDataStreamMap(Object name) {
     return new DataStreamMapImpl(name);
+  }
+
+  public static CompletableFuture<RaftClientRequest> streamEndOfRequestAsync(RaftServer.Division server, RaftClientRequest request) {
+    return ((RaftServerImpl)server).streamEndOfRequestAsync(request);
   }
 
   public static void assertLostMajorityHeartbeatsRecently(RaftServer.Division leader) {

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RetryCacheTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RetryCacheTestUtil.java
@@ -59,11 +59,15 @@ public class RetryCacheTestUtil {
     }
   }
 
-  public static void getOrCreateEntry(RaftServer.Division server, ClientInvocationId invocationId) {
-    getOrCreateEntry(server.getRetryCache(), invocationId);
+  public static RetryCache.Entry getOrCreateEntry(RaftServer.Division server, ClientInvocationId invocationId) {
+    return getOrCreateEntryImpl(server.getRetryCache(), invocationId);
   }
 
-  private static RetryCache.Entry getOrCreateEntry(RetryCache cache, ClientInvocationId invocationId) {
+  public static RetryCache.Entry getOrCreateEntry(RetryCache retryCache, ClientInvocationId invocationId) {
+    return getOrCreateEntryImpl(retryCache, invocationId);
+  }
+
+  private static RetryCache.Entry getOrCreateEntryImpl(RetryCache cache, ClientInvocationId invocationId) {
     return ((RetryCacheImpl)cache).getOrCreateEntry(invocationId);
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftServerWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftServerWithGrpc.java
@@ -30,7 +30,8 @@ import com.codahale.metrics.Gauge;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.log4j.Level;
 import org.apache.ratis.BaseTest;
-import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.*;
+import org.apache.ratis.protocol.exceptions.StreamException;
 import org.apache.ratis.server.impl.MiniRaftCluster;
 import org.apache.ratis.RaftTestUtil;
 import org.apache.ratis.RaftTestUtil.SimpleMessage;
@@ -44,9 +45,6 @@ import org.apache.ratis.grpc.client.GrpcClientProtocolService;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
-import org.apache.ratis.protocol.RaftClientReply;
-import org.apache.ratis.protocol.RaftClientRequest;
-import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.TimeoutIOException;
 import org.apache.ratis.retry.RetryPolicies;
 import org.apache.ratis.server.RaftServer;
@@ -74,6 +72,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 
 public class TestRaftServerWithGrpc extends BaseTest implements MiniRaftClusterWithGrpc.FactoryGet {
   {
@@ -311,9 +310,50 @@ public class TestRaftServerWithGrpc extends BaseTest implements MiniRaftClusterW
     }
   }
 
+  @Test
+  public void TestStreamEndOfRequestAsync() throws Exception {
+    runWithNewCluster(1, this::runTestStreamEndOfRequestAsync);
+  }
+
+  void runTestStreamEndOfRequestAsync(MiniRaftClusterWithGrpc cluster) throws Exception {
+    final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster);
+    final RaftPeerId leaderId = leader.getId();
+    final RaftGroupId leaderGroupId = leader.getGroup().getGroupId();
+    final RaftClient client = cluster.createClient();
+    final AtomicLong seqNum = new AtomicLong();
+    final RaftClientRequest clientRequest = newRaftClientRequest(client, leaderId, seqNum.incrementAndGet(),
+            RaftClientRequest.messageStreamRequestType(12, 12, true));
+
+    // Leader completes exceptionally, because there is no such stream
+    // Creating realistic stream is complex, since streams are created by clients, but
+    // this function tests server functionality.
+    CompletableFuture<RaftClientRequest> fRequest = RaftServerTestUtil.streamEndOfRequestAsync(leader, clientRequest);
+    Assert.assertNotNull(fRequest);
+    Assert.assertTrue(fRequest.isCompletedExceptionally());
+    fRequest.exceptionally(e -> {
+      Assert.assertSame(e.getCause().getClass(), StreamException.class);
+      return clientRequest;
+    });
+
+    // On non leader, request should fail because only leaders handle this kind of requests
+    RaftServer server = cluster.putNewServer(RaftPeerId.getRaftPeerId("Server 21"), leader.getGroup(), false);
+    fRequest = RaftServerTestUtil.streamEndOfRequestAsync(server.getDivision(leaderGroupId), clientRequest);
+    Assert.assertNotNull(fRequest);
+    Assert.assertTrue(fRequest.isCompletedExceptionally());
+    fRequest.exceptionally(e -> {
+      Assert.assertSame(e.getCause().getClass(), Exception.class);
+      return clientRequest;
+    });
+  }
+
   static RaftClientRequest newRaftClientRequest(RaftClient client, RaftPeerId serverId, long seqNum) {
+    return newRaftClientRequest(client, serverId, seqNum, RaftClientRequest.writeRequestType());
+  }
+
+  static RaftClientRequest newRaftClientRequest(RaftClient client, RaftPeerId serverId, long seqNum,
+                                                RaftClientRequest.Type type) {
     final SimpleMessage m = new SimpleMessage("m" + seqNum);
     return RaftClientTestUtil.newRaftClientRequest(client, serverId, seqNum, m,
-        RaftClientRequest.writeRequestType(), ProtoUtils.toSlidingWindowEntry(seqNum, seqNum == 1L));
+            type, ProtoUtils.toSlidingWindowEntry(seqNum, seqNum == 1L));
   }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -24,9 +24,7 @@ import org.apache.ratis.BaseTest;
 import org.apache.ratis.RaftTestUtil.SimpleOperation;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.metrics.RatisMetricRegistry;
-import org.apache.ratis.protocol.RaftGroupId;
-import org.apache.ratis.protocol.RaftGroupMemberId;
-import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.protocol.*;
 import org.apache.ratis.protocol.exceptions.TimeoutIOException;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.impl.RetryCacheTestUtil;
@@ -634,6 +632,29 @@ public class TestSegmentedRaftLog extends BaseTest {
     Assert.assertNotNull(ex);
     Assert.assertSame(LifeCycle.State.PAUSED, sm.getLifeCycleState());
     throw ex;
+  }
+
+  /**
+   * Verifies that getOrCreateEntry function creates cache entry in every case and does not return null.
+   */
+  @Test
+  public void testGetOrCreateEntry() {
+    final RetryCache retryCache = RetryCacheTestUtil.createRetryCache();
+    final ClientId clientId = ClientId.randomId();
+    final long invocationId1 = 123456789;
+    final ClientInvocationId clientInvocationId1 = ClientInvocationId.valueOf(clientId, invocationId1);
+    RetryCache.Entry cacheEntry1 = RetryCacheTestUtil.getOrCreateEntry(retryCache, clientInvocationId1);
+    Assert.assertNotNull(cacheEntry1);
+
+    RetryCache.Entry cacheEntry1Again = RetryCacheTestUtil.getOrCreateEntry(retryCache, clientInvocationId1);
+    Assert.assertEquals(cacheEntry1.toString(), cacheEntry1Again.toString());
+
+    final long invocationId2 = 987654321;
+    final ClientInvocationId clientInvocationId2 = ClientInvocationId.valueOf(clientId, invocationId2);
+    RetryCache.Entry cacheEntry2 = RetryCacheTestUtil.getOrCreateEntry(retryCache, clientInvocationId2);
+    Assert.assertNotNull(cacheEntry2);
+
+    Assert.assertNotEquals(cacheEntry1.toString(), cacheEntry2.toString());
   }
 
   static Thread startAppendEntryThread(RaftLog raftLog, LogEntryProto entry) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix three NPE issues reported by Sonar Qube in the server impl.
- Add default to streamEndOfRequestAsync function
- Throw error on notifyStateMachine... funtion
- Remove possibility for new cache entries to be null
- Add tests for changes

Was part of the https://github.com/apache/ratis/pull/461

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1368

## How was this patch tested?

Changes have been tested using existing test cases and two new test cases.
