### PR TITLE
RATIS-1394. Wrong date for 2.1.0 release

### DIFF
--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -44,7 +44,7 @@ The binaries are also uploaded to the maven central for convenience. (See the ge
     {{ if .Params.linked }}
      <tr>
        <td>{{.File.BaseFileName }}</td>
-       <td>2021 Mar 24 </td>
+       <td>{{ time.Format "2006 Jan 2" .Params.date }}</td>
        <td>
          <a href="https://www.apache.org/dyn/closer.cgi/ratis/{{.File.BaseFileName }}/apache-ratis-{{.File.BaseFileName }}-src.tar.gz">source</a>
          (<a href="https://downloads.apache.org/ratis/{{.File.BaseFileName }}/apache-ratis-{{.File.BaseFileName }}-src.tar.gz.mds">checksum</a>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use date from download content page header, instead of hard-coded string.

https://issues.apache.org/jira/browse/RATIS-1394

## How was this patch tested?

Verified release date for both 2.0.0 and 2.1.0 in the Download page.

```
hugo serve
open http://localhost:1313/downloads.html
```