### PR TITLE
Support ratis-shell base framework with info command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
     <module>ratis-logservice</module>
     <module>ratis-metrics</module>
     <module>ratis-tools</module>
+    <module>ratis-shell</module>
     <module>ratis-assembly</module>
   </modules>
 
@@ -308,6 +309,11 @@
         <version>${project.version}</version>
         <type>test-jar</type>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <artifactId>ratis-shell</artifactId>
+        <groupId>org.apache.ratis</groupId>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <artifactId>ratis-grpc</artifactId>

--- a/ratis-assembly/pom.xml
+++ b/ratis-assembly/pom.xml
@@ -127,6 +127,7 @@
             <descriptor>src/main/assembly/src.xml</descriptor>
             <descriptor>src/main/assembly/bin.xml</descriptor>
             <descriptor>src/main/assembly/examples-bin.xml</descriptor>
+            <descriptor>src/main/assembly/ratis-shell.xml</descriptor>
           </descriptors>
         </configuration>
       </plugin>
@@ -285,6 +286,10 @@
     <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-tools</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-shell</artifactId>
     </dependency>
   </dependencies>
 

--- a/ratis-assembly/src/main/assembly/ratis-shell.xml
+++ b/ratis-assembly/src/main/assembly/ratis-shell.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+  <id>ratis-shell</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/../ratis-shell/target/</directory>
+      <outputDirectory>lib/ratis-shell</outputDirectory>
+      <fileMode>755</fileMode>
+      <includes>
+        <include>ratis-shell-*-jar-with-dependencies.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/..</directory>
+      <outputDirectory>.</outputDirectory>
+      <includes>
+        <include>DISCLAIMER</include>
+      </includes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/maven-shared-archive-resources/META-INF/</directory>
+      <outputDirectory>.</outputDirectory>
+      <includes>
+        <include>LICENSE</include>
+        <include>NOTICE</include>
+      </includes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../ratis-shell/src/main/bin</directory>
+      <outputDirectory>bin</outputDirectory>
+      <fileMode>755</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../ratis-shell/src/main/libexec</directory>
+      <outputDirectory>libexec</outputDirectory>
+      <fileMode>0644</fileMode>
+      <directoryMode>0755</directoryMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../ratis-shell/src/main/conf</directory>
+      <outputDirectory>conf</outputDirectory>
+      <fileMode>644</fileMode>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/ratis-shell/pom.xml
+++ b/ratis-shell/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>ratis</artifactId>
+    <groupId>org.apache.ratis</groupId>
+    <version>2.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>ratis-shell</artifactId>
+  <name>Apache Ratis Shell</name>
+
+  <properties>
+  </properties>
+
+  <dependencies>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
+
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>LICENSE</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Main-Class>org.apache.ratis.shell.cli.sh.RatisShell</Main-Class>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ratis-shell/src/main/bin/ratis
+++ b/ratis-shell/src/main/bin/ratis
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function printUsage {
+  echo "Usage: ratis COMMAND [GENERIC_COMMAND_OPTIONS] [COMMAND_ARGS]"
+  echo
+  echo "COMMAND is one of:"
+  echo -e "  sh    \t Command line tool for ratis"
+  echo
+  echo "GENERIC_COMMAND_OPTIONS supports:"
+  echo -e "  -D<property=value>\t Use a value for a given ratis-shell property"
+  echo
+  echo "Commands print help when invoked without parameters."
+}
+
+function runJavaClass {
+  CLASS_ARGS=()
+  for arg in "$@"; do
+      case "${arg}" in
+          -D* | -X* | -agentlib* | -javaagent*)
+              RATIS_SHELL_JAVA_OPTS+=" ${arg}" ;;
+          *)
+              CLASS_ARGS+=("${arg}")
+      esac
+  done
+  "${JAVA}" -cp "${CLASSPATH}" ${RATIS_SHELL_JAVA_OPTS} "${CLASS}" ${PARAMETER} "${CLASS_ARGS[@]}"
+}
+
+function main {
+  BIN=$(cd "$( dirname "$( readlink "$0" || echo "$0" )" )" || exit; pwd)
+
+  if [[ $# == 0 ]]; then
+    printUsage
+    exit 1
+  fi
+
+  COMMAND=$1
+  shift
+
+  DEFAULT_LIBEXEC_DIR="${BIN}"/../libexec
+  RATIS_SHELL_LIBEXEC_DIR=${RATIS_SHELL_LIBEXEC_DIR:-$DEFAULT_LIBEXEC_DIR}
+  . "${RATIS_SHELL_LIBEXEC_DIR}"/ratis-shell-config.sh
+
+  PARAMETER=""
+
+  case ${COMMAND} in
+  "sh")
+    CLASS="org.apache.ratis.shell.cli.sh.RatisShell"
+    CLASSPATH=${RATIS_SHELL_CLIENT_CLASSPATH}
+    runJavaClass "$@"
+  ;;
+  *)
+    echo "Unsupported command ${COMMAND}" >&2
+    printUsage
+    exit 1
+  ;;
+  esac
+}
+
+main "$@"

