### PR TITLE
RATIS-1404. Copy .asf.yaml to asf-site branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+github:
+  description: "Open source Java implementation for Raft consensus protocol."
+  homepage: https://ratis.apache.org/
+  labels:
+    - raft
+    - consensus-protocol
+    - consensus
+    - java
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false
+
+notifications:
+  commits:      commits@ratis.apache.org
+  issues:       issues@ratis.apache.org
+  pullrequests: issues@ratis.apache.org
+  jira_options: link label worklog
+
+publish:
+  whoami:  asf-site


### PR DESCRIPTION
## What changes were proposed in this pull request?

Copy `.asf.yaml` file to the `asf-site` branch.  Based on the [doc](https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features#Git.asf.yamlfeatures-Publishingabranchtoyourprojectwebsite) this file needs to be present in the branch being published.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1404

## How was this patch tested?

Not tested, but hopefully we'll finally see the site being updated.