### PR TITLE
Second param is needed for gpg --verify

### DIFF
--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -75,8 +75,8 @@ site</a>.</li>
 <li>Download the <a href="https://dist.apache.org/repos/dist/release/ratis/KEYS">Ratis
 KEYS</a>
 file.</li>
-<li>gpg &ndash;import KEYS</li>
-<li>gpg &ndash;verify apache-ratis-X.Y.Z-src.tar.gz</li>
+<li>gpg --import KEYS</li>
+<li>gpg --verify apache-ratis-X.Y.Z-src.tar.gz.asc apache-ratis-X.Y.Z-src.tar.gz</li>
 </ol>
 <h2 id="to-perform-a-quick-check-using-sha-256">To perform a quick check using SHA-256:</h2>
 <ol>


### PR DESCRIPTION
https://www.apache.org/info/verification.html#specify_both

&ndash; is not the same as --