### PR TITLE
RATIS-1390. Bootstrapping Peer should always try to install a snapshot the first time.

### DIFF
--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -148,6 +148,7 @@ enum InstallSnapshotResult {
   IN_PROGRESS = 2;
   ALREADY_INSTALLED = 3;
   CONF_MISMATCH = 4;
+  NULL_SNAPSHOT = 5;
 }
 
 message RequestVoteRequestProto {

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -148,7 +148,8 @@ enum InstallSnapshotResult {
   IN_PROGRESS = 2;
   ALREADY_INSTALLED = 3;
   CONF_MISMATCH = 4;
-  NULL_SNAPSHOT = 5;
+  SNAPSHOT_INSTALLED = 5;
+  SNAPSHOT_UNAVAILABLE = 6;
 }
 
 message RequestVoteRequestProto {

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
@@ -54,7 +54,7 @@ public interface FollowerInfo {
 
   /** Acknowledge that Follower attempted to install a snapshot. It does not guarantee that the installation was
    * successful. This helps to determine whether Follower can come out of bootstrap process. */
-  void ackInstallSnapshotAttempt();
+  void setAttemptedToInstallSnapshot();
 
   /** Return true if install snapshot has been attempted by the Follower at least once. Used to verify if
    * Follower tried to install snapshot during bootstrap process. */

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
@@ -52,6 +52,14 @@ public interface FollowerInfo {
   /** Set follower's snapshotIndex. */
   void setSnapshotIndex(long newSnapshotIndex);
 
+  /** Acknowledge that Follower attempted to install a snapshot. It does not guarantee that the installation was
+   * successful. This helps to determine whether Follower can come out of bootstrap process. */
+  void ackInstallSnapshotAttempt();
+
+  /** Return true if install snapshot has been attempted by the Follower at least once. Used to verify if
+   * Follower tried to install snapshot during bootstrap process. */
+  boolean hasAttemptedToInstallSnapshot();
+
   /** @return the nextIndex for this follower. */
   long getNextIndex();
 

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LeaderState.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LeaderState.java
@@ -58,4 +58,8 @@ public interface LeaderState {
 
   /** Handle the event that the follower has replied a success append entries. */
   void onFollowerSuccessAppendEntries(FollowerInfo follower);
+
+  /** Check if a follower is bootstrapping. */
+  boolean isFollowerBootstrapping(FollowerInfo follower);
+
 }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -108,10 +108,24 @@ public interface LogAppender {
     // we should install snapshot if the follower needs to catch up and:
     // 1. there is no local log entry but there is snapshot
     // 2. or the follower's next index is smaller than the log start index
+    // 3. or the follower is bootstrapping and has not installed any snapshot yet
+    final FollowerInfo follower = getFollower();
+    final boolean isFollowerBootstrapping = getLeaderState().isFollowerBootstrapping(follower);
+    final SnapshotInfo snapshot = getServer().getStateMachine().getLatestSnapshot();
+
+    if (isFollowerBootstrapping && !follower.hasAttemptedToInstallSnapshot()) {
+      if (snapshot == null) {
+        // Leader cannot send null snapshot to follower. Hence, acknowledge InstallSnapshot attempt (even though it
+        // was not attempted) so that follower can come out of staging state after appending log entries.
+        follower.ackInstallSnapshotAttempt();
+      } else {
+        return snapshot;
+      }
+    }
+
     final long followerNextIndex = getFollower().getNextIndex();
     if (followerNextIndex < getRaftLog().getNextIndex()) {
       final long logStartIndex = getRaftLog().getStartIndex();
-      final SnapshotInfo snapshot = getServer().getStateMachine().getLatestSnapshot();
       if (followerNextIndex < logStartIndex || (logStartIndex == RaftLog.INVALID_LOG_INDEX && snapshot != null)) {
         return snapshot;
       }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -117,7 +117,7 @@ public interface LogAppender {
       if (snapshot == null) {
         // Leader cannot send null snapshot to follower. Hence, acknowledge InstallSnapshot attempt (even though it
         // was not attempted) so that follower can come out of staging state after appending log entries.
-        follower.ackInstallSnapshotAttempt();
+        follower.setAttemptedToInstallSnapshot();
       } else {
         return snapshot;
       }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -113,7 +113,7 @@ class FollowerInfoImpl implements FollowerInfo {
 
   @Override
   public void ackInstallSnapshotAttempt() {
-    LOG.info("----- Follower ack Install Snapshot old snapshotIndex: " + snapshotIndex.get());
+    LOG.info("Follower {} acknowledged installing snapshot", name);
     ackInstallSnapshotAttempt = true;
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -112,7 +112,7 @@ class FollowerInfoImpl implements FollowerInfo {
   }
 
   @Override
-  public void ackInstallSnapshotAttempt() {
+  public void setAttemptedToInstallSnapshot() {
     LOG.info("Follower {} acknowledged installing snapshot", name);
     ackInstallSnapshotAttempt = true;
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -40,6 +40,7 @@ class FollowerInfoImpl implements FollowerInfo {
   private final RaftLogIndex commitIndex = new RaftLogIndex("commitIndex", RaftLog.INVALID_LOG_INDEX);
   private final RaftLogIndex snapshotIndex = new RaftLogIndex("snapshotIndex", 0L);
   private volatile boolean attendVote;
+  private volatile boolean ackInstallSnapshotAttempt = false;
 
   FollowerInfoImpl(RaftGroupMemberId id, RaftPeer peer, Timestamp lastRpcTime, long nextIndex, boolean attendVote) {
     this.name = id + "->" + peer.getId();
@@ -108,6 +109,17 @@ class FollowerInfoImpl implements FollowerInfo {
     snapshotIndex.setUnconditionally(newSnapshotIndex, infoIndexChange);
     matchIndex.setUnconditionally(newSnapshotIndex, infoIndexChange);
     nextIndex.setUnconditionally(newSnapshotIndex + 1, infoIndexChange);
+  }
+
+  @Override
+  public void ackInstallSnapshotAttempt() {
+    LOG.info("----- Follower ack Install Snapshot old snapshotIndex: " + snapshotIndex.get());
+    ackInstallSnapshotAttempt = true;
+  }
+
+  @Override
+  public boolean hasAttemptedToInstallSnapshot() {
+    return ackInstallSnapshotAttempt;
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -619,7 +619,8 @@ class LeaderStateImpl implements LeaderState {
       LOG.debug("{} detects a follower {} timeout ({}) for bootstrapping", this, follower, timeoutTime);
       return BootStrapProgress.NOPROGRESS;
     } else if (follower.getMatchIndex() + stagingCatchupGap > committed
-        && follower.getLastRpcResponseTime().compareTo(progressTime) > 0) {
+        && follower.getLastRpcResponseTime().compareTo(progressTime) > 0
+        && follower.hasAttemptedToInstallSnapshot()) {
       return BootStrapProgress.CAUGHTUP;
     } else {
       return BootStrapProgress.PROGRESSING;
@@ -641,6 +642,11 @@ class LeaderStateImpl implements LeaderState {
     } else {
       eventQueue.submit(checkStagingEvent);
     }
+  }
+
+  @Override
+  public boolean isFollowerBootstrapping(FollowerInfo follower) {
+    return isBootStrappingPeer(follower.getPeer().getId());
   }
 
   private void checkStaging() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.impl;
 
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.client.impl.ClientProtoUtils;
 import org.apache.ratis.conf.RaftProperties;
@@ -166,6 +167,7 @@ class RaftServerImpl implements RaftServer.Division,
   private final RaftServerMetricsImpl raftServerMetrics;
 
   private final AtomicReference<TermIndex> inProgressInstallSnapshotRequest;
+  private final AtomicLong installedSnapshotIndex;
   private final AtomicBoolean isSnapshotNull;
 
   // To avoid append entry before complete start() method
@@ -195,6 +197,7 @@ class RaftServerImpl implements RaftServer.Division,
     this.state = new ServerState(id, group, properties, this, stateMachine);
     this.retryCache = new RetryCacheImpl(properties);
     this.inProgressInstallSnapshotRequest = new AtomicReference<>(null);
+    this.installedSnapshotIndex = new AtomicLong();
     this.isSnapshotNull = new AtomicBoolean(false);
     this.dataStreamMap = new DataStreamMapImpl(id);
 
@@ -1543,21 +1546,22 @@ class RaftServerImpl implements RaftServer.Division,
       }
       changeToFollowerAndPersistMetadata(leaderTerm, "installSnapshot");
       state.setLeader(leaderId, "installSnapshot");
+      long snapshotIndex = state.getSnapshotIndex();
 
       updateLastRpcTime(FollowerState.UpdateType.INSTALL_SNAPSHOT_NOTIFICATION);
       if (inProgressInstallSnapshotRequest.compareAndSet(null, firstAvailableLogTermIndex)) {
+        LOG.info("{}: Received notification to install snapshot at index {}", getMemberId(), firstAvailableLogIndex);
         // Check if snapshot index is already at par or ahead of the first
         // available log index of the Leader.
-        long snapshotIndex = state.getSnapshotIndex();
         if (snapshotIndex + 1 >= firstAvailableLogIndex && firstAvailableLogIndex > 0) {
           // State Machine has already installed the snapshot. Return the
           // latest snapshot index to the Leader.
 
           inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
-          final InstallSnapshotReplyProto reply = ServerProtoUtils.toInstallSnapshotReplyProto(
-              leaderId, getMemberId(), currentTerm, InstallSnapshotResult.ALREADY_INSTALLED, snapshotIndex);
-          LOG.info("{}: StateMachine snapshotIndex is {}", getMemberId(), snapshotIndex);
-          return reply;
+          LOG.info("{}: InstallSnapshot notification result: {}, current snapshot index: {}", getMemberId(),
+              InstallSnapshotResult.ALREADY_INSTALLED, snapshotIndex);
+          return ServerProtoUtils.toInstallSnapshotReplyProto(leaderId, getMemberId(), currentTerm,
+              InstallSnapshotResult.ALREADY_INSTALLED, snapshotIndex);
         }
 
         Optional<RaftPeerProto> leaderPeerInfo = null;
@@ -1595,13 +1599,13 @@ class RaftServerImpl implements RaftServer.Division,
                   stateMachine.pause();
                   state.updateInstalledSnapshotIndex(reply);
                   state.reloadStateMachine(reply.getIndex());
+                  installedSnapshotIndex.set(reply.getIndex());
                 } else {
                   isSnapshotNull.set(true);
                   if (LOG.isDebugEnabled()) {
                     LOG.debug("{}: StateMachine could not install snapshot as it is not available", this);
                   }
                 }
-                inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
               });
         } catch (Throwable t) {
           inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
@@ -1609,17 +1613,39 @@ class RaftServerImpl implements RaftServer.Division,
         }
 
         if (LOG.isDebugEnabled()) {
-          LOG.debug("{}: Snapshot Installation Request received and is in progress", getMemberId());
+          LOG.debug("{}: StateMachine is processing Snapshot Installation Request.", getMemberId());
         }
       } else {
-        LOG.info("{}: Snapshot Installation by StateMachine is in progress.", getMemberId());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("{}: StateMachine is already installing a snapshot.", getMemberId());
+        }
       }
 
+      // If the snapshot is null or unavailable, return SNAPSHOT_UNAVAILABLE.
       if (isSnapshotNull.compareAndSet(true, false)) {
+        LOG.info("{}: InstallSnapshot notification result: {}", getMemberId(),
+            InstallSnapshotResult.SNAPSHOT_UNAVAILABLE);
+        inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
         return ServerProtoUtils.toInstallSnapshotReplyProto(leaderId, getMemberId(),
-            currentTerm, InstallSnapshotResult.NULL_SNAPSHOT, -1);
+            currentTerm, InstallSnapshotResult.SNAPSHOT_UNAVAILABLE, -1);
       }
 
+      // If a snapshot has been installed, return SNAPSHOT_INSTALLED with the installed snapshot index and reset
+      // installedSnapshotIndex to 0.
+      long latestInstalledSnapshotIndex = this.installedSnapshotIndex.getAndSet(0);
+      if (latestInstalledSnapshotIndex > 0) {
+        LOG.info("{}: InstallSnapshot notification result: {}, at index: {}", getMemberId(),
+            InstallSnapshotResult.SNAPSHOT_INSTALLED, latestInstalledSnapshotIndex);
+        inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
+        return ServerProtoUtils.toInstallSnapshotReplyProto(leaderId, getMemberId(),
+            currentTerm, InstallSnapshotResult.SNAPSHOT_INSTALLED, latestInstalledSnapshotIndex);
+      }
+
+      // Otherwise, Snapshot installation is in progress.
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("{}: InstallSnapshot notification result: {}", getMemberId(),
+            InstallSnapshotResult.IN_PROGRESS);
+      }
       return ServerProtoUtils.toInstallSnapshotReplyProto(leaderId, getMemberId(),
           currentTerm, InstallSnapshotResult.IN_PROGRESS, -1);
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
@@ -176,7 +176,7 @@ public abstract class LogAppenderBase implements LogAppender {
 
   @Override
   public InstallSnapshotRequestProto newInstallSnapshotNotificationRequest(TermIndex firstAvailableLogTermIndex) {
-    Preconditions.assertTrue(firstAvailableLogTermIndex.getIndex() > 0);
+    Preconditions.assertTrue(firstAvailableLogTermIndex.getIndex() >= 0);
     synchronized (server) {
       return LeaderProtoUtils.toInstallSnapshotRequestProto(server, getFollowerId(), firstAvailableLogTermIndex);
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
@@ -22,7 +22,6 @@ import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
-import org.apache.ratis.proto.RaftProtos.InstallSnapshotResult;
 import org.apache.ratis.rpc.CallId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLogIOException;
@@ -129,9 +128,9 @@ class LogAppenderDefault extends LogAppenderBase {
                 onFollowerTerm(r.getTerm());
                 break;
               case SUCCESS:
-              case NULL_SNAPSHOT:
+              case SNAPSHOT_UNAVAILABLE:
               case ALREADY_INSTALLED:
-                getFollower().ackInstallSnapshotAttempt();
+                getFollower().setAttemptedToInstallSnapshot();
                 break;
               default:
                 break;

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -370,6 +370,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
 
   private void testInstallSnapshotDuringBootstrap(CLUSTER cluster) throws Exception {
     leaderSnapshotInfoRef.set(null);
+    numSnapshotRequests.set(0);
     int i = 0;
     try {
       RaftTestUtil.waitForLeader(cluster);
@@ -406,8 +407,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
       // trigger setConfiguration
       cluster.setConfiguration(change.allPeersInNewConf);
 
-      RaftServerTestUtil
-          .waitAndCheckNewConf(cluster, change.allPeersInNewConf, 0, null);
+      RaftServerTestUtil.waitAndCheckNewConf(cluster, change.allPeersInNewConf, 0, null);
 
       // Check the installed snapshot index on each Follower matches with the
       // leader snapshot.

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -350,4 +350,76 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
       cluster.shutdown();
     }
   }
+
+  /**
+   * Basic test for install snapshot notification: start a one node cluster
+   * (disable install snapshot option) and let it generate a snapshot. Then
+   * delete the log and restart the node, and add more nodes as followers.
+   * The new follower nodes should get a install snapshot notification.
+   */
+  /**
+   * Test for install snapshot during a peer bootstrap: start a one node cluster
+   * (disable install snapshot option) and let it generate a snapshot. Add
+   * another node and verify that the new node receives a install snapshot
+   * notification.
+   */
+  @Test
+  public void testInstallSnapshotDuringBootstrap() throws Exception {
+    runWithNewCluster(1, this::testInstallSnapshotDuringBootstrap);
+  }
+
+  private void testInstallSnapshotDuringBootstrap(CLUSTER cluster) throws Exception {
+    leaderSnapshotInfoRef.set(null);
+    int i = 0;
+    try {
+      RaftTestUtil.waitForLeader(cluster);
+      final RaftPeerId leaderId = cluster.getLeader().getId();
+
+      try(final RaftClient client = cluster.createClient(leaderId)) {
+        for (; i < SNAPSHOT_TRIGGER_THRESHOLD * 2 - 1; i++) {
+          RaftClientReply
+              reply = client.io().send(new RaftTestUtil.SimpleMessage("m" + i));
+          Assert.assertTrue(reply.isSuccess());
+        }
+      }
+
+      // wait for the snapshot to be done
+      final RaftServer.Division leader = cluster.getLeader();
+      final long nextIndex = leader.getRaftLog().getNextIndex();
+      LOG.info("nextIndex = {}", nextIndex);
+      final List<File> snapshotFiles = RaftSnapshotBaseTest.getSnapshotFiles(cluster,
+          nextIndex - SNAPSHOT_TRIGGER_THRESHOLD, nextIndex);
+      JavaUtils.attemptRepeatedly(() -> {
+        Assert.assertTrue(snapshotFiles.stream().anyMatch(RaftSnapshotBaseTest::exists));
+        return null;
+      }, 10, ONE_SECOND, "snapshotFile.exist", LOG);
+
+      RaftSnapshotBaseTest.assertLeaderContent(cluster);
+
+      final SnapshotInfo leaderSnapshotInfo = cluster.getLeader().getStateMachine().getLatestSnapshot();
+      final boolean set = leaderSnapshotInfoRef.compareAndSet(null, leaderSnapshotInfo);
+      Assert.assertTrue(set);
+
+      // add two more peers
+      final MiniRaftCluster.PeerChanges change = cluster.addNewPeers(2, true,
+          true);
+      // trigger setConfiguration
+      cluster.setConfiguration(change.allPeersInNewConf);
+
+      RaftServerTestUtil
+          .waitAndCheckNewConf(cluster, change.allPeersInNewConf, 0, null);
+
+      // Check the installed snapshot index on each Follower matches with the
+      // leader snapshot.
+      for (RaftServer.Division follower : cluster.getFollowers()) {
+        Assert.assertEquals(leaderSnapshotInfo.getIndex(),
+            RaftServerTestUtil.getLatestInstalledSnapshotIndex(follower));
+      }
+
+      // Make sure each new peer got one snapshot notification.
+      Assert.assertEquals(2, numSnapshotRequests.get());
+    } finally {
+      cluster.shutdown();
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a peer is bootstrapping and joins the Ratis ring via SetConf request, the Leader adds the peer to the sender list and sends it either the append log entries or the snapshot or a notification to install snapshot via State Machine. The leader sends the snapshot only when some or all of the ratis logs have been purged. 

The snapshot is maintained by the State Machine and as such could contain information not present in the Ratis logs (for example Ozone's OzoneManager StateMachine maintains the snapshot as a DB file and it could contain information which cannot be constructed just using the Ratis logs - HDDS-5338). 

To avoid this scenario, this Jira proposes that whenever a new peer is bootstrapping, the leader should send an install snapshot request at least once.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1390

## How was this patch tested?

Will add a unit test in next iteration.
