### PR TITLE
RATIS-1385. Project assembly fails on linux

### DIFF
--- a/ratis-assembly/pom.xml
+++ b/ratis-assembly/pom.xml
@@ -330,10 +330,7 @@
                   <arguments>
                     <argument>bash</argument>
                     <argument>-c</argument>
-                    <argument>cat maven-shared-archive-resources/META-INF/NOTICE \
-                      `find ${project.build.directory}/dependency -iname NOTICE -or -iname
-                      NOTICE.txt` \
-                    </argument>
+                    <argument>cat maven-shared-archive-resources/META-INF/NOTICE `find ${project.build.directory}/dependency -iname NOTICE -or -iname NOTICE.txt`</argument>
                   </arguments>
                   <outputFile>${project.build.directory}/NOTICE.aggregate</outputFile>
                   <workingDirectory>${project.build.directory}</workingDirectory>


### PR DESCRIPTION
## What changes were proposed in this pull request?



mvn build command is failing of assembly is turned on:
```
mvn clean install assembly:single -DskipTests=true  -Prelease
```

```
[INFO] --- exec-maven-plugin:1.6.0:exec (concat-NOTICE-files) @ ratis-assembly ---
[ERROR] Command execution failed.
org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
    at org.apache.commons.exec.DefaultExecutor.executeInternal (DefaultExecutor.java:404)
```

Looks like to be sensitive to the new lines in the command.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1385

## How was this patch tested?

Executed the same command with the patch and it worked well.