### PR TITLE
RATIS-1447. Cleanup NettyClientStreamRpc#replies empty queue

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyConfigKeys.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyConfigKeys.java
@@ -19,6 +19,7 @@ package org.apache.ratis.netty;
 
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.thirdparty.io.netty.util.NettyRuntime;
+import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,6 +93,18 @@ public interface NettyConfigKeys {
 
     static void setClientWorkerGroupShare(RaftProperties properties, boolean clientWorkerGroupShare) {
       setBoolean(properties::setBoolean, CLIENT_WORKER_GROUP_SHARE_KEY, clientWorkerGroupShare);
+    }
+
+    String CLIENT_REPLY_QUEUE_GRACE_PERIOD = PREFIX + ".client.reply.queue.grace-period";
+    TimeDuration CLIENT_REPLY_QUEUE_GRACE_PERIOD_DEFAULT = TimeDuration.ONE_SECOND;
+
+    static TimeDuration clientReplyQueueGracePeriod(RaftProperties properties) {
+      return getTimeDuration(properties.getTimeDuration(CLIENT_REPLY_QUEUE_GRACE_PERIOD_DEFAULT.getUnit()),
+          CLIENT_REPLY_QUEUE_GRACE_PERIOD, CLIENT_REPLY_QUEUE_GRACE_PERIOD_DEFAULT, getDefaultLog());
+    }
+
+    static void setClientReplyQueueGracePeriod(RaftProperties properties, TimeDuration timeoutDuration) {
+      setTimeDuration(properties::setTimeDuration, CLIENT_REPLY_QUEUE_GRACE_PERIOD, timeoutDuration);
     }
   }
 

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyConfigKeys.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyConfigKeys.java
@@ -95,16 +95,16 @@ public interface NettyConfigKeys {
       setBoolean(properties::setBoolean, CLIENT_WORKER_GROUP_SHARE_KEY, clientWorkerGroupShare);
     }
 
-    String CLIENT_REPLY_QUEUE_GRACE_PERIOD = PREFIX + ".client.reply.queue.grace-period";
+    String CLIENT_REPLY_QUEUE_GRACE_PERIOD_KEY = PREFIX + ".client.reply.queue.grace-period";
     TimeDuration CLIENT_REPLY_QUEUE_GRACE_PERIOD_DEFAULT = TimeDuration.ONE_SECOND;
 
     static TimeDuration clientReplyQueueGracePeriod(RaftProperties properties) {
       return getTimeDuration(properties.getTimeDuration(CLIENT_REPLY_QUEUE_GRACE_PERIOD_DEFAULT.getUnit()),
-          CLIENT_REPLY_QUEUE_GRACE_PERIOD, CLIENT_REPLY_QUEUE_GRACE_PERIOD_DEFAULT, getDefaultLog());
+          CLIENT_REPLY_QUEUE_GRACE_PERIOD_KEY, CLIENT_REPLY_QUEUE_GRACE_PERIOD_DEFAULT, getDefaultLog());
     }
 
     static void setClientReplyQueueGracePeriod(RaftProperties properties, TimeDuration timeoutDuration) {
-      setTimeDuration(properties::setTimeDuration, CLIENT_REPLY_QUEUE_GRACE_PERIOD, timeoutDuration);
+      setTimeDuration(properties::setTimeDuration, CLIENT_REPLY_QUEUE_GRACE_PERIOD_KEY, timeoutDuration);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

org.apache.ratis.netty.client.NettyClientStreamRpc#replies

```
private final ConcurrentMap<ClientInvocationId, Queue<CompletableFuture<DataStreamReply>>> replies =
      new ConcurrentHashMap<>();
When all data for a streamID has been sent, is it necessary to clear the queue from the map？
```
I would implement a ExpiringMap. If you don't use it for a long time or Queue.size is 0, I delete it from the Map.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1447