### PR TITLE
RATIS-1395. Cannot use commands from download page as is

### DIFF
--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -76,7 +76,7 @@ site</a>.</li>
 KEYS</a>
 file.</li>
 <li>gpg --import KEYS</li>
-<li>gpg --verify apache-ratis-X.Y.Z-src.tar.gz</li>
+<li>gpg --verify apache-ratis-X.Y.Z-src.tar.gz.asc</li>
 </ol>
 <h2 id="to-perform-a-quick-check-using-sha-256">To perform a quick check using SHA-256:</h2>
 <ol>

--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -75,8 +75,8 @@ site</a>.</li>
 <li>Download the <a href="https://dist.apache.org/repos/dist/release/ratis/KEYS">Ratis
 KEYS</a>
 file.</li>
-<li>gpg &ndash;import KEYS</li>
-<li>gpg &ndash;verify apache-ratis-X.Y.Z-src.tar.gz</li>
+<li>gpg --import KEYS</li>
+<li>gpg --verify apache-ratis-X.Y.Z-src.tar.gz</li>
 </ol>
 <h2 id="to-perform-a-quick-check-using-sha-256">To perform a quick check using SHA-256:</h2>
 <ol>


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Fix dash in `gpg` commands
 * Fix argument of `gpg --verify` commands (pass signature file, not the tarball)

https://issues.apache.org/jira/browse/RATIS-1395

## How was this patch tested?

```
hugo serve
open http://localhost:1313/downloads.html
```

Copied and ran command:

```
$ gpg --import KEYS
...
gpg: Total number processed: 6
...
```

Also copied, adapted and ran:

```
$ gpg --verify apache-ratis-2.1.0-src.tar.gz.asc
gpg: assuming signed data in 'apache-ratis-2.1.0-src.tar.gz'
gpg: Signature made Sat Jun 26 08:17:39 2021 CEST
gpg:                using RSA key 1CEF33FA61800117BDB2E0E0D51EA8F00EE79B28
gpg: Good signature from "Marton Elek (CODE SIGNING KEY) <elek@apache.org>" [unknown]
...
```