### PR TITLE
RATIS-1371. Support multi-client when transfer data between servers

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -29,6 +29,7 @@ import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.server.DataStreamServerRpc;
 import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.thirdparty.io.netty.bootstrap.ServerBootstrap;
 import org.apache.ratis.thirdparty.io.netty.buffer.ByteBuf;
 import org.apache.ratis.thirdparty.io.netty.channel.ChannelFuture;
@@ -54,6 +55,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -109,17 +111,22 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
   private final EventLoopGroup bossGroup = new NioEventLoopGroup();
   private final EventLoopGroup workerGroup = new NioEventLoopGroup();
   private final ChannelFuture channelFuture;
+  private final int clientNum;
 
   private final DataStreamManagement requests;
-  private final Proxies proxies;
+  private final List<Proxies> proxies = new ArrayList<>();
 
   public NettyServerStreamRpc(RaftServer server) {
     this.name = server.getId() + "-" + JavaUtils.getClassSimpleName(getClass());
     this.requests = new DataStreamManagement(server);
-
     final RaftProperties properties = server.getProperties();
+
+    this.clientNum = RaftServerConfigKeys.DataStream.clientNum(properties);
+    for (int i = 0; i < clientNum; i ++) {
+      this.proxies.add(new Proxies(new PeerProxyMap<>(name, peer -> newClient(peer, properties))));
+    }
+
     final int port = NettyConfigKeys.DataStream.port(properties);
-    this.proxies = new Proxies(new PeerProxyMap<>(name, peer -> newClient(peer, properties)));
     this.channelFuture = new ServerBootstrap()
         .group(bossGroup, workerGroup)
         .channel(NioServerSocketChannel.class)
@@ -139,7 +146,9 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
 
   @Override
   public void addRaftPeers(Collection<RaftPeer> newPeers) {
-    proxies.addPeers(newPeers);
+    for (int i = 0; i < clientNum; i ++) {
+      proxies.get(i).addPeers(newPeers);
+    }
   }
 
   static class RequestRef {
@@ -174,7 +183,9 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
         }
 
         final DataStreamRequestByteBuf request = requestRef.set((DataStreamRequestByteBuf)msg);
-        requests.read(request, ctx, proxies::getDataStreamOutput);
+
+        int index = (int)request.getStreamId() % clientNum;
+        requests.read(request, ctx, proxies.get(index)::getDataStreamOutput);
         requestRef.reset(request);
       }
 
@@ -243,7 +254,9 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
       LOG.error(this + ": Interrupted close()", e);
     }
 
-    proxies.close();
+    for (int i = 0; i < clientNum; i ++) {
+      proxies.get(i).close();
+    }
   }
 
   @Override

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -184,7 +184,8 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
 
         final DataStreamRequestByteBuf request = requestRef.set((DataStreamRequestByteBuf)msg);
 
-        int index = (int)request.getStreamId() % proxies.size();
+        int index = Math.toIntExact(
+            ((0xFFFFFFFFL & request.getClientId().hashCode()) + request.getStreamId()) % proxies.size());
         requests.read(request, ctx, proxies.get(index)::getDataStreamOutput);
 
         requestRef.reset(request);

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -446,17 +446,17 @@ public interface RaftServerConfigKeys {
       setInt(properties::setInt, ASYNC_WRITE_THREAD_POOL_SIZE_KEY, port);
     }
 
-    String CLIENT_NUM_KEY = PREFIX + ".client.number";
-    int CLIENT_NUM_DEFAULT = 10;
+    String CLIENT_POOL_SIZE_KEY = PREFIX + ".client.pool.size";
+    int CLIENT_POOL_SIZE_DEFAULT = 10;
 
-    static int clientNum(RaftProperties properties) {
-      return getInt(properties::getInt, CLIENT_NUM_KEY,
-          CLIENT_NUM_DEFAULT, getDefaultLog(),
+    static int clientPoolSize(RaftProperties properties) {
+      return getInt(properties::getInt, CLIENT_POOL_SIZE_KEY,
+          CLIENT_POOL_SIZE_DEFAULT, getDefaultLog(),
           requireMin(0), requireMax(65536));
     }
 
-    static void setClientNum(RaftProperties properties, int num) {
-      setInt(properties::setInt, CLIENT_NUM_KEY, num);
+    static void setClientPoolSize(RaftProperties properties, int num) {
+      setInt(properties::setInt, CLIENT_POOL_SIZE_KEY, num);
     }
   }
 

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -445,6 +445,19 @@ public interface RaftServerConfigKeys {
     static void setAsyncWriteThreadPoolSize(RaftProperties properties, int port) {
       setInt(properties::setInt, ASYNC_WRITE_THREAD_POOL_SIZE_KEY, port);
     }
+
+    String CLIENT_NUM_KEY = PREFIX + ".client.number";
+    int CLIENT_NUM_DEFAULT = 10;
+
+    static int clientNum(RaftProperties properties) {
+      return getInt(properties::getInt, CLIENT_NUM_KEY,
+          CLIENT_NUM_DEFAULT, getDefaultLog(),
+          requireMin(0), requireMax(65536));
+    }
+
+    static void setClientNum(RaftProperties properties, int num) {
+      setInt(properties::setInt, CLIENT_NUM_KEY, num);
+    }
   }
 
   /** server rpc timeout related */


### PR DESCRIPTION
## What changes were proposed in this pull request?

If server1 use only one client to transfer data to server2, there is bottleneck, so we should use multi-client.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1371

## How was this patch tested?

No need new ut.
