### PR TITLE
Integrate ratis-shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 target
 build
 patchprocess
+**/logs

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
     <module>ratis-metrics</module>
     <module>ratis-tools</module>
     <module>ratis-assembly</module>
+    <module>ratis-shell</module>
   </modules>
 
   <pluginRepositories>
@@ -308,6 +309,11 @@
         <version>${project.version}</version>
         <type>test-jar</type>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <artifactId>ratis-shell</artifactId>
+        <groupId>org.apache.ratis</groupId>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <artifactId>ratis-grpc</artifactId>

--- a/ratis-assembly/pom.xml
+++ b/ratis-assembly/pom.xml
@@ -127,6 +127,7 @@
             <descriptor>src/main/assembly/src.xml</descriptor>
             <descriptor>src/main/assembly/bin.xml</descriptor>
             <descriptor>src/main/assembly/examples-bin.xml</descriptor>
+            <descriptor>src/main/assembly/ratis-shell.xml</descriptor>
           </descriptors>
         </configuration>
       </plugin>
@@ -285,6 +286,10 @@
     <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-tools</artifactId>
+    </dependency>
+    <dependency>
+      <artifactId>ratis-shell</artifactId>
+      <groupId>org.apache.ratis</groupId>
     </dependency>
   </dependencies>
 

--- a/ratis-assembly/src/main/assembly/ratis-shell.xml
+++ b/ratis-assembly/src/main/assembly/ratis-shell.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+  <!--
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements.  See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership.  The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License.  You may obtain a copy of the License at
+   *
+   *     http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+  -->
+  <id>ratis-shell</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/../ratis-shell/target/</directory>
+      <outputDirectory>lib/ratis-shell</outputDirectory>
+      <fileMode>755</fileMode>
+      <includes>
+        <include>ratis-shell-*-jar-with-dependencies.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/..</directory>
+      <outputDirectory>.</outputDirectory>
+      <includes>
+        <include>DISCLAIMER</include>
+      </includes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/maven-shared-archive-resources/META-INF/</directory>
+      <outputDirectory>.</outputDirectory>
+      <includes>
+        <include>LICENSE</include>
+        <include>NOTICE</include>
+      </includes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../ratis-shell/src/main/bin</directory>
+      <outputDirectory>bin</outputDirectory>
+      <fileMode>755</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../ratis-shell/src/main/libexec</directory>
+      <outputDirectory>libexec</outputDirectory>
+      <fileMode>0644</fileMode>
+      <directoryMode>0755</directoryMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../ratis-shell/src/main/conf</directory>
+      <outputDirectory>conf</outputDirectory>
+      <fileMode>644</fileMode>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/ratis-shell/pom.xml
+++ b/ratis-shell/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>ratis</artifactId>
+    <groupId>org.apache.ratis</groupId>
+    <version>2.2.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>ratis-shell</artifactId>
+  <name>Apache Ratis Shell</name>
+
+  <properties>
+    <guava.version>29.0-jre</guava.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>jsr305</artifactId>
+          <groupId>com.google.code.findbugs</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <artifactId>ratis-client</artifactId>
+      <groupId>org.apache.ratis</groupId>
+    </dependency>
+    <dependency>
+      <artifactId>ratis-grpc</artifactId>
+      <groupId>org.apache.ratis</groupId>
+    </dependency>
+    <dependency>
+      <artifactId>ratis-server-api</artifactId>
+      <groupId>org.apache.ratis</groupId>
+    </dependency>
+    <dependency>
+      <artifactId>ratis-metrics</artifactId>
+      <groupId>org.apache.ratis</groupId>
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.12</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
+
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>LICENSE</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Main-Class>org.apache.ratis.ratisshell.cli.sh.RatisShell</Main-Class>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ratis-shell/src/main/bin/ratis
+++ b/ratis-shell/src/main/bin/ratis
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function printUsage {
+  echo "Usage: ratis COMMAND [GENERIC_COMMAND_OPTIONS] [COMMAND_ARGS]"
+  echo
+  echo "COMMAND is one of:"
+  echo -e "  sh    \t Command line tool for ratis"
+  echo
+  echo "GENERIC_COMMAND_OPTIONS supports:"
+  echo -e "  -D<property=value>\t Use a value for a given ratis-shell property"
+  echo
+  echo "Commands print help when invoked without parameters."
+}
+
+function runJavaClass {
+  CLASS_ARGS=()
+  for arg in "$@"; do
+      case "${arg}" in
+          -D* | -X* | -agentlib* | -javaagent*)
+              RATIS_SHELL_JAVA_OPTS+=" ${arg}" ;;
+          *)
+              CLASS_ARGS+=("${arg}")
+      esac
+  done
+  "${JAVA}" -cp ${CLASSPATH} ${RATIS_SHELL_JAVA_OPTS} ${CLASS} ${PARAMETER} "${CLASS_ARGS[@]}"
+}
+
+function main {
+  LAUNCHER=
+  # If debugging is enabled propagate that through to sub-shells
+  if [[ $- == *x* ]]; then
+    LAUNCHER="bash -x"
+  fi
+  BIN=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )"; pwd)
+
+  if [[ $# == 0 ]]; then
+    printUsage
+    exit 1
+  fi
+
+  COMMAND=$1
+  shift
+
+  DEFAULT_LIBEXEC_DIR="${BIN}"/../libexec
+  RATIS_SHELL_LIBEXEC_DIR=${RATIS_SHELL_LIBEXEC_DIR:-$DEFAULT_LIBEXEC_DIR}
+  . ${RATIS_SHELL_LIBEXEC_DIR}/ratis-shell-config.sh
+
+  PARAMETER=""
+
+  case ${COMMAND} in
+  "sh")
+    CLASS="org.apache.ratis.ratisshell.cli.sh.RatisShell"
+    CLASSPATH=${RATIS_SHELL_CLIENT_CLASSPATH}
+    runJavaClass "$@"
+  ;;
+  *)
+    echo "Unsupported command ${COMMAND}" >&2
+    printUsage
+    exit 1
+  ;;
+  esac
+}
+
+main "$@"

--- a/ratis-shell/src/main/conf/log4j.properties
+++ b/ratis-shell/src/main/conf/log4j.properties
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These properties may be overridden by system properties. log4j gives system properties
+# a higher precedence than locally defined variables.
+log4j.rootLogger=INFO, SHELL_LOGGER
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M) - %m%n
+
+#SHELL Logger
+log4j.appender.SHELL_LOGGER=org.apache.log4j.RollingFileAppender
+log4j.appender.SHELL_LOGGER.File=${ratis.shell.logs.dir}/ratis-shell.log
+log4j.appender.SHELL_LOGGER.MaxFileSize=100MB
+log4j.appender.SHELL_LOGGER.MaxBackupIndex=10
+log4j.appender.SHELL_LOGGER.layout=org.apache.log4j.PatternLayout
+log4j.appender.SHELL_LOGGER.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M) - %m%n