--- a/ratis-shell/src/main/conf/log4j.properties
+++ b/ratis-shell/src/main/conf/log4j.properties
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These properties may be overridden by system properties. log4j gives system properties
+# a higher precedence than locally defined variables.
+log4j.rootLogger=INFO, SHELL_LOGGER
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M) - %m%n
+
+#SHELL Logger
+log4j.appender.SHELL_LOGGER=org.apache.log4j.RollingFileAppender
+log4j.appender.SHELL_LOGGER.File=${ratis.shell.logs.dir}/ratis-shell.log
+log4j.appender.SHELL_LOGGER.MaxFileSize=100MB
+log4j.appender.SHELL_LOGGER.MaxBackupIndex=10
+log4j.appender.SHELL_LOGGER.layout=org.apache.log4j.PatternLayout
+log4j.appender.SHELL_LOGGER.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M) - %m%n

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/RatisShell.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/RatisShell.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.shell.cli.sh;
+
+public class RatisShell {
+  public static void main(String[] args) {
+    System.out.println("Hello " + RatisShell.class.getSimpleName());
+  }
+}

--- a/ratis-shell/src/main/libexec/ratis-shell-config.sh
+++ b/ratis-shell/src/main/libexec/ratis-shell-config.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# resolve links - $0 may be a softlink
+this="${BASH_SOURCE-$0}"
+common_bin=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
+script="$(basename -- "${this}")"
+this="${common_bin}/${script}"
+
+# convert relative path to absolute path
+config_bin=$(dirname "${this}")
+script=$(basename "${this}")
+config_bin=$(cd "${config_bin}"; pwd)
+this="${config_bin}/${script}"
+
+# This will set the default installation for a tarball installation while os distributors can
+# set system installation locations.
+RATIS_SHELL_HOME=$(dirname $(dirname "${this}"))
+RATIS_SHELL_ASSEMBLY_CLIENT_JAR="${RATIS_SHELL_HOME}/lib/ratis-shell/*"
+RATIS_SHELL_CONF_DIR="${RATIS_SHELL_CONF_DIR:-${RATIS_SHELL_HOME}/conf}"
+RATIS_SHELL_LOGS_DIR="${RATIS_SHELL_LOGS_DIR:-${RATIS_SHELL_HOME}/logs}"
+
+if [[ -e "${RATIS_SHELL_CONF_DIR}/ratis-shell-env.sh" ]]; then
+  . "${RATIS_SHELL_CONF_DIR}/ratis-shell-env.sh"
+fi
+
+# Check if java is found
+if [[ -z "${JAVA}" ]]; then
+  if [[ -n "${JAVA_HOME}" ]] && [[ -x "${JAVA_HOME}/bin/java" ]];  then
+    JAVA="${JAVA_HOME}/bin/java"
+  elif [[ -n "$(which java 2>/dev/null)" ]]; then
+    JAVA=$(which java)
+  else
+    echo "Error: Cannot find 'java' on path or under \$JAVA_HOME/bin/. Please set JAVA_HOME in ratis-shell-env.sh or user bash profile."
+    exit 1
+  fi
+fi
+
+# Check Java version == 1.8 or == 11
+JAVA_VERSION=$(${JAVA} -version 2>&1 | awk -F '"' '/version/ {print $2}')
+JAVA_MAJORMINOR=$(echo "${JAVA_VERSION}" | awk -F. '{printf("%03d%03d",$1,$2);}')
+JAVA_MAJOR=$(echo "${JAVA_VERSION}" | awk -F. '{printf("%03d",$1);}')
+if [[ ${JAVA_MAJORMINOR} != 001008 && ${JAVA_MAJOR} != 011 ]]; then
+  echo "Error: ratis-shell requires Java 8 or Java 11, currently Java $JAVA_VERSION found."
+  exit 1
+fi
+
+RATIS_SHELL_CLIENT_CLASSPATH="${RATIS_SHELL_CONF_DIR}/:${RATIS_SHELL_CLASSPATH}:${RATIS_SHELL_ASSEMBLY_CLIENT_JAR}"
+
+if [[ -n "${RATIS_SHELL_HOME}" ]]; then
+  RATIS_SHELL_JAVA_OPTS+=" -Dratis.shell.home=${RATIS_SHELL_HOME}"
+fi
+
+RATIS_SHELL_JAVA_OPTS+=" -Dratis.shell.conf.dir=${RATIS_SHELL_CONF_DIR} -Dratis.shell.logs.dir=${RATIS_SHELL_LOGS_DIR} -Dratis.shell.user.logs.dir=${RATIS_SHELL_USER_LOGS_DIR}"
+
+RATIS_SHELL_JAVA_OPTS+=" -Dlog4j.configuration=file:${RATIS_SHELL_CONF_DIR}/log4j.properties"
+RATIS_SHELL_JAVA_OPTS+=" -Dorg.apache.jasper.compiler.disablejsr199=true"
+RATIS_SHELL_JAVA_OPTS+=" -Djava.net.preferIPv4Stack=true"
+RATIS_SHELL_JAVA_OPTS+=" -Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false"


### PR DESCRIPTION
- How to build

```console
mvn clean install  assembly:single -DskipTests -Dmaven.javadoc.skip=true -Dlicense.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Denforcer.skip=true   -Djsse.enableSNIExtension=false  -Prelease -Papache-releas
```

- How to run
```
cd ratis/ratis-assembly/target/
tar -xzf apache-ratis-2.3.0-SNAPSHOT-bin.tar.gz
cd apache-ratis-2.3.0-SNAPSHOT
bin/ratis sh info -peers PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT
```