### PR TITLE
RATIS-1445. NettyClientStreamRpc exception handling

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedStreamAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedStreamAsync.java
@@ -114,7 +114,10 @@ public class OrderedStreamAsync {
     final LongFunction<DataStreamWindowRequest> constructor
         = seqNum -> new DataStreamWindowRequest(header, data, seqNum);
     return slidingWindow.submitNewRequest(constructor, this::sendRequestToNetwork).
-           getReplyFuture().whenComplete((r, e) -> requestSemaphore.release());
+           getReplyFuture().whenComplete((r, e) -> {
+      LOG.error("send request error:", e);
+      requestSemaphore.release();
+    });
   }
 
   private void sendRequestToNetwork(DataStreamWindowRequest request){

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedStreamAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedStreamAsync.java
@@ -115,7 +115,7 @@ public class OrderedStreamAsync {
         = seqNum -> new DataStreamWindowRequest(header, data, seqNum);
     return slidingWindow.submitNewRequest(constructor, this::sendRequestToNetwork).
            getReplyFuture().whenComplete((r, e) -> {
-      LOG.error("send request error:", e);
+      LOG.error("Failed to send request, header=" + header, e);
       requestSemaphore.release();
     });
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

NettyClientStreamRpc exception handling：

1. When an exception occurs, clear the clientInvocation's send queue.
2. Write error logs when exceptions occur

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1445
