### PR TITLE
RATIS-1401. Failed to add a new group due to RaftServerProxy$ImplMap LOCK unavailable.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -515,18 +515,6 @@ public class SegmentedRaftLog extends RaftLogBase {
   }
 
   @Override
-  public String toString() {
-    try(AutoCloseableLock readLock = readLock()) {
-      if (isOpened()) {
-        return super.toString() + ",f" + getFlushIndex()
-            + ",i" + Optional.ofNullable(getLastEntryTermIndex()).map(TermIndex::getIndex).orElse(0L);
-      } else {
-        return super.toString();
-      }
-    }
-  }
-
-  @Override
   public String toLogEntryString(LogEntryProto logEntry) {
     return LogProtoUtils.toLogEntryString(logEntry, stateMachine::toStateMachineLogEntryString);
   }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1401