### PR TITLE
RATIS-1369. When there is no snapshot, the return snapshotIndex should be -1, not 0.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -440,7 +440,7 @@ class ServerState implements Closeable {
    */
   long getSnapshotIndex() {
     final SnapshotInfo s = getLatestSnapshot();
-    final long latestSnapshotIndex = s != null ? s.getIndex() : -1;
+    final long latestSnapshotIndex = s != null ? s.getIndex() : RaftLog.INVALID_LOG_INDEX;
     return Math.max(latestSnapshotIndex, getLatestInstalledSnapshotIndex());
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -431,7 +431,7 @@ class ServerState implements Closeable {
 
   long getLatestInstalledSnapshotIndex() {
     final TermIndex ti = latestInstalledSnapshot.get();
-    return ti != null? ti.getIndex(): -1L;
+    return ti != null? ti.getIndex(): RaftLog.INVALID_LOG_INDEX;
   }
 
   /**

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -431,7 +431,7 @@ class ServerState implements Closeable {
 
   long getLatestInstalledSnapshotIndex() {
     final TermIndex ti = latestInstalledSnapshot.get();
-    return ti != null? ti.getIndex(): 0L;
+    return ti != null? ti.getIndex(): -1L;
   }
 
   /**
@@ -440,7 +440,7 @@ class ServerState implements Closeable {
    */
   long getSnapshotIndex() {
     final SnapshotInfo s = getLatestSnapshot();
-    final long latestSnapshotIndex = s != null ? s.getIndex() : 0;
+    final long latestSnapshotIndex = s != null ? s.getIndex() : -1;
     return Math.max(latestSnapshotIndex, getLatestInstalledSnapshotIndex());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

For now, if there is no snapshot existed, the returned snapshotIndex is 0. 
It is not correctly, since the raft log starts from index 0 (BTW, in raft paper, the first valid log index is 1, but in ratis, it is 0), a snapshot taken at snapshotIndex 0 should contain the log entry 0. The snapshotIndex indicating an empty/fake snapshot should be -1.

```
diff --git a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
index 728f7e9c..6307ca79 100644
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -431,7 +431,7 @@ class ServerState implements Closeable {
 
   long getLatestInstalledSnapshotIndex() {
     final TermIndex ti = latestInstalledSnapshot.get();
-    return ti != null? ti.getIndex(): 0L;
+    return ti != null? ti.getIndex(): -1L;
   }
 
   /**
@@ -440,7 +440,7 @@ class ServerState implements Closeable {
    */
   long getSnapshotIndex() {
     final SnapshotInfo s = getLatestSnapshot();
-    final long latestSnapshotIndex = s != null ? s.getIndex() : 0;
+    final long latestSnapshotIndex = s != null ? s.getIndex() : -1;
     return Math.max(latestSnapshotIndex, getLatestInstalledSnapshotIndex());
   }
```

This issue is found in the test of bootstrap SCM in SCM HA. For details, please check the jira.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1369

## How was this patch tested?

CI
