### PR TITLE
RATIS-1428. Add ratis-shell elect command

### DIFF
--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/AbstractRatisCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/AbstractRatisCommand.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.shell.cli.sh.command;
 
+import org.apache.commons.cli.Option;
 import org.apache.ratis.protocol.*;
 import org.apache.ratis.protocol.exceptions.RaftException;
 import org.apache.ratis.shell.cli.Command;
@@ -80,10 +81,7 @@ public abstract class AbstractRatisCommand implements Command {
   @Override
   public int run(CommandLine cl) throws IOException {
     List<InetSocketAddress> addresses = new ArrayList<>();
-    String peersStr = "";
-    if (cl.hasOption(PEER_OPTION_NAME)) {
-      peersStr = cl.getOptionValue(PEER_OPTION_NAME);
-    }
+    String peersStr = cl.getOptionValue(PEER_OPTION_NAME);
     String[] peersArray = peersStr.split(",");
     for (int i = 0; i < peersArray.length; i++) {
       String[] hostPortPair = peersArray[i].split(":");
@@ -131,17 +129,15 @@ public abstract class AbstractRatisCommand implements Command {
   }
 
   @Override
-  public void validateArgs(CommandLine cl) throws IllegalArgumentException {
-    if (!cl.hasOption(PEER_OPTION_NAME)) {
-      throw new IllegalArgumentException(String.format(
-          "should provide [%s]", PEER_OPTION_NAME));
-    }
-  }
-
-  @Override
   public Options getOptions() {
     return new Options()
-            .addOption(PEER_OPTION_NAME, true, "Peer addresses seperated by comma")
+            .addOption(
+                Option.builder()
+                    .option(PEER_OPTION_NAME)
+                    .hasArg()
+                    .required()
+                    .desc("Peer addresses seperated by comma")
+                    .build())
             .addOption(GROUPID_OPTION_NAME, true, "Raft group id");
   }
 

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/ElectCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/ElectCommand.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.shell.cli.sh.command;
+
+import org.apache.commons.cli.Option;
+import org.apache.ratis.shell.cli.RaftUtils;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Command for transferring the leadership to another peer.
+ */
+public class ElectCommand extends AbstractRatisCommand {
+  public static final String ADDRESS_OPTION_NAME = "address";
+
+  /**
+   * @param context command context
+   */
+  public ElectCommand(Context context) {
+    super(context);
+  }
+
+  @Override
+  public String getCommandName() {
+    return "elect";
+  }
+
+  @Override
+  public int run(CommandLine cl) throws IOException {
+    super.run(cl);
+
+    String strAddr = cl.getOptionValue(ADDRESS_OPTION_NAME);
+
+    RaftPeerId newLeaderId = null;
+    // update priorities to enable transfer
+    List<RaftPeer> peersWithNewPriorities = new ArrayList<>();
+    for (RaftPeer peer : getRaftGroup().getPeers()) {
+      peersWithNewPriorities.add(
+          RaftPeer.newBuilder(peer)
+              .setPriority(peer.getAddress().equals(strAddr) ? 2 : 1)
+              .build()
+      );
+      if (peer.getAddress().equals(strAddr)) {
+        newLeaderId = peer.getId();
+      }
+    }
+    if (newLeaderId == null) {
+      return -2;
+    }
+    try (RaftClient client = RaftUtils.createClient(getRaftGroup())) {
+      String stringPeers = "[" + peersWithNewPriorities.stream().map(RaftPeer::toString)
+          .collect(Collectors.joining(", ")) + "]";
+      printf("Applying new peer state before transferring leadership: %n%s%n", stringPeers);
+      RaftClientReply setConfigurationReply =
+          client.admin().setConfiguration(peersWithNewPriorities);
+      processReply(setConfigurationReply,
+          () -> "failed to set priorities before initiating election");
+      // transfer leadership
+      printf("Transferring leadership to server with address <%s> %n", strAddr);
+      try {
+        Thread.sleep(3_000);
+        RaftClientReply transferLeadershipReply =
+            client.admin().transferLeadership(newLeaderId, 60_000);
+        processReply(transferLeadershipReply, () -> "election failed");
+      } catch (Throwable t) {
+        printf("caught an error when executing transfer: %s%n", t.getMessage());
+        return -1;
+      }
+      println("Transferring leadership initiated");
+    }
+    return 0;
+  }
+
+  @Override
+  public String getUsage() {
+    return String.format("%s -%s <HOSTNAME:PORT>"
+        + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
+        + " [-%s <RAFT_GROUP_ID>]",
+        getCommandName(), ADDRESS_OPTION_NAME, PEER_OPTION_NAME,
+        GROUPID_OPTION_NAME);
+  }
+
+  @Override
+  public String getDescription() {
+    return description();
+  }
+
+  @Override
+  public Options getOptions() {
+    return super.getOptions().addOption(
+        Option.builder()
+            .option(ADDRESS_OPTION_NAME)
+            .hasArg()
+            .required()
+            .desc("Server address that will take over as leader")
+            .build()
+    );
+  }
+
+  /**
+   * @return command's description
+   */
+  public static String description() {
+    return "Transfers leadership to the <hostname>:<port>";
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/InfoCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/InfoCommand.java
@@ -59,8 +59,8 @@ public class InfoCommand extends AbstractRatisCommand {
   @Override
   public String getUsage() {
     return String.format("%s"
-        + " [-%s PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT]"
-        + " [-%s RAFT_GROUP_ID]",
+        + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
+        + " [-%s <RAFT_GROUP_ID>]",
         getCommandName(), PEER_OPTION_NAME, GROUPID_OPTION_NAME);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a elect sub command to trigger elect specific peer to be next leader.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1428

## How was this patch tested?

mI did the following test within three alluxio ratis based masters.

```Console
➜  incubator-ratis git:(rs-elect) ✗ mvn clean install  assembly:single -DskipTests -Dmaven.javadoc.skip=true -Dlicense.skip=true  -Dfindbugs.skip=true -Denforcer.skip=true   -Djsse.enableSNIExtension=false  -Prelease -Papache-release 
➜  incubator-ratis git:(rs-elect) ✗ cd ratis-assembly/target 
➜  target git:(rs-elect) ✗ tar -xzf apache-ratis-2.3.0-SNAPSHOT-ratis-shell.tar.gz
➜  target git:(rs-elect) ✗ cd apache-ratis-2.3.0-SNAPSHOT 
➜  apache-ratis-2.3.0-SNAPSHOT git:(rs-elect) ✗ bin/ratis sh
Usage: ratis sh [generic options]
         [elect -address <HOSTNAME:PORT> -peers <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT> [-groupid <RAFT_GROUP_ID>]]
         [info -peers <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT> [-groupid <RAFT_GROUP_ID>]]
➜  apache-ratis-2.3.0-SNAPSHOT git:(rs-elect) ✗ bin/ratis sh info -peers localhost:19200,localhost:19201,localhost:19202
group id: 02511d47-d67c-49a3-9011-abb3109a44c1
leader info: localhost_19201(localhost:19201)

[server {
  id: "localhost_19200"
  address: "localhost:19200"
}
commitIndex: 2
, server {
  id: "localhost_19202"
  address: "localhost:19202"
}
commitIndex: 2
, server {
  id: "localhost_19201"
  address: "localhost:19201"
}
commitIndex: 2
]
➜  apache-ratis-2.3.0-SNAPSHOT git:(rs-elect) ✗ bin/ratis sh elect -peers localhost:19200,localhost:19201,localhost:19202 -address localhost:19202 
Applying new peer state before transferring leadership: 
[localhost_19202|rpc:localhost:19202|admin:|client:|dataStream:|priority:2, localhost_19201|rpc:localhost:19201|admin:|client:|dataStream:|priority:1, localhost_19200|rpc:localhost:19200|admin:|client:|dataStream:|priority:1]
Transferring leadership to server with address <localhost:19202> 
Transferring leadership initiated
➜  apache-ratis-2.3.0-SNAPSHOT git:(rs-elect) ✗ bin/ratis sh info -peers localhost:19200,localhost:19201,localhost:19202                          
group id: 02511d47-d67c-49a3-9011-abb3109a44c1
leader info: localhost_19202(localhost:19202)

[server {
  id: "localhost_19200"
  address: "localhost:19200"
  priority: 1
}
commitIndex: 16
, server {
  id: "localhost_19202"
  address: "localhost:19202"
  priority: 2
}
commitIndex: 16
, server {
  id: "localhost_19201"
  address: "localhost:19201"
  priority: 1
}
commitIndex: 16
]

```
