### PR TITLE
RATIS-1386. Some MetricsRegistry instances never unregistered

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/intercept/client/MetricClientInterceptor.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/intercept/client/MetricClientInterceptor.java
@@ -21,13 +21,15 @@ package org.apache.ratis.grpc.metrics.intercept.client;
 import org.apache.ratis.grpc.metrics.MessageMetrics;
 import org.apache.ratis.thirdparty.io.grpc.*;
 
+import java.io.Closeable;
+
 /**
  * An implementation of a client interceptor.
  * Intercepts the messages and increments metrics accordingly
  * before sending them.
  */
 
-public class MetricClientInterceptor implements ClientInterceptor {
+public class MetricClientInterceptor implements ClientInterceptor, Closeable {
   private final String identifier;
   private final MessageMetrics metrics;
 
@@ -52,5 +54,10 @@ public class MetricClientInterceptor implements ClientInterceptor {
         metrics,
         getMethodMetricPrefix(methodDescriptor)
     );
+  }
+
+  @Override
+  public void close() {
+    metrics.unregister();
   }
 }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
@@ -270,6 +270,8 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
       }
       LOG.info("{} successfully", name);
     }
+
+    serverInterceptor.close();
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/memory/MemoryRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/memory/MemoryRaftLog.java
@@ -28,6 +28,7 @@ import org.apache.ratis.server.storage.RaftStorageMetadata;
 import org.apache.ratis.util.AutoCloseableLock;
 import org.apache.ratis.util.Preconditions;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -84,6 +85,12 @@ public class MemoryRaftLog extends RaftLogBase {
                        RaftProperties properties) {
     super(memberId, commitIndexSupplier, properties);
     this.metrics = new RaftLogMetricsBase(memberId);
+  }
+
+  @Override
+  public void close() throws IOException {
+    super.close();
+    metrics.unregister();
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make sure `Metric*Interceptor` unregisters its metrics from the global registry to avoid memory leak.

https://issues.apache.org/jira/browse/RATIS-1386

## How was this patch tested?

Built Ratis and Ozone with it.  Created objects in Ozone via S3 Gateway.  Verified that no `MetricRegistryInfo` and `RatisMetricRegistryImpl` instances are retained in S3 Gateway memory for each object.

https://github.com/adoroszlai/incubator-ratis/actions/runs/979350754