### PR TITLE
RATIS-1377. Ratis min free space for storage dirs.

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -51,6 +51,16 @@ public interface RaftServerConfigKeys {
     setFiles(properties::setFiles, STORAGE_DIR_KEY, storageDir);
   }
 
+  String STORAGE_FREE_SPACE_MIN_KEY = PREFIX + ".storage.free-space.min";
+  SizeInBytes STORAGE_FREE_SPACE_MIN_DEFAULT = SizeInBytes.valueOf("0MB");
+  static SizeInBytes storageFreeSpaceMin(RaftProperties properties) {
+    return getSizeInBytes(properties::getSizeInBytes,
+        STORAGE_FREE_SPACE_MIN_KEY, STORAGE_FREE_SPACE_MIN_DEFAULT, getDefaultLog());
+  }
+  static void setStorageFreeSpaceMin(RaftProperties properties, SizeInBytes storageFreeSpaceMin) {
+    setSizeInBytes(properties::set, STORAGE_FREE_SPACE_MIN_KEY, storageFreeSpaceMin);
+  }
+
   String REMOVED_GROUPS_DIR_KEY = PREFIX + ".removed.groups.dir";
   File REMOVED_GROUPS_DIR_DEFAULT = new File("/tmp/raft-server/removed-groups/");
   static File removedGroupsDir(RaftProperties properties) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -110,7 +110,8 @@ class ServerState implements Closeable {
       // use full uuid string to create a subdirectory
       File dir = chooseStorageDir(directories, group.getGroupId().getUuid().toString());
       try {
-        storage = new RaftStorageImpl(dir, RaftServerConfigKeys.Log.corruptionPolicy(prop));
+        storage = new RaftStorageImpl(dir, RaftServerConfigKeys.Log.corruptionPolicy(prop),
+            RaftServerConfigKeys.storageFreeSpaceMin(prop).getSize());
         storageFound = true;
         break;
       } catch (IOException e) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorageImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorageImpl.java
@@ -47,12 +47,14 @@ public class RaftStorageImpl implements RaftStorage {
   private final CorruptionPolicy logCorruptionPolicy;
   private volatile RaftStorageMetadataFileImpl metaFile;
 
-  public RaftStorageImpl(File dir, CorruptionPolicy logCorruptionPolicy) throws IOException {
-    this(dir, logCorruptionPolicy, null);
+  public RaftStorageImpl(File dir, CorruptionPolicy logCorruptionPolicy,
+      long storageFeeSpaceMin) throws IOException {
+    this(dir, logCorruptionPolicy, null, storageFeeSpaceMin);
   }
 
-  RaftStorageImpl(File dir, CorruptionPolicy logCorruptionPolicy, StartupOption option) throws IOException {
-    this.storageDir = new RaftStorageDirectoryImpl(dir);
+  RaftStorageImpl(File dir, CorruptionPolicy logCorruptionPolicy, StartupOption option,
+      long storageFeeSpaceMin) throws IOException {
+    this.storageDir = new RaftStorageDirectoryImpl(dir, storageFeeSpaceMin);
     if (option == StartupOption.FORMAT) {
       if (storageDir.analyzeStorage(false) == StorageState.NON_EXISTENT) {
         throw new IOException("Cannot format " + storageDir);

--- a/ratis-server/src/test/java/org/apache/ratis/server/storage/RaftStorageTestUtils.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/storage/RaftStorageTestUtils.java
@@ -33,7 +33,7 @@ import java.util.function.Consumer;
 
 public interface RaftStorageTestUtils {
   static RaftStorage newRaftStorage(File dir) throws IOException {
-    return new RaftStorageImpl(dir, null);
+    return new RaftStorageImpl(dir, null, 0L);
   }
 
   static String getLogFlushTimeMetric(String memberId) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce a '.storage.space.reserved' for storage dir, it is used to prevent RaftServer from failing to take a final snapshot
when raftgroups are removed.
This threshold is only saved for final snapshots and should not be very large (e.g. 100MB),
and it is not for ratis log disks to be shared with other services, so maybe a simple global config is enough.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1377

## How was this patch tested?

a new ut.