--- a/ratis-shell/src/main/conf/ratis-shell-site.properties.template
+++ b/ratis-shell/src/main/conf/ratis-shell-site.properties.template
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ratis.shell.alluxio-master.peers=localhost:19200,localhost:19201,localhost:19202
+ratis.shell.alluxio-jobmaster.peers=localhost:20003,localhost:20013,localhost:20023
+ratis.shell.ozone-om.peers=localhost:9872,localhost:19872,localhost:29872
+ratis.shell.ozone-scm.peers=localhost:9894,localhost:19894,localhost:29894

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/Constants.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/Constants.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell;
+
+/**
+ * System wide constants.
+ */
+public final class Constants {
+
+  public static final String SITE_PROPERTIES = "ratis-shell-site.properties";
+
+  private Constants() {} // prevent instantiation
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/DefaultSupplier.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/DefaultSupplier.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell;
+
+import java.util.function.Supplier;
+
+/**
+ * Supplier for a configuration property default.
+ */
+public class DefaultSupplier implements Supplier<Object> {
+  private final Supplier<Object> mSupplier;
+  private final String mDescription;
+
+  /**
+   * @param supplier the value
+   * @param description a description of the default value
+   */
+  public DefaultSupplier(Supplier<Object> supplier, String description) {
+    mSupplier = supplier;
+    mDescription = description;
+  }
+
+  @Override
+  public Object get() {
+    return mSupplier.get();
+  }
+
+  /**
+   * @return a description of how the default value is determined
+   */
+  public String getDescription() {
+    return mDescription;
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/RetryUtil.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/RetryUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Retry related utilities function.
+ */
+public final class RetryUtil {
+
+  /**
+   * Execute a given function with input parameter from member of list.
+   *
+   * @param list the input parameters
+   * @param function the function to be executed
+   * @param <T> parameter type
+   * @param <K> return value type
+   * @return the function return value
+   */
+  public static <T, K> K run(List<T> list, Function<T, K> function) {
+    for (T t : list) {
+      try {
+        K ret = function.apply(t);
+        if (ret != null) {
+          return ret;
+        }
+      } catch (Throwable e) {
+        e.printStackTrace();
+      }
+    }
+    return null;
+  }
+
+  private RetryUtil() {} // prevent instantiation
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/AbstractShell.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/AbstractShell.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.cli;
+
+import com.google.common.io.Closer;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * Abstract class for handling command line inputs.
+ */
+public abstract class AbstractShell implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractShell.class);
+
+  private Map<String, Command> mCommands;
+  private Closer closer;
+
+  /**
+   * Creates a new instance of {@link AbstractShell}.
+   */
+  public AbstractShell() {
+    closer = Closer.create();
+    mCommands = loadCommands();
+    // Register all loaded commands under closer.
+    mCommands.values().stream().forEach((cmd) -> closer.register(cmd));
+  }
+
+  /**
+   * Handles the specified shell command request, displaying usage if the command format is invalid.
+   *
+   * @param argv [] Array of arguments given by the user's input from the terminal
+   * @return 0 if command is successful, -1 if an error occurred
+   */
+  public int run(String... argv) {
+    if (argv.length == 0) {
+      printUsage();
+      return -1;
+    }
+
+    // Sanity check on the number of arguments
+    String cmd = argv[0];
+    Command command = mCommands.get(cmd);
+
+    if (command == null) {
+      // Unknown command (we didn't find the cmd in our dict)
+      System.err.println(String.format("%s is an unknown command.", cmd));
+      printUsage();
+      return -1;
+    }
+
+    // Find the inner-most command and its argument line.
+    CommandLine cmdline;
+    try {
+      String[] currArgs = Arrays.copyOf(argv, argv.length);
+      while (command.hasSubCommand()) {
+        if (currArgs.length < 2) {
+          throw new IllegalArgumentException("No sub-command is specified");
+        }
+        if (!command.getSubCommands().containsKey(currArgs[1])) {
+          throw new IllegalArgumentException("Unknown sub-command: " + currArgs[1]);
+        }
+        command = command.getSubCommands().get(currArgs[1]);
+        if (currArgs.length >= 2) {
+          currArgs = Arrays.copyOfRange(currArgs, 1, currArgs.length);
+        }
+      }
+      currArgs = Arrays.copyOfRange(currArgs, 1, currArgs.length);
+
+      cmdline = command.parseAndValidateArgs(currArgs);
+    } catch (IllegalArgumentException e) {
+      // It outputs a prompt message when passing wrong args to CLI
+      System.out.println(e.getMessage());
+      System.out.println("Usage: " + command.getUsage());
+      System.out.println(command.getDescription());
+      LOG.error("Invalid arguments for command {}:", command.getCommandName(), e);
+      return -1;
+    }
+
+    // Handle the command
+    try {
+      return command.run(cmdline);
+    } catch (Exception e) {
+      System.out.println(e.getMessage());
+      LOG.error("Error running " + StringUtils.join(argv, " "), e);
+      return -1;
+    }
+  }
+
+  /**
+   * @return all commands provided by this shell
+   */
+  public Collection<Command> getCommands() {
+    return mCommands.values();
+  }
+
+  @Override
+  public void close() throws IOException {
+    closer.close();
+  }
+
+  /**
+   * @return name of the shell
+   */
+  protected abstract String getShellName();
+
+  /**
+   * Map structure: Command name => {@link Command} instance.
+   *
+   * @return a set of commands which can be executed under this shell
+   */
+  protected abstract Map<String, Command> loadCommands();
+
+  protected Closer getCloser() {
+    return closer;
+  }
+
+  /**
+   * Prints usage for all commands.
+   */
+  protected void printUsage() {
+    System.out.println("Usage: ratis " + getShellName() + " [generic options]");
+    SortedSet<String> sortedCmds = new TreeSet<>(mCommands.keySet());
+    for (String cmd : sortedCmds) {
+      System.out.format("%-60s%n", "\t [" + mCommands.get(cmd).getUsage() + "]");
+    }
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/Command.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/Command.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An interface for all the commands that can be run from a shell.
+ */
+public interface Command extends Closeable {
+
+  /**
+   * Gets the command name as input from the shell.
+   *
+   * @return the command name
+   */
+  String getCommandName();
+
+  /**
+   * @return the supported {@link Options} of the command
+   */
+  default Options getOptions() {
+    return new Options();
+  }
+
+  /**
+   * If a command has sub-commands, the first argument should be the sub-command's name,
+   * all arguments and options will be parsed for the sub-command.
+   *
+   * @return whether this command has sub-commands
+   */
+  default boolean hasSubCommand() {
+    return false;
+  }
+
+  /**
+   * @return a map from sub-command names to sub-command instances
+   */
+  default Map<String, Command> getSubCommands() {
+    return new HashMap<>();
+  }
+
+  /**
+   * Parses and validates the arguments.
+   *
+   * @param args the arguments for the command, excluding the command name
+   * @return the parsed command line object
+   * @throws IllegalArgumentException when arguments are not valid
+   */
+  default CommandLine parseAndValidateArgs(String... args) throws IllegalArgumentException {
+    CommandLine cmdline;
+    Options opts = getOptions();
+    CommandLineParser parser = new DefaultParser();
+    try {
+      cmdline = parser.parse(opts, args);
+    } catch (ParseException e) {
+      throw new IllegalArgumentException(
+          String.format("Failed to parse args for %s: %s", getCommandName(), e.getMessage()), e);
+    }
+    validateArgs(cmdline);
+    return cmdline;
+  }
+
+  /**
+   * Checks if the arguments are valid or throw InvalidArgumentException.
+   *
+   * @param cl the parsed command line for the arguments
+   * @throws IllegalArgumentException when arguments are not valid
+   */
+  default void validateArgs(CommandLine cl) throws IllegalArgumentException {}
+
+  /**
+   * Runs the command.
+   *
+   * @param cl the parsed command line for the arguments
+   * @return the result of running the command
+   */
+  default int run(CommandLine cl) throws IOException {
+    return 0;
+  }
+
+  /**
+   * @return the usage information of the command
+   */
+  String getUsage();
+
+  /**
+   * @return the description information of the command
+   */
+  String getDescription();
+
+  /**
+   * Used to close resources created by commands.
+   *
+   * @throws IOException if closing resources fails
+   */
+  default void close() throws IOException {}
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/RaftUtils.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/RaftUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.cli;
+
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.client.RaftClientConfigKeys;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.retry.ExponentialBackoffRetry;
+import org.apache.ratis.util.TimeDuration;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Helper class for raft operations.
+ */
+public final class RaftUtils {
+
+  private RaftUtils() {
+    // prevent instantiation
+  }
+
+  /**
+   * Gets the raft peer id.
+   *
+   * @param address the address of the server
+   * @return the raft peer id
+   */
+  public static RaftPeerId getPeerId(InetSocketAddress address) {
+    return getPeerId(address.getHostString(), address.getPort());
+  }
+
+  /**
+   * Gets the raft peer id.
+   *
+   * @param host the hostname of the server
+   * @param port the port of the server
+   * @return the raft peer id
+   */
+  public static RaftPeerId getPeerId(String host, int port) {
+    return RaftPeerId.getRaftPeerId(host + "_" + port);
+  }
+
+  /**
+   * Create a raft client to communicate to ratis server.
+   * @param raftGroup the raft group
+   * @return return a raft client
+   */
+  public static RaftClient createClient(
+      RaftGroup raftGroup) {
+    RaftProperties properties = new RaftProperties();
+    Parameters parameters = new Parameters();
+    RaftClientConfigKeys.Rpc.setRequestTimeout(properties,
+        TimeDuration.valueOf(15, TimeUnit.SECONDS));
+    ExponentialBackoffRetry retryPolicy = ExponentialBackoffRetry.newBuilder()
+        .setBaseSleepTime(TimeDuration.valueOf(1000, TimeUnit.MILLISECONDS))
+        .setMaxAttempts(10)
+        .setMaxSleepTime(
+            TimeDuration.valueOf(100_000, TimeUnit.MILLISECONDS))
+        .build();
+    return RaftClient.newBuilder()
+        .setRaftGroup(raftGroup)
+        .setClientId(ClientId.randomId())
+        .setLeaderId(null)
+        .setProperties(properties)
+        .setParameters(parameters)
+        .setRetryPolicy(retryPolicy)
+        .build();
+  }
+
+  /**
+   * @param reply from the ratis operation
+   * @param msgToUser message to user
+   * @param printStream the print stream
+   * @throws IOException
+   */
+  public static void processReply(RaftClientReply reply, String msgToUser,
+      PrintStream printStream) throws IOException {
+    if (!reply.isSuccess()) {
+      IOException ioe = reply.getException() != null
+          ? reply.getException()
+          : new IOException(String.format("reply <%s> failed", reply));
+      printStream.printf("%s. Error: %s%n", msgToUser, ioe);
+      throw new IOException(msgToUser);
+    }
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/sh/RatisShell.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/sh/RatisShell.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.cli.sh;
+
+import org.apache.ratis.ratisshell.cli.AbstractShell;
+import org.apache.ratis.ratisshell.cli.Command;
+import org.apache.ratis.ratisshell.cli.sh.command.Context;
+import org.apache.ratis.ratisshell.util.CommonUtils;
+
+import org.reflections.Reflections;
+
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Shell for manage ratis group.
+ */
+public class RatisShell extends AbstractShell {
+
+  /**
+   * Manage ratis shell command.
+   *
+   * @param args array of arguments given by the user's input from the terminal
+   */
+  public static void main(String[] args) {
+    RatisShell extensionShell = new RatisShell();
+    System.exit(extensionShell.run(args));
+  }
+
+  @Override
+  protected String getShellName() {
+    return "sh";
+  }
+
+  @Override
+  protected Map<String, Command> loadCommands() {
+    Context adminContext = new Context(System.out);
+    return loadCommands(RatisShell.class.getPackage().getName(),
+        new Class[] {Context.class},
+        new Object[] {getCloser().register(adminContext)});
+  }
+
+  /**
+   * Get instances of all subclasses of {@link Command} in a sub-package called "command" the given
+   * package.
+   *
+   * @param pkgName package prefix to look in
+   * @param classArgs type of args to instantiate the class
+   * @param objectArgs args to instantiate the class
+   * @return a mapping from command name to command instance
+   */
+  public static Map<String, Command> loadCommands(String pkgName, Class[] classArgs,
+      Object[] objectArgs) {
+    Map<String, Command> commandsMap = new HashMap<>();
+    Reflections reflections = new Reflections(pkgName);
+    for (Class<? extends Command> cls : reflections.getSubTypesOf(Command.class)) {
+      // Add commands from <pkgName>.command.*
+      if (cls.getPackage().getName().equals(pkgName + ".command")
+          && !Modifier.isAbstract(cls.getModifiers())) {
+        // Only instantiate a concrete class
+        Command cmd = CommonUtils.createNewClassInstance(cls, classArgs, objectArgs);
+        commandsMap.put(cmd.getCommandName(), cmd);
+      }
+    }
+    return commandsMap;
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/sh/command/AbstractRatisCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/sh/command/AbstractRatisCommand.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.cli.sh.command;
+
+import org.apache.ratis.ratisshell.RetryUtil;
+import org.apache.ratis.ratisshell.cli.Command;
+import org.apache.ratis.ratisshell.cli.RaftUtils;
+import org.apache.ratis.ratisshell.conf.InstancedConfiguration;
+import org.apache.ratis.ratisshell.conf.PropertyKey;
+import org.apache.ratis.ratisshell.conf.RatisShellConfiguration;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.proto.RaftProtos.FollowerInfoProto;
+import org.apache.ratis.proto.RaftProtos.RaftPeerProto;
+import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
+import org.apache.ratis.proto.RaftProtos.RoleInfoProto;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeer;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * The base class for all the ratis shell {@link Command} classes.
+ */
+public abstract class AbstractRatisCommand implements Command {
+  public static final String SERVICE_ID_OPTION_NAME = "serviceid";
+  public static final String PEER_OPTION_NAME = "peers";
+  public static final String GROUPID_OPTION_NAME = "groupid";
+  public static final RaftGroupId DEFAULT_RAFT_GROUP_ID
+      = RaftGroupId.valueOf(
+      UUID.fromString("1-1-1-1-1"));
+  private final PrintStream printStream;
+  private RaftGroup raftGroup;
+
+  protected AbstractRatisCommand(Context context) {
+    printStream = context.getPrintStream();
+  }
+
+  @Override
+  public int run(CommandLine cl) throws IOException {
+    RatisShellConfiguration conf = InstancedConfiguration.defaults();
+    List<InetSocketAddress> addresses = new ArrayList<>();
+    String peersStr = "";
+    if (cl.hasOption(PEER_OPTION_NAME)) {
+      peersStr = cl.getOptionValue(PEER_OPTION_NAME);
+    } else {
+      if (cl.hasOption(SERVICE_ID_OPTION_NAME)) {
+        peersStr = conf.get(
+            PropertyKey.Template.RATIS_SHELL_PEER_IDS.format(
+                cl.getOptionValue(SERVICE_ID_OPTION_NAME)));
+      }
+    }
+    String[] peersArray = peersStr.split(",");
+    for (int i = 0; i < peersArray.length; i++) {
+      String[] hostPortPair = peersArray[i].split(":");
+      InetSocketAddress addr =
+          new InetSocketAddress(hostPortPair[0], Integer.parseInt(hostPortPair[1]));
+      addresses.add(addr);
+    }
+
+    RaftGroupId raftGroupIdFromConfig = DEFAULT_RAFT_GROUP_ID;
+    if (cl.hasOption(GROUPID_OPTION_NAME)) {
+      raftGroupIdFromConfig = RaftGroupId.valueOf(
+          UUID.fromString(cl.getOptionValue(GROUPID_OPTION_NAME)));
+    } else {
+      if (cl.hasOption(SERVICE_ID_OPTION_NAME)) {
+        PropertyKey groupIdKey =
+            PropertyKey.Template.RATIS_SHELL_GROUP_ID.format(
+                cl.getOptionValue(SERVICE_ID_OPTION_NAME));
+        try {
+          raftGroupIdFromConfig =
+              RaftGroupId.valueOf(UUID.fromString(conf.get(groupIdKey)));
+        } catch (IllegalArgumentException e) {
+          // do nothing
+        }
+      }
+    }
+
+    List<RaftPeer> peers = addresses.stream()
+        .map(addr -> RaftPeer.newBuilder()
+            .setId(RaftUtils.getPeerId(addr))
+            .setAddress(addr)
+            .build()
+        ).collect(Collectors.toList());
+    raftGroup = RaftGroup.valueOf(raftGroupIdFromConfig, peers);
+    try (final RaftClient client = RaftUtils.createClient(raftGroup)) {
+      RaftGroupId remoteGroupId;
+      List<RaftGroupId> groupIds;
+      groupIds = RetryUtil.run(peers,
+          p -> {
+            try {
+              return client.getGroupManagementApi((p.getId())).list().getGroupIds();
+            } catch (IOException e) {
+              e.printStackTrace();
+              return null;
+            }
+          }
+      );
+
+      if (groupIds.size() == 1) {
+        remoteGroupId = groupIds.get(0);
+      } else {
+        final UUID raftGroupUuid = raftGroupIdFromConfig.getUuid();
+        Optional<RaftGroupId> raftGroupId =
+            groupIds.stream().filter(r -> raftGroupUuid.equals(r.getUuid()))
+                .findFirst();
+        if (!raftGroupId.isPresent()) {
+          printStream.println(
+              "there are more than one group, you should specific one."
+                  + groupIds);
+          return -1;
+        } else {
+          remoteGroupId = raftGroupId.get();
+        }
+      }
+      // TODO(maobaolong): failover to other peer if communicate failure
+      raftGroup = RetryUtil.run(peers,
+          p -> {
+            try {
+              return client.getGroupManagementApi((p.getId()))
+                  .info(remoteGroupId).getGroup();
+            } catch (IOException e) {
+              e.printStackTrace();
+              return null;
+            }
+          }
+      );
+    }
+    return 0;
+  }
+
+  @Override
+  public void validateArgs(CommandLine cl) throws IllegalArgumentException {
+    if (!cl.hasOption(SERVICE_ID_OPTION_NAME)
+        && !cl.hasOption(PEER_OPTION_NAME)) {
+      throw new IllegalArgumentException(String.format(
+          "should provide at least one of [%s] and [%s]",
+          SERVICE_ID_OPTION_NAME, PEER_OPTION_NAME));
+    }
+  }
+
+  @Override
+  public Options getOptions() {
+    return new Options()
+            .addOption(PEER_OPTION_NAME, true, "Peer addresses seperated by comma")
+            .addOption(GROUPID_OPTION_NAME, true, "Raft group id")
+            .addOption(SERVICE_ID_OPTION_NAME, true, "Service id");
+  }
+
+  protected PrintStream getPrintStream() {
+    return printStream;
+  }
+
+  protected RaftGroup getRaftGroup() {
+    return raftGroup;
+  }
+
+  /**
+   * Get the leader id.
+   *
+   * @param roleInfo the role info
+   * @return the leader id
+   */
+  protected RaftPeerProto getLeader(RoleInfoProto roleInfo) {
+    if (roleInfo == null) {
+      return null;
+    }
+    if (roleInfo.getRole() == RaftPeerRole.LEADER) {
+      return roleInfo.getSelf();
+    }
+    FollowerInfoProto followerInfo = roleInfo.getFollowerInfo();
+    if (followerInfo == null) {
+      return null;
+    }
+    return followerInfo.getLeaderInfo().getId();
+  }
+
+  protected void processReply(RaftClientReply reply, String msg)
+      throws IOException {
+    RaftUtils.processReply(reply, msg, printStream);
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/sh/command/Context.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/sh/command/Context.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.cli.sh.command;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.Closer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.PrintStream;
+
+/**
+ * A context for ratis-shell.
+ */
+public final class Context implements Closeable {
+  private final PrintStream mPrintStream;
+  private final Closer mCloser;
+
+  /**
+   * Build a context.
+   * @param printStream the print stream
+   */
+  public Context(PrintStream printStream) {
+    mCloser = Closer.create();
+    mCloser.register(
+        mPrintStream = Preconditions.checkNotNull(printStream, "printStream"));
+  }
+
+  /**
+   * @return the print stream to write to
+   */
+  public PrintStream getPrintStream() {
+    return mPrintStream;
+  }
+
+  @Override
+  public void close() throws IOException {
+    mCloser.close();
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/sh/command/ElectCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/sh/command/ElectCommand.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.cli.sh.command;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.ratis.ratisshell.cli.RaftUtils;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Command for transferring the leadership to another peer.
+ */
+public class ElectCommand extends AbstractRatisCommand {
+  public static final String ADDRESS_OPTION_NAME = "address";
+
+  /**
+   * @param context command context
+   */
+  public ElectCommand(Context context) {
+    super(context);
+  }
+
+  @Override
+  public String getCommandName() {
+    return "elect";
+  }
+
+  @Override
+  public int run(CommandLine cl) throws IOException {
+    super.run(cl);
+
+    String strAddr = cl.getOptionValue(ADDRESS_OPTION_NAME);
+
+    RaftPeerId newLeaderId = null;
+    // update priorities to enable transfer
+    List<RaftPeer> peersWithNewPriorities = new ArrayList<>();
+    for (RaftPeer peer : getRaftGroup().getPeers()) {
+      peersWithNewPriorities.add(
+          RaftPeer.newBuilder(peer)
+              .setPriority(peer.getAddress().equals(strAddr) ? 2 : 1)
+              .build()
+      );
+      if (peer.getAddress().equals(strAddr)) {
+        newLeaderId = peer.getId();
+      }
+    }
+    if (newLeaderId == null) {
+      return -2;
+    }
+    try (RaftClient client = RaftUtils.createClient(getRaftGroup())) {
+      String stringPeers = "[" + peersWithNewPriorities.stream().map(RaftPeer::toString)
+          .collect(Collectors.joining(", ")) + "]";
+      getPrintStream().printf(
+          "Applying new peer state before transferring leadership: %n%s%n", stringPeers);
+      RaftClientReply setConfigurationReply =
+          client.admin().setConfiguration(peersWithNewPriorities);
+      processReply(setConfigurationReply,
+          "failed to set priorities before initiating election");
+      // transfer leadership
+      getPrintStream().printf(
+          "Transferring leadership to server with address <%s> %n", strAddr);
+      try {
+        Thread.sleep(3_000);
+        RaftClientReply transferLeadershipReply =
+            client.admin().transferLeadership(newLeaderId, 60_000);
+        processReply(transferLeadershipReply, "election failed");
+      } catch (Throwable t) {
+        getPrintStream().printf("caught an error when executing transfer: %s%n", t.getMessage());
+        return -1;
+      }
+      getPrintStream().println("Transferring leadership initiated");
+    }
+    return 0;
+  }
+
+  @Override
+  public void validateArgs(CommandLine cl) throws IllegalArgumentException {
+    super.validateArgs(cl);
+    if (!cl.hasOption(ADDRESS_OPTION_NAME)) {
+      throw new IllegalArgumentException(String.format("[%s]", ADDRESS_OPTION_NAME));
+    }
+  }
+
+  @Override
+  public String getUsage() {
+    return String.format("%s -%s <HOSTNAME:PORT>"
+        + " [-%s PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT]"
+        + " [-%s RAFT_GROUP_ID]"
+        + " [-%s SERVICE_ID]",
+        getCommandName(), ADDRESS_OPTION_NAME, PEER_OPTION_NAME,
+        GROUPID_OPTION_NAME, SERVICE_ID_OPTION_NAME);
+  }
+
+  @Override
+  public String getDescription() {
+    return description();
+  }
+
+  @Override
+  public Options getOptions() {
+    return super.getOptions()
+        .addOption(ADDRESS_OPTION_NAME, true,
+            "Server address that will take over as leader");
+  }
+
+  /**
+   * @return command's description
+   */
+  @VisibleForTesting
+  public static String description() {
+    return "Transfers leadership to the <hostname>:<port>";
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/sh/command/InfoCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/sh/command/InfoCommand.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.cli.sh.command;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.ratis.ratisshell.cli.RaftUtils;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.protocol.GroupInfoReply;
+
+import java.io.IOException;
+
+/**
+ * Command for querying ratis group information.
+ */
+public class InfoCommand extends AbstractRatisCommand {
+
+  /**
+   * @param context command context
+   */
+  public InfoCommand(Context context) {
+    super(context);
+  }
+
+  @Override
+  public String getCommandName() {
+    return "info";
+  }
+
+  @Override
+  public int run(CommandLine cl) throws IOException {
+    super.run(cl);
+    getPrintStream().println("group id: " + getRaftGroup().getGroupId().getUuid());
+    try (RaftClient client = RaftUtils.createClient(getRaftGroup())) {
+      GroupInfoReply reply =
+          client.getGroupManagementApi(
+              getRaftGroup().getPeers().stream()
+                  .findFirst()
+                  .get()
+                  .getId())
+              .info(getRaftGroup().getGroupId());
+      processReply(reply,
+          "failed to get info");
+      RaftProtos.RaftPeerProto leader =
+          getLeader(reply.getRoleInfoProto());
+      getPrintStream().printf("leader info: %s(%s)%n%n",
+          leader.getId().toStringUtf8(), leader.getAddress());
+      getPrintStream().println(reply.getCommitInfos());
+    }
+    return 0;
+  }
+
+  @Override
+  public String getUsage() {
+    return String.format("%s"
+        + " [-%s PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT]"
+        + " [-%s RAFT_GROUP_ID]"
+        + " [-%s SERVICE_ID]",
+        getCommandName(), PEER_OPTION_NAME, GROUPID_OPTION_NAME, SERVICE_ID_OPTION_NAME);
+  }
+
+  @Override
+  public String getDescription() {
+    return description();
+  }
+
+  @Override
+  public Options getOptions() {
+    return super.getOptions();
+  }
+
+  /**
+   * @return command's description
+   */
+  @VisibleForTesting
+  public static String description() {
+    return "Display the information of a specific raft group";
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/sh/command/SetPriorityCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/cli/sh/command/SetPriorityCommand.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.cli.sh.command;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.ratis.ratisshell.cli.RaftUtils;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftPeer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *  Command for setting priority of the specific ratis server.
+ */
+public class SetPriorityCommand extends AbstractRatisCommand {
+  public static final String PEER_WITH_NEW_PRIORITY = "addressPriority";
+
+  /**
+   * @param context command context
+   */
+  public SetPriorityCommand(Context context) {
+    super(context);
+  }
+
+  @Override
+  public String getCommandName() {
+    return "setPriority";
+  }
+
+  @Override
+  public int run(CommandLine cl) throws IOException {
+    super.run(cl);
+    String[] peersNewPriority = cl.getOptionValues(PEER_WITH_NEW_PRIORITY);
+    if (peersNewPriority.length < 1) {
+      return -2;
+    }
+    Map<String, Integer> addressPriorityMap = new HashMap<>();
+    for (String peer : peersNewPriority) {
+      String[] str = peer.split(",");
+      addressPriorityMap.put(str[0], Integer.parseInt(str[1]));
+    }
+
+    try (RaftClient client = RaftUtils.createClient(getRaftGroup())) {
+      List<RaftPeer> peers = new ArrayList<>();
+      for (RaftPeer peer : getRaftGroup().getPeers()) {
+        if (!addressPriorityMap.containsKey(peer.getAddress())) {
+          peers.add(RaftPeer.newBuilder(peer).build());
+        } else {
+          peers.add(
+                  RaftPeer.newBuilder(peer)
+                          .setPriority(addressPriorityMap.get(peer.getAddress()))
+                          .build()
+          );
+        }
+      }
+      RaftClientReply reply = client.admin().setConfiguration(peers);
+      processReply(reply, "failed to set master priorities");
+    }
+    return 0;
+  }
+
+  @Override
+  public String getUsage() {
+    return String.format("%s"
+                    + " [-%s PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT]"
+                    + " [-%s RAFT_GROUP_ID]"
+                    + " [-%s SERVICE_ID]"
+                    + " [-%s PEER_HOST:PEER_PORT,PRIORITY]",
+            getCommandName(), PEER_OPTION_NAME, GROUPID_OPTION_NAME,
+            SERVICE_ID_OPTION_NAME, PEER_WITH_NEW_PRIORITY);
+  }
+
+  @Override
+  public String getDescription() {
+    return description();
+  }
+
+  @Override
+  public Options getOptions() {
+    return super.getOptions().addOption(PEER_WITH_NEW_PRIORITY, true,
+            "Peers information with priority");
+  }
+
+  /**
+   * @return command's description
+   */
+  @VisibleForTesting
+  public static String description() {
+    return "Set priority to ratis peers";
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/conf/InstancedConfiguration.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/conf/InstancedConfiguration.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.conf;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import org.apache.ratis.ratisshell.util.ConfigurationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Ratis shell configuration.
+ */
+public class InstancedConfiguration implements RatisShellConfiguration {
+  private static final Logger LOG = LoggerFactory.getLogger(InstancedConfiguration.class);
+
+  /** Regex string to find "${key}" for variable substitution. */
+  private static final String REGEX_STRING = "(\\$\\{([^{}]*)\\})";
+  /** Regex to find ${key} for variable substitution. */
+  private static final Pattern CONF_REGEX = Pattern.compile(REGEX_STRING);
+  /** Source of the truth of all property values (default or customized). */
+  private RatisShellProperties properties;
+
+  /**
+   * Users should use this API to obtain a configuration for modification before passing to a
+   * FileSystem constructor. The default configuration contains all default configuration params
+   * and configuration properties modified in the ratis-shell-site.properties file.
+   *
+   * Example usage:
+   *
+   * InstancedConfiguration conf = InstancedConfiguration.defaults();
+   * conf.set(...);
+   * FileSystem fs = FileSystem.Factory.create(conf);
+   *
+   * WARNING: This API is unstable and may be changed in a future minor release.
+   *
+   * @return an instanced configuration preset with defaults
+   */
+  public static InstancedConfiguration defaults() {
+    return new InstancedConfiguration(ConfigurationUtils.defaults());
+  }
+
+  /**
+   * Creates a new instance of {@link InstancedConfiguration}.
+   *
+   * Application code should use {@link InstancedConfiguration#defaults}.
+   *
+   * @param properties properties underlying this configuration
+   */
+  public InstancedConfiguration(RatisShellProperties properties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Creates a new instance of {@link InstancedConfiguration}.
+   *
+   * Application code should use {@link InstancedConfiguration#defaults}.
+   *
+   * @param conf configuration to copy
+   */
+  public InstancedConfiguration(RatisShellConfiguration conf) {
+    properties = conf.copyProperties();
+  }
+
+  /**
+   * @return the properties backing this configuration
+   */
+  public RatisShellProperties copyProperties() {
+    return properties.copy();
+  }
+
+  @Override
+  public String get(PropertyKey key) {
+    String value = properties.get(key);
+    if (value == null) {
+      // if value or default value is not set in configuration for the given key
+      throw new RuntimeException("undefined " + key);
+    }
+    try {
+      value = lookup(value);
+    } catch (UnresolvablePropertyException e) {
+      throw new RuntimeException("Could not resolve key \""
+          + key.getName() + "\": " + e.getMessage(), e);
+    }
+    return value;
+  }
+
+  private boolean isResolvable(PropertyKey key) {
+    String val = properties.get(key);
+    try {
+      // Lookup to resolve any key before simply returning isSet. An exception will be thrown if
+      // the key can't be resolved or if a lower level value isn't set.
+      lookup(val);
+      return true;
+    } catch (UnresolvablePropertyException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public boolean isSet(PropertyKey key) {
+    return properties.isSet(key) && isResolvable(key);
+  }
+
+  @Override
+  public boolean isSetByUser(PropertyKey key) {
+    return properties.isSetByUser(key) && isResolvable(key);
+  }
+
+  /**
+   * Unsets the value for the appropriate key in the {@link java.util.Properties}.
+   * If the {@link PropertyKey} has a default value,
+   * it will still be considered set after executing this method.
+   *
+   * @param key the key to unset
+   */
+  public void unset(PropertyKey key) {
+    Preconditions.checkNotNull(key, "key");
+    properties.remove(key);
+  }
+
+  /**
+   * Merges map of properties into the current properties.
+   *
+   * @param props map of keys to values
+   */
+  public void merge(Map<?, ?> props) {
+    this.properties.merge(props);
+  }
+
+  @Override
+  public Set<PropertyKey> keySet() {
+    return properties.keySet();
+  }
+
+  @Override
+  public Set<PropertyKey> userKeySet() {
+    return properties.userKeySet();
+  }
+
+  @Override
+  public int getInt(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return Integer.parseInt(rawValue);
+    } catch (NumberFormatException e) {
+      throw new RuntimeException("key not integer " + rawValue);
+    }
+  }
+
+  @Override
+  public long getLong(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return Long.parseLong(rawValue);
+    } catch (NumberFormatException e) {
+      throw new RuntimeException("key not long " + rawValue);
+    }
+  }
+
+  @Override
+  public double getDouble(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return Double.parseDouble(rawValue);
+    } catch (NumberFormatException e) {
+      throw new RuntimeException("key not double " + rawValue);
+    }
+  }
+
+  @Override
+  public float getFloat(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      return Float.parseFloat(rawValue);
+    } catch (NumberFormatException e) {
+      throw new RuntimeException("key not float " + rawValue);
+    }
+  }
+
+  @Override
+  public boolean getBoolean(PropertyKey key) {
+    String rawValue = get(key);
+
+    if (rawValue.equalsIgnoreCase("true")) {
+      return true;
+    } else if (rawValue.equalsIgnoreCase("false")) {
+      return false;
+    } else {
+      throw new RuntimeException("key not boolean " + rawValue);
+    }
+  }
+
+  @Override
+  public List<String> getList(PropertyKey key, String delimiter) {
+    Preconditions.checkArgument(delimiter != null,
+        "Illegal separator for ratis-shell properties as list");
+    String rawValue = get(key);
+    return ConfigurationUtils.parseAsList(rawValue, delimiter);
+  }
+
+  @Override
+  public <T extends Enum<T>> T getEnum(PropertyKey key, Class<T> enumType) {
+    String rawValue = get(key).toUpperCase();
+    try {
+      return Enum.valueOf(enumType, rawValue);
+    } catch (IllegalArgumentException e) {
+      throw new RuntimeException("key not enum " + rawValue);
+    }
+  }
+
+  @Override
+  public <T> Class<T> getClass(PropertyKey key) {
+    String rawValue = get(key);
+
+    try {
+      @SuppressWarnings("unchecked")
+      Class<T> clazz = (Class<T>) Class.forName(rawValue);
+      return clazz;
+    } catch (Exception e) {
+      LOG.error("requested class could not be loaded: {}", rawValue, e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Map<String, String> getNestedProperties(PropertyKey prefixKey) {
+    Map<String, String> ret = Maps.newHashMap();
+    for (Map.Entry<PropertyKey, String> entry: properties.entrySet()) {
+      String key = entry.getKey().getName();
+      if (prefixKey.isNested(key)) {
+        String suffixKey = key.substring(prefixKey.length() + 1);
+        ret.put(suffixKey, entry.getValue());
+      }
+    }
+    return ret;
+  }
+
+  @Override
+  public void validate() {
+  }
+
+  /**
+   * Lookup key names to handle ${key} stuff.
+   *
+   * @param base the String to look for
+   * @return resolved String value
+   */
+  private String lookup(final String base) throws UnresolvablePropertyException {
+    return lookupRecursively(base, new HashSet<>());
+  }
+
+  /**
+   * Actual recursive lookup replacement.
+   *
+   * @param base the string to resolve
+   * @param seen strings already seen during this lookup, used to prevent unbound recursion
+   * @return the resolved string
+   */
+  private String lookupRecursively(String base, Set<String> seen)
+      throws UnresolvablePropertyException {
+    // check argument
+    if (base == null) {
+      throw new UnresolvablePropertyException("Can't resolve property with null value");
+    }
+
+    String resolved = base;
+    // Lets find pattern match to ${key}.
+    Matcher matcher = CONF_REGEX.matcher(base);
+    while (matcher.find()) {
+      String match = matcher.group(2).trim();
+      if (!seen.add(match)) {
+        throw new RuntimeException("KEY_CIRCULAR_DEPENDENCY " + match);
+      }
+      if (!PropertyKey.isValid(match)) {
+        throw new RuntimeException("INVALID_CONFIGURATION_KEY " + match);
+      }
+      String value = lookupRecursively(properties.get(PropertyKey.fromString(match)), seen);
+      seen.remove(match);
+      if (value == null) {
+        throw new UnresolvablePropertyException("UNDEFINED_CONFIGURATION_KEY");
+      }
+      resolved = resolved.replaceFirst(REGEX_STRING, Matcher.quoteReplacement(value));
+    }
+    return resolved;
+  }
+
+  private static class UnresolvablePropertyException extends Exception {
+
+    public UnresolvablePropertyException(String msg) {
+      super(msg);
+    }
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/conf/PropertyKey.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/conf/PropertyKey.java
@@ -1,0 +1,496 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.conf;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Sets;
+import org.apache.ratis.ratisshell.Constants;
+import org.apache.ratis.ratisshell.DefaultSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Configuration property keys. This class provides a set of pre-defined property keys.
+ */
+public final class PropertyKey implements Comparable<PropertyKey> {
+  private static final Logger LOG = LoggerFactory.getLogger(PropertyKey.class);
+
+  // The following two maps must be the first to initialize within this file.
+  /** A map from default property key's string name to the key. */
+  private static final Map<String, PropertyKey> DEFAULT_KEYS_MAP = new ConcurrentHashMap<>();
+  /** A cache storing result for template regexp matching results. */
+  private static final Cache<String, Boolean> REGEXP_CACHE = CacheBuilder.newBuilder()
+      .maximumSize(1024)
+      .build();
+
+  /**
+   * Builder to create {@link PropertyKey} instances. Note that, <code>Builder.build()</code> will
+   * throw exception if there is an existing property built with the same name.
+   */
+  public static final class Builder {
+    private DefaultSupplier mDefaultSupplier;
+    private Object mDefaultValue;
+    private String mDescription;
+    private String mName;
+
+    /**
+     * @param name name of the property
+     */
+    public Builder(String name) {
+      mName = name;
+    }
+
+    /**
+     * @param template template for the property name
+     * @param params parameters of the template
+     */
+    public Builder(Template template, Object... params) {
+      mName = String.format(template.mFormat, params);
+    }
+
+    /**
+     * @param name name for the property
+     * @return the updated builder instance
+     */
+    public Builder setName(String name) {
+      mName = name;
+      return this;
+    }
+
+    /**
+     * @param defaultSupplier supplier for the property's default value
+     * @return the updated builder instance
+     */
+    public Builder setDefaultSupplier(DefaultSupplier defaultSupplier) {
+      mDefaultSupplier = defaultSupplier;
+      return this;
+    }
+
+    /**
+     * @param supplier supplier for the property's default value
+     * @param description description of the default value
+     * @return the updated builder instance
+     */
+    public Builder setDefaultSupplier(Supplier<Object> supplier, String description) {
+      mDefaultSupplier = new DefaultSupplier(supplier, description);
+      return this;
+    }
+
+    /**
+     * @param defaultValue the property's default value
+     * @return the updated builder instance
+     */
+    public Builder setDefaultValue(Object defaultValue) {
+      mDefaultValue = defaultValue;
+      return this;
+    }
+
+    /**
+     * @param description of the property
+     * @return the updated builder instance
+     */
+    public Builder setDescription(String description) {
+      mDescription = description;
+      return this;
+    }
+
+    /**
+     * Creates and registers the property key.
+     *
+     * @return the created property key instance
+     */
+    public PropertyKey build() {
+      PropertyKey key = buildUnregistered();
+      Preconditions.checkState(PropertyKey.register(key), "Cannot register existing key \"%s\"",
+          mName);
+      return key;
+    }
+
+    /**
+     * Creates the property key without registering it with default property list.
+     *
+     * @return the created property key instance
+     */
+    public PropertyKey buildUnregistered() {
+      DefaultSupplier defaultSupplier = mDefaultSupplier;
+      if (defaultSupplier == null) {
+        String defaultString = String.valueOf(mDefaultValue);
+        defaultSupplier = (mDefaultValue == null)
+            ? new DefaultSupplier(() -> null, "null")
+            : new DefaultSupplier(() -> defaultString, defaultString);
+      }
+
+      PropertyKey key = new PropertyKey(mName, mDescription, defaultSupplier);
+      return key;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("defaultValue", mDefaultValue)
+          .add("description", mDescription)
+          .add("name", mName).toString();
+    }
+  }
+
+  public static final PropertyKey CONF_DIR =
+      new Builder(Name.CONF_DIR)
+          .setDefaultValue(String.format("${%s}/conf", Name.HOME))
+          .setDescription("The directory containing files used to configure ratis-shell.")
+          .build();
+  public static final PropertyKey TEST_MODE =
+      new Builder(Name.TEST_MODE)
+          .setDefaultValue(false)
+          .setDescription("Flag used only during tests to allow special behavior.")
+          .build();
+  public static final PropertyKey SITE_CONF_DIR =
+      new Builder(Name.SITE_CONF_DIR)
+          .setDefaultSupplier(
+              () -> String.format("${%s}/,%s/.ratis-shell/,/etc/ratis-shell/",
+                  Name.CONF_DIR, System.getProperty("user.home")),
+              String.format("${%s}/,${user.home}/.ratis-shell/,/etc/ratis-shell/", Name.CONF_DIR))
+          .setDescription(
+              String.format("Comma-separated search path for %s.", Constants.SITE_PROPERTIES))
+          .build();
+
+  /**
+   * A nested class to hold named string constants for their corresponding properties.
+   * Used for setting configuration in integration tests.
+   */
+  public static final class Name {
+    public static final String CONF_DIR = "ratis.shell.conf.dir";
+    public static final String HOME = "ratis.shell.home";
+    public static final String SITE_CONF_DIR = "ratis.shell.site.conf.dir";
+    public static final String TEST_MODE = "ratis.shell.test.mode";
+
+    private Name() {} // prevent instantiation
+  }
+
+  /**
+   * A set of templates to generate the names of parameterized properties given
+   * different parameters.
+   */
+  public enum Template {
+    RATIS_SHELL_GROUP_ID("ratis.shell.%s.groupid",
+        "ratis\\.shell\\.(\\w+)\\.groupid"),
+    RATIS_SHELL_PEER_IDS("ratis.shell.%s.peers",
+        "ratis\\.shell\\.(\\w+)\\.peers"),
+    ;
+
+    // puts property creators in a nested class to avoid NPE in enum static initialization
+    private static class PropertyCreators {
+      private static final BiFunction<String, PropertyKey, PropertyKey> DEFAULT_PROPERTY_CREATOR =
+          fromBuilder(new Builder(""));
+
+      private static BiFunction<String, PropertyKey, PropertyKey> fromBuilder(Builder builder) {
+        return (name, baseProperty) -> builder.setName(name).buildUnregistered();
+      }
+    }
+
+    private static final String NESTED_GROUP = "nested";
+    private final String mFormat;
+    private final Pattern mPattern;
+    private BiFunction<String, PropertyKey, PropertyKey> mPropertyCreator =
+        PropertyCreators.DEFAULT_PROPERTY_CREATOR;
+
+    /**
+     * Constructs a property key format.
+     *
+     * @param format String of this property as formatted string
+     * @param re String of this property as regexp
+     */
+    Template(String format, String re) {
+      mFormat = format;
+      mPattern = Pattern.compile(re);
+    }
+
+    /**
+     * Constructs a nested property key format with a function to construct property key given
+     * base property key.
+     *
+     * @param format String of this property as formatted string
+     * @param re String of this property as regexp
+     * @param propertyCreator a function that creates property key given name and base property key
+     *                        (for nested properties only, will be null otherwise)
+     */
+    Template(String format, String re,
+        BiFunction<String, PropertyKey, PropertyKey> propertyCreator) {
+      this(format, re);
+      mPropertyCreator = propertyCreator;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this).add("format", mFormat).add("pattern", mPattern)
+          .toString();
+    }
+
+    /**
+     * Converts a property key template.
+     *
+     * @param params ordinal
+     * @return corresponding property
+     */
+    public PropertyKey format(Object... params) {
+      return new PropertyKey(String.format(mFormat, params));
+    }
+
+    /**
+     * @param input the input property key string
+     * @return whether the input string matches this template
+     */
+    public boolean matches(String input) {
+      Matcher matcher = mPattern.matcher(input);
+      return matcher.matches();
+    }
+
+    /**
+     * @param input the input property key string
+     * @return the matcher matching the template to the string
+     */
+    public Matcher match(String input) {
+      return mPattern.matcher(input);
+    }
+
+    /**
+     * Gets the property key if the property name matches the template.
+     *
+     * @param propertyName name of the property
+     * @return the property key, or null if the property name does not match the template
+     */
+    private PropertyKey getPropertyKey(String propertyName) {
+      Matcher matcher = match(propertyName);
+      if (!matcher.matches()) {
+        return null;
+      }
+      // if the template can extract a nested property, build the new property from the nested one
+      String nestedKeyName = null;
+      try {
+        nestedKeyName = matcher.group(NESTED_GROUP);
+      } catch (IllegalArgumentException e) {
+        // ignore if group is not found
+      }
+      PropertyKey nestedProperty = null;
+      if (nestedKeyName != null && isValid(nestedKeyName)) {
+        nestedProperty = fromString(nestedKeyName);
+      }
+      return mPropertyCreator.apply(propertyName, nestedProperty);
+    }
+  }
+
+  /**
+   * @param input string of property key
+   * @return whether the input is a valid property name
+   */
+  public static boolean isValid(String input) {
+    // Check if input matches any default keys
+    if (DEFAULT_KEYS_MAP.containsKey(input)) {
+      return true;
+    }
+    // Regex matching for templates can be expensive when checking properties frequently.
+    // Use a cache to store regexp matching results to reduce CPU overhead.
+    Boolean result = REGEXP_CACHE.getIfPresent(input);
+    if (result != null) {
+      return result;
+    }
+    // Check if input matches any parameterized keys
+    result = false;
+    for (Template template : Template.values()) {
+      if (template.matches(input)) {
+        result = true;
+        break;
+      }
+    }
+    REGEXP_CACHE.put(input, result);
+    return result;
+  }
+
+  /**
+   * Parses a string and return its corresponding {@link PropertyKey}, throwing exception if no such
+   * a property can be found.
+   *
+   * @param input string of property key
+   * @return corresponding property
+   */
+  public static PropertyKey fromString(String input) {
+    // First try to parse it as default key
+    PropertyKey key = DEFAULT_KEYS_MAP.get(input);
+    if (key != null) {
+      return key;
+    }
+
+    // Try different templates and see if any template matches
+    for (Template template : Template.values()) {
+      key = template.getPropertyKey(input);
+      if (key != null) {
+        return key;
+      }
+    }
+
+    throw new IllegalArgumentException("Invalid configuration key " + input);
+  }
+
+  /**
+   * @return all pre-defined property keys
+   */
+  public static Collection<? extends PropertyKey> defaultKeys() {
+    return Sets.newHashSet(DEFAULT_KEYS_MAP.values());
+  }
+
+  /** Property name. */
+  private final String mName;
+
+  /** Property Key description. */
+  private final String mDescription;
+
+  /** Supplies the Property Key default value. */
+  private final DefaultSupplier mDefaultSupplier;
+
+  /**
+   * @param name String of this property
+   * @param description String description of this property key
+   * @param defaultSupplier default value supplier
+   */
+  private PropertyKey(String name, String description, DefaultSupplier defaultSupplier) {
+    mName = Preconditions.checkNotNull(name, "name");
+    mDescription = Strings.isNullOrEmpty(description) ? "N/A" : description;
+    mDefaultSupplier = defaultSupplier;
+  }
+
+  /**
+   * @param name String of this property
+   */
+  private PropertyKey(String name) {
+    this(name, null, new DefaultSupplier(() -> null, "null"));
+  }
+
+  /**
+   * Registers the given key to the global key map.
+   *
+   * @param key th property
+   * @return whether the property key is successfully registered
+   */
+  @VisibleForTesting
+  public static boolean register(PropertyKey key) {
+    String name = key.getName();
+
+    DEFAULT_KEYS_MAP.put(name, key);
+    return true;
+  }
+
+  /**
+   * Unregisters the given key from the global key map.
+   *
+   * @param key the property to unregister
+   */
+  @VisibleForTesting
+  public static void unregister(PropertyKey key) {
+    String name = key.getName();
+    DEFAULT_KEYS_MAP.remove(name);
+  }
+
+  /**
+   * @param name name of the property
+   * @return the registered property key if found, or else create a new one and return
+   */
+  public static PropertyKey getOrBuildCustom(String name) {
+    return DEFAULT_KEYS_MAP.computeIfAbsent(name,
+        (key) -> {
+          final Builder propertyKeyBuilder = new Builder(key);
+          return propertyKeyBuilder.buildUnregistered();
+        });
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PropertyKey)) {
+      return false;
+    }
+    PropertyKey that = (PropertyKey) o;
+    return Objects.equal(mName, that.mName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(mName);
+  }
+
+  @Override
+  public String toString() {
+    return mName;
+  }
+
+  @Override
+  public int compareTo(PropertyKey o) {
+    return mName.compareTo(o.mName);
+  }
+
+  /**
+   * @return length of this property key
+   */
+  public int length() {
+    return mName.length();
+  }
+
+  /**
+   * @param key the name of input key
+   * @return if this key is nested inside the given key
+   */
+  public boolean isNested(String key) {
+    return key.length() > length() + 1 && key.startsWith(mName) && key.charAt(length()) == '.';
+  }
+
+  /**
+   * @return the name of the property
+   */
+  public String getName() {
+    return mName;
+  }
+
+  /**
+   * @return the description of a property
+   */
+  public String getDescription() {
+    return mDescription;
+  }
+
+  /**
+   * @return the default value of a property key or null if value not set
+   */
+  public String getDefaultValue() {
+    Object defaultValue = mDefaultSupplier.get();
+    return defaultValue == null ? null : defaultValue.toString();
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/conf/RatisShellConfiguration.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/conf/RatisShellConfiguration.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.conf;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Ratis shell configuration.
+ */
+public interface RatisShellConfiguration {
+
+  /**
+   * Gets the value for the given key in the {@link java.util.Properties};
+   * if this key is not found, a RuntimeException is thrown.
+   *
+   * @param key the key to get the value for
+   * @return the value for the given key
+   */
+  String get(PropertyKey key);
+
+  /**
+   * @param key the key to get the value for
+   * @param defaultValue the value to return if no value is set for the specified key
+   * @return the value
+   */
+  default String getOrDefault(PropertyKey key, String defaultValue) {
+    return isSet(key) ? get(key) : defaultValue;
+  }
+
+  /**
+   * Checks if the configuration contains a value for the given key.
+   *
+   * @param key the key to check
+   * @return true if there is value for the key, false otherwise
+   */
+  boolean isSet(PropertyKey key);
+
+  /**
+   * @param key the key to check
+   * @return true if there is value for the key set by user, false otherwise even when there is a
+   *         default value for the key
+   */
+  boolean isSetByUser(PropertyKey key);
+
+  /**
+   * @return the keys configured by the configuration
+   */
+  Set<PropertyKey> keySet();
+
+  /**
+   * @return the keys set by user
+   */
+  Set<PropertyKey> userKeySet();
+
+  /**
+   * Gets the integer representation of the value for the given key.
+   *
+   * @param key the key to get the value for
+   * @return the value for the given key as an {@code int}
+   */
+  int getInt(PropertyKey key);
+
+  /**
+   * Gets the long representation of the value for the given key.
+   *
+   * @param key the key to get the value for
+   * @return the value for the given key as a {@code long}
+   */
+  long getLong(PropertyKey key);
+
+  /**
+   * Gets the double representation of the value for the given key.
+   *
+   * @param key the key to get the value for
+   * @return the value for the given key as a {@code double}
+   */
+  double getDouble(PropertyKey key);
+
+  /**
+   * Gets the float representation of the value for the given key.
+   *
+   * @param key the key to get the value for
+   * @return the value for the given key as a {@code float}
+   */
+  float getFloat(PropertyKey key);
+
+  /**
+   * Gets the boolean representation of the value for the given key.
+   *
+   * @param key the key to get the value for
+   * @return the value for the given key as a {@code boolean}
+   */
+  boolean getBoolean(PropertyKey key);
+
+  /**
+   * Gets the value for the given key as a list.
+   *
+   * @param key the key to get the value for
+   * @param delimiter the delimiter to split the values
+   * @return the list of values for the given key
+   */
+  List<String> getList(PropertyKey key, String delimiter);
+
+  /**
+   * Gets the value for the given key as an enum value.
+   *
+   * @param key the key to get the value for
+   * @param enumType the type of the enum
+   * @param <T> the type of the enum
+   * @return the value for the given key as an enum value
+   */
+  <T extends Enum<T>> T getEnum(PropertyKey key, Class<T> enumType);
+
+  /**
+   * Gets the value for the given key as a class.
+   *
+   * @param key the key to get the value for
+   * @param <T> the type of the class
+   * @return the value for the given key as a class
+   */
+  <T> Class<T> getClass(PropertyKey key);
+
+  /**
+   * Gets a set of properties that share a given common prefix key as a map. E.g., if A.B=V1 and
+   * A.C=V2, calling this method with prefixKey=A returns a map of {B=V1, C=V2}, where B and C are
+   * also valid properties. If no property shares the prefix, an empty map is returned.
+   *
+   * @param prefixKey the prefix key
+   * @return a map from nested properties aggregated by the prefix
+   */
+  Map<String, String> getNestedProperties(PropertyKey prefixKey);
+
+  /**
+   * Gets a copy of the {@link RatisShellProperties} which back the {@link RatisShellConfiguration}.
+   *
+   * @return A copy of RatisShellProperties representing the configuration
+   */
+  RatisShellProperties copyProperties();
+
+  /**
+   * Validates the configuration.
+   *
+   * @throws IllegalStateException if invalid configuration is encountered
+   */
+  void validate();
+
+  /**
+   * @return hash of properties, if hashing is not supported, return empty string
+   */
+  default String hash() {
+    return "";
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/conf/RatisShellProperties.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/conf/RatisShellProperties.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.conf;
+
+import com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * Provides the source of truth of property values and a unified abstraction to put and get
+ * properties, hiding the difference of accessing user-specified properties, the default properties
+ * (known at construction time) and the extension properties (known at runtime). This class is
+ * supposed to handle the ordering and priority of properties from different sources, whereas the
+ * <code>Configuration</code> class is supposed to handle the type conversion on top of the source
+ * of truth of the properties.
+ *
+ * For a given property key, the order of preference of its value is (from highest to lowest)
+ *
+ * (1) runtime config
+ * (2) system properties,
+ * (3) properties in the specified file (site-properties),
+ * (4) default property values.
+ */
+public class RatisShellProperties {
+  private static final Logger LOG = LoggerFactory.getLogger(RatisShellProperties.class);
+
+  /**
+   * Map of user-specified properties. When key is mapped to Optional.empty(), it indicates no
+   * value is set for this key. Note that, ConcurrentHashMap requires not null for key and value.
+   */
+  private final ConcurrentHashMap<PropertyKey, Optional<String>> userProps =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Constructs a new instance of properties.
+   */
+  public RatisShellProperties() {}
+
+  /**
+   * @param properties properties to copy
+   */
+  public RatisShellProperties(RatisShellProperties properties) {
+    userProps.putAll(properties.userProps);
+  }
+
+  /**
+   * @param key the key to query
+   * @return the value, or null if the key has no value set
+   */
+  public String get(PropertyKey key) {
+    if (userProps.containsKey(key)) {
+      return userProps.get(key).orElse(null);
+    }
+    // In case key is not the reference to the original key
+    return PropertyKey.fromString(key.toString()).getDefaultValue();
+  }
+
+  /**
+   * Clears all existing user-specified properties.
+   */
+  public void clear() {
+    userProps.clear();
+  }
+
+  /**
+   * Puts the key value pair specified by users.
+   *
+   * @param key key to put
+   * @param value value to put
+   */
+  public void put(PropertyKey key, String value) {
+    userProps.putIfAbsent(key, Optional.ofNullable(value));
+  }
+
+  /**
+   * Merges the current configuration properties with new properties. If a property exists
+   * both in the new and current configuration, the one from the new configuration wins if
+   * its priority is higher or equal than the existing one.
+   *
+   * @param properties the source {@link java.util.Properties} to be merged
+   */
+  public void merge(Map<?, ?> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return;
+    }
+    // merge the properties
+    for (Map.Entry<?, ?> entry : properties.entrySet()) {
+      String key = entry.getKey().toString().trim();
+      String value = entry.getValue() == null ? null : entry.getValue().toString().trim();
+      PropertyKey propertyKey;
+      if (PropertyKey.isValid(key)) {
+        propertyKey = PropertyKey.fromString(key);
+      } else {
+        propertyKey = PropertyKey.getOrBuildCustom(key);
+      }
+      put(propertyKey, value);
+    }
+  }
+
+  /**
+   * Remove the value set for key.
+   *
+   * @param key key to remove
+   */
+  public void remove(PropertyKey key) {
+    // remove is a nop if the key doesn't already exist
+    if (userProps.containsKey(key)) {
+      userProps.remove(key);
+    }
+  }
+
+  /**
+   * Checks if there is a value set for the given key.
+   *
+   * @param key the key to check
+   * @return true if there is value for the key, false otherwise
+   */
+  public boolean isSet(PropertyKey key) {
+    if (isSetByUser(key)) {
+      return true;
+    }
+    // In case key is not the reference to the original key
+    return PropertyKey.fromString(key.toString()).getDefaultValue() != null;
+  }
+
+  /**
+   * @param key the key to check
+   * @return true if there is a value for the key set by user, false otherwise even when there is a
+   *         default value for the key
+   */
+  public boolean isSetByUser(PropertyKey key) {
+    if (userProps.containsKey(key)) {
+      Optional<String> val = userProps.get(key);
+      return val.isPresent();
+    }
+    return false;
+  }
+
+  /**
+   * @return the entry set of all property key and value pairs (value can be null)
+   */
+  public Set<Map.Entry<PropertyKey, String>> entrySet() {
+    return keySet().stream().map(key -> Maps.immutableEntry(key, get(key))).collect(toSet());
+  }
+
+  /**
+   * @return the key set of all ratis-shell property
+   */
+  public Set<PropertyKey> keySet() {
+    Set<PropertyKey> keySet = new HashSet<>(PropertyKey.defaultKeys());
+    keySet.addAll(userProps.keySet());
+    return Collections.unmodifiableSet(keySet);
+  }
+
+  /**
+   * @return the key set of user set properties
+   */
+  public Set<PropertyKey> userKeySet() {
+    return Collections.unmodifiableSet(userProps.keySet());
+  }
+
+  /**
+   * Iterates over all the key value pairs and performs the given action.
+   *
+   * @param action the operation to perform on each key value pair
+   */
+  public void forEach(BiConsumer<? super PropertyKey, ? super String> action) {
+    for (Map.Entry<PropertyKey, String> entry : entrySet()) {
+      action.accept(entry.getKey(), entry.getValue());
+    }
+  }
+
+  /**
+   * Makes a copy of the backing properties and returns them in a new object.
+   *
+   * @return a copy of the current properties
+   */
+  public RatisShellProperties copy() {
+    return new RatisShellProperties(this);
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/util/CommonUtils.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/util/CommonUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Common utilities shared by all components.
+ */
+public final class CommonUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(CommonUtils.class);
+
+  /**
+   * Creates new instance of a class by calling a constructor that receives ctorClassArgs arguments.
+   *
+   * @param <T> type of the object
+   * @param cls the class to create
+   * @param ctorClassArgs parameters type list of the constructor to initiate, if null default
+   *        constructor will be called
+   * @param ctorArgs the arguments to pass the constructor
+   * @return new class object
+   * @throws RuntimeException if the class cannot be instantiated
+   */
+  public static <T> T createNewClassInstance(Class<T> cls, Class<?>[] ctorClassArgs,
+      Object[] ctorArgs) {
+    try {
+      if (ctorClassArgs == null) {
+        return cls.newInstance();
+      }
+      Constructor<T> ctor = cls.getConstructor(ctorClassArgs);
+      return ctor.newInstance(ctorArgs);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e.getCause());
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private CommonUtils() {} // prevent instantiation
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/util/ConfigurationUtils.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/util/ConfigurationUtils.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.util;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import org.apache.ratis.ratisshell.Constants;
+import org.apache.ratis.ratisshell.conf.InstancedConfiguration;
+import org.apache.ratis.ratisshell.conf.PropertyKey;
+import org.apache.ratis.ratisshell.conf.RatisShellConfiguration;
+import org.apache.ratis.ratisshell.conf.RatisShellProperties;
+import org.apache.ratis.ratisshell.util.io.PathUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Utilities for working with ratis-shell configurations.
+ */
+public final class ConfigurationUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(ConfigurationUtils.class);
+
+  private static volatile RatisShellProperties sDefaultProperties = null;
+
+  private static final Object DEFAULT_PROPERTIES_LOCK = new Object();
+
+  private ConfigurationUtils() {} // prevent instantiation
+
+  /**
+   * Loads properties from a resource.
+   *
+   * @param resource url of the properties file
+   * @return a set of properties on success, or null if failed
+   */
+  public static Properties loadPropertiesFromResource(URL resource) {
+    try (InputStream stream = resource.openStream()) {
+      return loadProperties(stream);
+    } catch (IOException e) {
+      LOG.warn("Failed to read properties from {}: {}", resource, e.toString());
+      return null;
+    }
+  }
+
+  /**
+   * Loads properties from the given file.
+   *
+   * @param filePath the absolute path of the file to load properties
+   * @return a set of properties on success, or null if failed
+   */
+  public static Properties loadPropertiesFromFile(String filePath) {
+    try (FileInputStream fileInputStream = new FileInputStream(filePath)) {
+      return loadProperties(fileInputStream);
+    } catch (FileNotFoundException e) {
+      return null;
+    } catch (IOException e) {
+      LOG.warn("Failed to close property input stream from {}: {}", filePath, e.toString());
+      return null;
+    }
+  }
+
+  /**
+   * @param stream the stream to read properties from
+   * @return a properties object populated from the stream
+   */
+  public static Properties loadProperties(InputStream stream) {
+    Properties properties = new Properties();
+    try {
+      properties.load(stream);
+    } catch (IOException e) {
+      LOG.warn("Unable to load properties: {}", e.toString());
+      return null;
+    }
+    return properties;
+  }
+
+  /**
+   * Searches the given properties file from a list of paths.
+   *
+   * @param propertiesFile the file to load properties
+   * @param confPathList a list of paths to search the propertiesFile
+   * @return the site properties file on success search, or null if failed
+   */
+  public static String searchPropertiesFile(String propertiesFile,
+      String[] confPathList) {
+    if (propertiesFile == null || confPathList == null) {
+      return null;
+    }
+    for (String path : confPathList) {
+      String file = PathUtils.concatPath(path, propertiesFile);
+      Properties properties = loadPropertiesFromFile(file);
+      if (properties != null) {
+        // If a site conf is successfully loaded, stop trying different paths.
+        return file;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @param value the value or null (value is not set)
+   * @return the value or "(no value set)" when the value is not set
+   */
+  public static String valueAsString(String value) {
+    return value == null ? "(no value set)" : value;
+  }
+
+  /**
+   * Returns an instance of {@link RatisShellConfiguration} with the defaults and values from
+   * ratis-shell-site properties.
+   *
+   * @return the set of properties loaded from the site-properties file
+   */
+  public static RatisShellProperties defaults() {
+    if (sDefaultProperties == null) {
+      synchronized (DEFAULT_PROPERTIES_LOCK) { // We don't want multiple threads to reload
+        // properties at the same time.
+        // Check if properties are still null so we don't reload a second time.
+        if (sDefaultProperties == null) {
+          reloadProperties();
+        }
+      }
+    }
+    return sDefaultProperties.copy();
+  }
+
+  /**
+   * Reloads site properties from disk.
+   */
+  public static void reloadProperties() {
+    synchronized (DEFAULT_PROPERTIES_LOCK) {
+      RatisShellProperties properties = new RatisShellProperties();
+      InstancedConfiguration conf = new InstancedConfiguration(properties);
+      Properties sysProps = new Properties();
+      System.getProperties().stringPropertyNames()
+          .forEach(key -> sysProps.setProperty(key, System.getProperty(key)));
+      properties.merge(sysProps);
+
+      if (conf.getBoolean(PropertyKey.TEST_MODE)) {
+        conf.validate();
+        sDefaultProperties = properties;
+        return;
+      }
+
+      // we are not in test mode, load site properties
+      String confPaths = conf.get(PropertyKey.SITE_CONF_DIR);
+      String[] confPathList = confPaths.split(",");
+      String sitePropertyFile = ConfigurationUtils
+          .searchPropertiesFile(Constants.SITE_PROPERTIES, confPathList);
+      Properties siteProps = null;
+      if (sitePropertyFile != null) {
+        siteProps = loadPropertiesFromFile(sitePropertyFile);
+      } else {
+        URL resource =
+            ConfigurationUtils.class.getClassLoader().getResource(Constants.SITE_PROPERTIES);
+        if (resource != null) {
+          siteProps = loadPropertiesFromResource(resource);
+        }
+      }
+      properties.merge(siteProps);
+      conf.validate();
+      sDefaultProperties = properties;
+    }
+  }
+
+  /**
+   * Merges the current configuration properties with new properties. If a property exists
+   * both in the new and current configuration, the one from the new configuration wins if
+   * its priority is higher or equal than the existing one.
+   *
+   * @param conf the base configuration
+   * @param properties the source {@link Properties} to be merged
+   * @return a new configuration representing the merged properties
+   */
+  public static RatisShellConfiguration merge(RatisShellConfiguration conf, Map<?, ?> properties) {
+    RatisShellProperties props = conf.copyProperties();
+    props.merge(properties);
+    return new InstancedConfiguration(props);
+  }
+
+  /**
+   * Returns the input string as a list, splitting on a specified delimiter.
+   *
+   * @param value the value to split
+   * @param delimiter the delimiter to split the values
+   * @return the list of values for input string
+   */
+  public static List<String> parseAsList(String value, String delimiter) {
+    return Lists.newArrayList(Splitter.on(delimiter).trimResults().omitEmptyStrings()
+        .split(value));
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/ratisshell/util/io/PathUtils.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/ratisshell/util/io/PathUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.ratisshell.util.io;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Preconditions;
+
+import java.io.File;
+
+/**
+ * Utilities related to local file paths.
+ */
+public final class PathUtils {
+  private static final CharMatcher SEPARATOR_MATCHER =
+      CharMatcher.is(File.separator.charAt(0));
+
+  /**
+   * Joins two path elements, separated by {@link File#separator}.
+   * <p>
+   * Note that empty element in base or paths is ignored.
+   *
+   * @param base base path
+   * @param path path element to concatenate
+   * @return joined path
+   */
+  public static String concatPath(Object base, Object path) {
+    Preconditions.checkNotNull(base, "base");
+    Preconditions.checkNotNull(path, "path");
+    String trimmedBase = SEPARATOR_MATCHER.trimTrailingFrom(base.toString());
+    String trimmedPath = SEPARATOR_MATCHER.trimFrom(path.toString());
+
+    StringBuilder output = new StringBuilder(trimmedBase.length() + trimmedPath.length() + 1);
+    output.append(trimmedBase);
+    if (!trimmedPath.isEmpty()) {
+      output.append(File.separator);
+      output.append(trimmedPath);
+    }
+
+    if (output.length() == 0) {
+      // base must be "[/]+"
+      return File.separator;
+    }
+    return output.toString();
+  }
+
+  private PathUtils() {} // prevent instantiation
+}

--- a/ratis-shell/src/main/libexec/ratis-shell-config.sh
+++ b/ratis-shell/src/main/libexec/ratis-shell-config.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# resolve links - $0 may be a softlink
+this="${BASH_SOURCE-$0}"
+common_bin=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
+script="$(basename -- "${this}")"
+this="${common_bin}/${script}"
+
+# convert relative path to absolute path
+config_bin=$(dirname "${this}")
+script=$(basename "${this}")
+config_bin=$(cd "${config_bin}"; pwd)
+this="${config_bin}/${script}"
+
+# This will set the default installation for a tarball installation while os distributors can
+# set system installation locations.
+RATIS_SHELL_HOME=$(dirname $(dirname "${this}"))
+RATIS_SHELL_ASSEMBLY_CLIENT_JAR="${RATIS_SHELL_HOME}/lib/*"
+RATIS_SHELL_CONF_DIR="${RATIS_SHELL_CONF_DIR:-${RATIS_SHELL_HOME}/conf}"
+RATIS_SHELL_LOGS_DIR="${RATIS_SHELL_LOGS_DIR:-${RATIS_SHELL_HOME}/logs}"
+
+if [[ -e "${RATIS_SHELL_CONF_DIR}/ratis-shell-env.sh" ]]; then
+  . "${RATIS_SHELL_CONF_DIR}/ratis-shell-env.sh"
+fi
+
+# Check if java is found
+if [[ -z "${JAVA}" ]]; then
+  if [[ -n "${JAVA_HOME}" ]] && [[ -x "${JAVA_HOME}/bin/java" ]];  then
+    JAVA="${JAVA_HOME}/bin/java"
+  elif [[ -n "$(which java 2>/dev/null)" ]]; then
+    JAVA=$(which java)
+  else
+    echo "Error: Cannot find 'java' on path or under \$JAVA_HOME/bin/. Please set JAVA_HOME in ratis-shell-env.sh or user bash profile."
+    exit 1
+  fi
+fi
+
+# Check Java version == 1.8 or == 11
+JAVA_VERSION=$(${JAVA} -version 2>&1 | awk -F '"' '/version/ {print $2}')
+JAVA_MAJORMINOR=$(echo "${JAVA_VERSION}" | awk -F. '{printf("%03d%03d",$1,$2);}')
+JAVA_MAJOR=$(echo "${JAVA_VERSION}" | awk -F. '{printf("%03d",$1);}')
+if [[ ${JAVA_MAJORMINOR} != 001008 && ${JAVA_MAJOR} != 011 ]]; then
+  echo "Error: ratis-shell requires Java 8 or Java 11, currently Java $JAVA_VERSION found."
+  exit 1
+fi
+
+RATIS_SHELL_CLIENT_CLASSPATH="${RATIS_SHELL_CONF_DIR}/:${RATIS_SHELL_CLASSPATH}:${RATIS_SHELL_ASSEMBLY_CLIENT_JAR}"
+
+if [[ -n "${RATIS_SHELL_HOME}" ]]; then
+  RATIS_SHELL_JAVA_OPTS+=" -Dratis.shell.home=${RATIS_SHELL_HOME}"
+fi
+
+RATIS_SHELL_JAVA_OPTS+=" -Dratis.shell.conf.dir=${RATIS_SHELL_CONF_DIR} -Dratis.shell.logs.dir=${RATIS_SHELL_LOGS_DIR} -Dratis.shell.user.logs.dir=${RATIS_SHELL_USER_LOGS_DIR}"
+
+RATIS_SHELL_JAVA_OPTS+=" -Dlog4j.configuration=file:${RATIS_SHELL_CONF_DIR}/log4j.properties"
+RATIS_SHELL_JAVA_OPTS+=" -Dorg.apache.jasper.compiler.disablejsr199=true"
+RATIS_SHELL_JAVA_OPTS+=" -Djava.net.preferIPv4Stack=true"
+RATIS_SHELL_JAVA_OPTS+=" -Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add ratis-shell as a module of ratis

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1412

## How was this patch tested?

```bash
mvn clean install  assembly:single -DskipTests -Dmaven.javadoc.skip=true -Dlicense.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Denforcer.skip=true   -Djsse.enableSNIExtension=false  -Prelease -Papache-release

cd ratis-assembly/target
tar -xzvf apache-ratis-2.2.0-SNAPSHOT-ratis-shell.tar.gz
cd apache-ratis-2.2.0-SNAPSHOT
# Get ozone manager ratis information
bin/ratis sh info -peers ratis.shell.ozone-om.peers=localhost:9872,localhost:19872,localhost:29872
# Elect localhost:29872 to be new leader of ozone manager
bin/ratis sh elect -peers ratis.shell.ozone-om.peers=localhost:9872,localhost:19872,localhost:29872 -address localhost:29872 
```
