### PR TITLE
RATIS-1376. Improve the used memory

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/RaftClientConfigKeys.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/RaftClientConfigKeys.java
@@ -95,7 +95,7 @@ public interface RaftClientConfigKeys {
     String PREFIX = RaftClientConfigKeys.PREFIX + ".data-stream";
 
     String OUTSTANDING_REQUESTS_MAX_KEY = PREFIX + ".outstanding-requests.max";
-    int OUTSTANDING_REQUESTS_MAX_DEFAULT = 100;
+    int OUTSTANDING_REQUESTS_MAX_DEFAULT = 10;
     static int outstandingRequestsMax(RaftProperties properties) {
       return getInt(properties::getInt, OUTSTANDING_REQUESTS_MAX_KEY,
           OUTSTANDING_REQUESTS_MAX_DEFAULT, getDefaultLog(), requireMin(2));

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedStreamAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedStreamAsync.java
@@ -127,9 +127,10 @@ public class OrderedStreamAsync {
     }
     final CompletableFuture<DataStreamReply> requestFuture = dataStreamClientRpc.streamAsync(
         request.getDataStreamRequest());
+    long seqNum = request.getSeqNum();
     requestFuture.thenApply(reply -> {
       slidingWindow.receiveReply(
-          request.getSeqNum(), reply, this::sendRequestToNetwork);
+          seqNum, reply, this::sendRequestToNetwork);
       return reply;
     }).thenAccept(reply -> {
       if (f.isDone()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Decrease outstanding-requests
2. Do not use request in lambda, because the request contains data, before lambda finish, request can not free memory.
![image](https://user-images.githubusercontent.com/51938049/117949755-07ce2d80-b345-11eb-8a37-ad0a0b6e3034.png)



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1376

## How was this patch tested?

no need new ut.
