### PR TITLE
RATIS-1382. Bump ratis-thirdparty version to the latest release (0.7.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
     <maven.min.version>3.3.9</maven.min.version>
 
     <!-- Contains all shaded thirdparty dependencies -->
-    <ratis.thirdparty.version>0.7.0-a398b19-SNAPSHOT</ratis.thirdparty.version>
+    <ratis.thirdparty.version>0.7.0</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
     <shaded.protobuf.version>3.12.0</shaded.protobuf.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Just a version bump after the 0.7.0 release of ratis-thirdparty

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1382

## How was this patch tested?

Full build.