### PR TITLE
RATIS-1419. Use cached thread pools in DataStreamManagement.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/ConcurrentUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ConcurrentUtils.java
@@ -22,7 +22,7 @@ import org.apache.ratis.util.function.CheckedFunction;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -83,6 +83,6 @@ public interface ConcurrentUtils {
    */
   static ExecutorService newCachedThreadPool(int maximumPoolSize, ThreadFactory threadFactory) {
     return new ThreadPoolExecutor(0, maximumPoolSize, 60L, TimeUnit.SECONDS,
-        new SynchronousQueue<>(), threadFactory);
+        new LinkedBlockingQueue<>(), threadFactory);
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/util/ConcurrentUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ConcurrentUtils.java
@@ -19,9 +19,7 @@ package org.apache.ratis.util;
 
 import org.apache.ratis.util.function.CheckedFunction;
 
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -75,11 +73,11 @@ public interface ConcurrentUtils {
   }
 
   /**
-   * The same as {@link Executors#newCachedThreadPool()} except that this method takes a maximumPoolSize parameter.
+   * The same as {@link java.util.concurrent.Executors#newCachedThreadPool()}
+   * except that this method takes a maximumPoolSize parameter.
    *
    * @param maximumPoolSize the maximum number of threads to allow in the pool.
    * @return a new {@link ExecutorService}.
-   * @see ThreadPoolExecutor#ThreadPoolExecutor(int, int, long, TimeUnit, BlockingQueue, ThreadFactory)
    */
   static ExecutorService newCachedThreadPool(int maximumPoolSize, ThreadFactory threadFactory) {
     return new ThreadPoolExecutor(0, maximumPoolSize, 60L, TimeUnit.SECONDS,

--- a/ratis-common/src/main/java/org/apache/ratis/util/ConcurrentUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ConcurrentUtils.java
@@ -19,48 +19,20 @@ package org.apache.ratis.util;
 
 import org.apache.ratis.util.function.CheckedFunction;
 
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Utilities related to atomic operations.
+ * Utilities related to concurrent programming.
  */
-public interface AtomicUtils {
-
-  /**
-   * Updates a AtomicLong which is supposed to maintain the minimum values. This method is not
-   * synchronized but is thread-safe.
-   */
-  static void updateMin(AtomicLong min, long value) {
-    while (true) {
-      long cur = min.get();
-      if (value >= cur) {
-        break;
-      }
-
-      if (min.compareAndSet(cur, value)) {
-        break;
-      }
-    }
-  }
-
-  /**
-   * Updates a AtomicLong which is supposed to maintain the maximum values. This method is not
-   * synchronized but is thread-safe.
-   */
-  static void updateMax(AtomicLong max, long value) {
-    while (true) {
-      long cur = max.get();
-      if (value <= cur) {
-        break;
-      }
-
-      if (max.compareAndSet(cur, value)) {
-        break;
-      }
-    }
-  }
-
+public interface ConcurrentUtils {
   /**
    * Similar to {@link AtomicReference#updateAndGet(java.util.function.UnaryOperator)}
    * except that the update function is checked.
@@ -84,5 +56,33 @@ public interface AtomicUtils {
       throw t;
     }
     return updated;
+  }
+
+  /**
+   * Creates a {@link ThreadFactory} so that the threads created by the factory are named with the given name prefix.
+   *
+   * @param namePrefix the prefix used in the name of the threads created.
+   * @return a new {@link ThreadFactory}.
+   */
+  static ThreadFactory newThreadFactory(String namePrefix) {
+    final AtomicInteger numThread = new AtomicInteger();
+    return runnable -> {
+      final int id = numThread.incrementAndGet();
+      final Thread t = new Thread(runnable);
+      t.setName(namePrefix + "-thread" + id);
+      return t;
+    };
+  }
+
+  /**
+   * The same as {@link Executors#newCachedThreadPool()} except that this method takes a maximumPoolSize parameter.
+   *
+   * @param maximumPoolSize the maximum number of threads to allow in the pool.
+   * @return a new {@link ExecutorService}.
+   * @see ThreadPoolExecutor#ThreadPoolExecutor(int, int, long, TimeUnit, BlockingQueue, ThreadFactory)
+   */
+  static ExecutorService newCachedThreadPool(int maximumPoolSize, ThreadFactory threadFactory) {
+    return new ThreadPoolExecutor(0, maximumPoolSize, 60L, TimeUnit.SECONDS,
+        new SynchronousQueue<>(), threadFactory);
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorageMetadataFileImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorageMetadataFileImpl.java
@@ -19,7 +19,7 @@ package org.apache.ratis.server.storage;
 
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.util.AtomicFileOutputStream;
-import org.apache.ratis.util.AtomicUtils;
+import org.apache.ratis.util.ConcurrentUtils;
 import org.apache.ratis.util.JavaUtils;
 
 import java.io.BufferedReader;
@@ -52,12 +52,12 @@ class RaftStorageMetadataFileImpl implements RaftStorageMetadataFile {
 
   @Override
   public RaftStorageMetadata getMetadata() throws IOException {
-    return AtomicUtils.updateAndGet(metadata, value -> value != null? value: load(file));
+    return ConcurrentUtils.updateAndGet(metadata, value -> value != null? value: load(file));
   }
 
   @Override
   public void persist(RaftStorageMetadata newMetadata) throws IOException {
-    AtomicUtils.updateAndGet(metadata,
+    ConcurrentUtils.updateAndGet(metadata,
         old -> Objects.equals(old, newMetadata)? old: atomicWrite(newMetadata, file));
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamAsyncClusterTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamAsyncClusterTests.java
@@ -86,7 +86,7 @@ public abstract class DataStreamAsyncClusterTests<CLUSTER extends MiniRaftCluste
 
     final List<CompletableFuture<Long>> futures = new ArrayList<>();
     futures.add(CompletableFuture.supplyAsync(() -> runTestDataStream(cluster, 5, 10, 1_000_000, 10, stepDownLeader), executor));
-    futures.add(CompletableFuture.supplyAsync(() -> runTestDataStream(cluster, 2, 20, 1_000, 10_000, stepDownLeader), executor));
+    futures.add(CompletableFuture.supplyAsync(() -> runTestDataStream(cluster, 2, 20, 1_000, 5_000, stepDownLeader), executor));
     final long maxIndex = futures.stream()
         .map(CompletableFuture::join)
         .max(Long::compareTo)


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1419