### PR TITLE
RATIS-1398. Wrong link for KEYS file.

### DIFF
--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -72,9 +72,7 @@ The binaries are also uploaded to the maven central for convenience. (See the ge
 site</a>.</li>
 <li>Download the signature file apache-ratis-X.Y.Z-src.tar.gz.asc from
 <a href="https://dist.apache.org/repos/dist/release/ratis/">Apache</a>.</li>
-<li>Download the <a href="https://dist.apache.org/repos/dist/release/ratis/KEYS">Ratis
-KEYS</a>
-file.</li>
+<li>Download the <a href="https://downloads.apache.org/ratis/KEYS">Ratis KEYS</a> file.</li>
 <li>gpg --import KEYS</li>
 <li>gpg --verify apache-ratis-X.Y.Z-src.tar.gz.asc</li>
 </ol>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1398