### PR TITLE
RATIS-1436.Add ratis-shell GroupInfo command

### DIFF
--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/Command.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/Command.java
@@ -27,6 +27,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * An interface for all the commands that can be run from a shell.
@@ -54,7 +55,7 @@ public interface Command extends Closeable {
    * @return whether this command has sub-commands
    */
   default boolean hasSubCommand() {
-    return false;
+    return Optional.ofNullable(getSubCommands()).filter(subs -> !subs.isEmpty()).isPresent();
   }
 
   /**

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/AbstractRatisCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/AbstractRatisCommand.java
@@ -46,6 +46,18 @@ public abstract class AbstractRatisCommand implements Command {
   public static final String GROUPID_OPTION_NAME = "groupid";
   public static final RaftGroupId DEFAULT_RAFT_GROUP_ID = RaftGroupId.randomId();
 
+  public static InetSocketAddress parseInetSocketAddress(String address) {
+    try {
+      final String[] hostPortPair = address.split(":");
+      if (hostPortPair.length < 2) {
+        throw new IllegalArgumentException("Unexpected address format <HOST:PORT>.");
+      }
+      return new InetSocketAddress(hostPortPair[0], Integer.parseInt(hostPortPair[1]));
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to parse the server address parameter \"" + address + "\".", e);
+    }
+  }
+
   /**
    * Execute a given function with input parameter from the members of a list.
    *
@@ -83,11 +95,8 @@ public abstract class AbstractRatisCommand implements Command {
     List<InetSocketAddress> addresses = new ArrayList<>();
     String peersStr = cl.getOptionValue(PEER_OPTION_NAME);
     String[] peersArray = peersStr.split(",");
-    for (int i = 0; i < peersArray.length; i++) {
-      String[] hostPortPair = peersArray[i].split(":");
-      InetSocketAddress addr =
-          new InetSocketAddress(hostPortPair[0], Integer.parseInt(hostPortPair[1]));
-      addresses.add(addr);
+    for (String peer : peersArray) {
+      addresses.add(parseInetSocketAddress(peer));
     }
 
     final RaftGroupId raftGroupIdFromConfig = cl.hasOption(GROUPID_OPTION_NAME)?

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupCommand.java
@@ -74,7 +74,7 @@ public class GroupCommand extends AbstractRatisCommand {
 
   @Override
   public boolean hasSubCommand() {
-    return Optional.ofNullable(getSubCommands()).filter(subs -> !subs.isEmpty()).isPresent();
+    return Optional.ofNullable(getSubCommands()).filter(sub -> !subs.isEmpty()).isPresent();
   }
 
   @Override

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupCommand.java
@@ -20,8 +20,6 @@ package org.apache.ratis.shell.cli.sh.command;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.ratis.shell.cli.Command;
-import org.apache.ratis.shell.cli.sh.command.AbstractRatisCommand;
-import org.apache.ratis.shell.cli.sh.command.Context;
 import org.apache.ratis.shell.cli.sh.group.GroupInfoCommand;
 import org.apache.ratis.shell.cli.sh.group.GroupListCommand;
 

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupCommand.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.shell.cli.sh.command;
+
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.ratis.shell.cli.Command;
+import org.apache.ratis.shell.cli.sh.command.AbstractRatisCommand;
+import org.apache.ratis.shell.cli.sh.command.Context;
+import org.apache.ratis.shell.cli.sh.group.GroupInfoCommand;
+import org.apache.ratis.shell.cli.sh.group.GroupListCommand;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Command for the ratis group
+ */
+public class GroupCommand extends AbstractRatisCommand {
+
+  private static final Map<String, Function<Context, ? extends Command>>
+          SUB_COMMANDS = new HashMap<>();
+
+  static {
+    SUB_COMMANDS.put("info", GroupInfoCommand::new);
+    SUB_COMMANDS.put("list", GroupListCommand::new);
+  }
+
+  private Map<String, Command> mSubCommands = new HashMap<>();
+
+  /**
+   * @param context command context
+   */
+  public GroupCommand(Context context) {
+    super(context);
+    SUB_COMMANDS.forEach((name, constructor) -> {
+      mSubCommands.put(name, constructor.apply(context));
+    });
+  }
+
+  @Override
+  public String getCommandName() {
+    return "group";
+  }
+
+  @Override
+  public String getUsage() {
+
+    StringBuilder usage = new StringBuilder(getCommandName());
+    for (String cmd : SUB_COMMANDS.keySet()) {
+      usage.append(" [").append(cmd).append("]");
+    }
+    return usage.toString();
+  }
+
+  @Override
+  public String getDescription() {
+    return description();
+  }
+
+  @Override
+  public boolean hasSubCommand() {
+    return true;
+  }
+
+  @Override
+  public Map<String, Command> getSubCommands() {
+    return mSubCommands;
+  }
+
+  @Override
+  public Options getOptions() {
+    return super.getOptions().addOption(
+        Option.builder()
+            .option(GROUPID_OPTION_NAME)
+            .hasArg()
+            .required()
+            .desc("the group id")
+            .build());
+  }
+
+  /**
+   * @return command's description
+   */
+  public static String description() {
+    return "Manage the ratis gropu, See sub-commands' descriptions for more details.";
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupCommand.java
@@ -97,6 +97,6 @@ public class GroupCommand extends AbstractRatisCommand {
    * @return command's description
    */
   public static String description() {
-    return "Manage the ratis gropu, See sub-commands' descriptions for more details.";
+    return "Manage ratis groups; see the sub-commands for the details.";
   }
 }

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupCommand.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -70,11 +69,6 @@ public class GroupCommand extends AbstractRatisCommand {
   @Override
   public String getDescription() {
     return description();
-  }
-
-  @Override
-  public boolean hasSubCommand() {
-    return Optional.ofNullable(getSubCommands()).filter(sub -> !subs.isEmpty()).isPresent();
   }
 
   @Override

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupInfoCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupInfoCommand.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.shell.cli.sh.command;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.protocol.GroupListReply;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.shell.cli.RaftUtils;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+/**
+ * Command for querying the group information of a ratis server.
+ */
+public class GroupInfoCommand extends AbstractRatisCommand{
+  public static final String SERVER_ADDRESS_OPTION_NAME = "serverAddress";
+  /**
+   * @param context command context
+   */
+  public GroupInfoCommand(Context context) {
+    super(context);
+  }
+
+  @Override
+  public String getCommandName() {
+    return "groupInfo";
+  }
+
+  @Override
+  public int run(CommandLine cl) throws IOException {
+    super.run(cl);
+    String strAddr = cl.getOptionValue(SERVER_ADDRESS_OPTION_NAME);
+
+    String[] str = strAddr.split(":");
+    if(str.length < 2) {
+      throw new IllegalArgumentException("Failed to parse the server address parameter \"" + strAddr + "\".");
+    }
+    final InetSocketAddress serverAddress = InetSocketAddress.createUnresolved(str[0], Integer.parseInt(str[1]));
+    final RaftPeerId peerId = RaftUtils.getPeerId(serverAddress);
+
+    try(final RaftClient raftClient = RaftUtils.createClient(getRaftGroup())){
+      GroupListReply reply = raftClient.getGroupManagementApi(peerId).list();
+      processReply(reply, () -> String.format("Failed to get group information of server %s",strAddr));
+      printf(String.format("The server %s is in %d groups, and the groupIds is: %s",
+              strAddr, reply.getGroupIds().size(),reply.getGroupIds()));
+    }
+    return 0;
+  }
+
+  @Override
+  public String getUsage() {
+    return String.format("%s"
+                    + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
+                    + "-%s <PEER0_HOST:PEER0_PORT>",
+            getCommandName(), PEER_OPTION_NAME, SERVER_ADDRESS_OPTION_NAME);
+  }
+
+  @Override
+  public String getDescription() {
+    return description();
+  }
+
+  @Override
+  public Options getOptions() {
+    return super.getOptions().addOption(
+        Option.builder()
+            .option(SERVER_ADDRESS_OPTION_NAME)
+            .hasArg()
+            .required()
+            .desc("the server address")
+            .build());
+  }
+
+  /**
+   * @return command's description
+   */
+  public static String description() {
+    return "Display the group information of a specific raft server";
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/PeerCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/PeerCommand.java
@@ -90,21 +90,12 @@ public class PeerCommand extends AbstractRatisCommand {
     }
     final List<RaftPeerId> ids = new ArrayList<>();
     for (String address : optionValues) {
-      final String[] str = parse(address);
-      final InetSocketAddress serverAddress = InetSocketAddress.createUnresolved(str[0], Integer.parseInt(str[1]));
+      final InetSocketAddress serverAddress = parseInetSocketAddress(address);
       final RaftPeerId peerId = RaftUtils.getPeerId(serverAddress);
       consumer.accept(peerId, serverAddress);
       ids.add(peerId);
     }
     return ids;
-  }
-
-  private static String[] parse(String address) {
-    String[] str = address.split(":");
-    if(str.length < 2) {
-      throw new IllegalArgumentException("Failed to parse the address parameter \"" + address + "\".");
-    }
-    return str;
   }
 
   @Override

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/PeerCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/PeerCommand.java
@@ -40,20 +40,20 @@ import java.util.stream.Stream;
 /**
  * Command for remove and add ratis server.
  */
-public class GroupCommand extends AbstractRatisCommand {
+public class PeerCommand extends AbstractRatisCommand {
   public static final String REMOVE_OPTION_NAME = "remove";
   public static final String ADD_OPTION_NAME = "add";
 
   /**
    * @param context command context
    */
-  public GroupCommand(Context context) {
+  public PeerCommand(Context context) {
     super(context);
   }
 
   @Override
   public String getCommandName() {
-    return "group";
+    return "peer";
   }
 
   @Override

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/group/GroupInfoCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/group/GroupInfoCommand.java
@@ -18,7 +18,6 @@
 package org.apache.ratis.shell.cli.sh.group;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.GroupInfoReply;

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/group/GroupInfoCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/group/GroupInfoCommand.java
@@ -15,24 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.ratis.shell.cli.sh.command;
+package org.apache.ratis.shell.cli.sh.group;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.GroupInfoReply;
+import org.apache.ratis.shell.cli.sh.command.AbstractRatisCommand;
+import org.apache.ratis.shell.cli.sh.command.Context;
 
 import java.io.IOException;
 
 /**
  * Command for querying ratis group information.
  */
-public class InfoCommand extends AbstractRatisCommand {
-
+public class GroupInfoCommand extends AbstractRatisCommand {
   /**
    * @param context command context
    */
-  public InfoCommand(Context context) {
+  public GroupInfoCommand(Context context) {
     super(context);
   }
 

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/group/GroupListCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/group/GroupListCommand.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.ratis.shell.cli.sh.command;
+package org.apache.ratis.shell.cli.sh.group;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -24,6 +24,8 @@ import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.protocol.GroupListReply;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.shell.cli.RaftUtils;
+import org.apache.ratis.shell.cli.sh.command.AbstractRatisCommand;
+import org.apache.ratis.shell.cli.sh.command.Context;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -31,18 +33,19 @@ import java.net.InetSocketAddress;
 /**
  * Command for querying the group information of a ratis server.
  */
-public class GroupInfoCommand extends AbstractRatisCommand{
+public class GroupListCommand extends AbstractRatisCommand {
   public static final String SERVER_ADDRESS_OPTION_NAME = "serverAddress";
+
   /**
    * @param context command context
    */
-  public GroupInfoCommand(Context context) {
+  public GroupListCommand(Context context) {
     super(context);
   }
 
   @Override
   public String getCommandName() {
-    return "groupInfo";
+    return "list";
   }
 
   @Override
@@ -57,21 +60,23 @@ public class GroupInfoCommand extends AbstractRatisCommand{
     final InetSocketAddress serverAddress = InetSocketAddress.createUnresolved(str[0], Integer.parseInt(str[1]));
     final RaftPeerId peerId = RaftUtils.getPeerId(serverAddress);
 
-    try(final RaftClient raftClient = RaftUtils.createClient(getRaftGroup())){
+    try(final RaftClient raftClient = RaftUtils.createClient(getRaftGroup())) {
       GroupListReply reply = raftClient.getGroupManagementApi(peerId).list();
-      processReply(reply, () -> String.format("Failed to get group information of server %s",strAddr));
+      processReply(reply, () -> String.format("Failed to get group information of server %s", strAddr));
       printf(String.format("The server %s is in %d groups, and the groupIds is: %s",
-              strAddr, reply.getGroupIds().size(),reply.getGroupIds()));
+              strAddr, reply.getGroupIds().size(), reply.getGroupIds()));
     }
     return 0;
+
   }
 
   @Override
   public String getUsage() {
     return String.format("%s"
                     + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
+                    + " [-%s <RAFT_GROUP_ID>]"
                     + "-%s <PEER0_HOST:PEER0_PORT>",
-            getCommandName(), PEER_OPTION_NAME, SERVER_ADDRESS_OPTION_NAME);
+            getCommandName(), PEER_OPTION_NAME, GROUPID_OPTION_NAME, SERVER_ADDRESS_OPTION_NAME);
   }
 
   @Override
@@ -81,13 +86,13 @@ public class GroupInfoCommand extends AbstractRatisCommand{
 
   @Override
   public Options getOptions() {
-    return super.getOptions().addOption(
-        Option.builder()
-            .option(SERVER_ADDRESS_OPTION_NAME)
-            .hasArg()
-            .required()
-            .desc("the server address")
-            .build());
+    return super.getOptions()
+            .addOption(Option.builder()
+                    .option(SERVER_ADDRESS_OPTION_NAME)
+                    .hasArg()
+                    .required()
+                    .desc("the server address")
+                    .build());
   }
 
   /**

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/group/GroupListCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/group/GroupListCommand.java
@@ -52,12 +52,7 @@ public class GroupListCommand extends AbstractRatisCommand {
   public int run(CommandLine cl) throws IOException {
     super.run(cl);
     String strAddr = cl.getOptionValue(SERVER_ADDRESS_OPTION_NAME);
-
-    String[] str = strAddr.split(":");
-    if(str.length < 2) {
-      throw new IllegalArgumentException("Failed to parse the server address parameter \"" + strAddr + "\".");
-    }
-    final InetSocketAddress serverAddress = InetSocketAddress.createUnresolved(str[0], Integer.parseInt(str[1]));
+    final InetSocketAddress serverAddress = parseInetSocketAddress(strAddr);
     final RaftPeerId peerId = RaftUtils.getPeerId(serverAddress);
 
     try(final RaftClient raftClient = RaftUtils.createClient(getRaftGroup())) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a sub command to show the group information of a ratis server

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1436

## How was this patch tested?

```
[~/local/myproject/ratis] [group *] -> %  mvn clean install  assembly:single -DskipTests -Dmaven.javadoc.skip=true -Dlicense.skip=true  -Dfindbugs.skip=true -Denforcer.skip=true -Dgpg.skip=true   -Djsse.enableSNIExtension=false  -Prelease -Papache-release
[~/local/myproject/ratis] [group *]-> % cd ratis-assembly/target
[~/local/myproject/ratis/ratis-assembly/target] [group *] -> % tar -xzf apache-ratis-2.3.0-SNAPSHOT-ratis-shell.tar.gz
[~/local/myproject/ratis/ratis-assembly/target] [group *] -> % cd apache-ratis-2.3.0-SNAPSHOT
[~/local/myproject/ratis/ratis-assembly/target/apache-ratis-2.3.0-SNAPSHOT] [group *] -> % bin/ratis sh groupInfo -peers localhost:19200,localhost:19201,localhost:19202 -serverAddress localhost:19200
The server localhost:19200 is in 1 groups, and the groupIds is: [group-ABB3109A44C1]
```