### PR TITLE
RATIS-1399. should notify all the log senders Asynchronously

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -200,7 +200,7 @@ class LeaderStateImpl implements LeaderState {
     }
 
     void forEach(Consumer<LogAppender> action) {
-      senders.forEach(action);
+      senders.parallelStream().forEach(action);
     }
 
     void addAll(Collection<LogAppender> newSenders) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
//LeaderStateImpl.java

void notifySenders() {
  senders.forEach(LogAppender::notifyLogAppender);
}

```
if raft , one slow log sender should not block others sender

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1399

## How was this patch tested?

no need
