### PR TITLE
RATIS-1458. Implement ExceptionDependentRetry#toString

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/retry/ExceptionDependentRetry.java
+++ b/ratis-common/src/main/java/org/apache/ratis/retry/ExceptionDependentRetry.java
@@ -18,11 +18,13 @@
 
 package org.apache.ratis.retry;
 
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Preconditions;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 
 /**
  * Exception dependent retry policy.
@@ -69,7 +71,7 @@ public final class ExceptionDependentRetry implements RetryPolicy {
   private final RetryPolicy defaultPolicy;
   private final Map<String, RetryPolicy> exceptionNameToPolicyMap;
   private final int maxAttempts;
-
+  private final Supplier<String> toStringSupplier;
 
   private ExceptionDependentRetry(RetryPolicy defaultPolicy,
       Map<String, RetryPolicy> policyMap, int maxAttempts) {
@@ -77,6 +79,15 @@ public final class ExceptionDependentRetry implements RetryPolicy {
     this.defaultPolicy = defaultPolicy;
     this.exceptionNameToPolicyMap = Collections.unmodifiableMap(policyMap);
     this.maxAttempts = maxAttempts;
+    this.toStringSupplier = JavaUtils.memoize(() -> {
+      final StringBuilder b = new StringBuilder(JavaUtils.getClassSimpleName(getClass())).append("{")
+          .append("maxAttempts=").append(maxAttempts).append("; ")
+          .append("defaultPolicy=").append(defaultPolicy).append("; ")
+          .append("map=");
+      policyMap.forEach((key, value) -> b.append(key).append("->").append(value).append(", "));
+      b.setLength(b.length() - 2);
+      return b.append("}").toString();
+    });
   }
 
   @Override
@@ -97,5 +108,10 @@ public final class ExceptionDependentRetry implements RetryPolicy {
 
     return event.getAttemptCount() < maxAttempts ? policy.handleAttemptFailure(event::getCauseCount) :
         NO_RETRY_ACTION;
+  }
+
+  @Override
+  public String toString() {
+    return toStringSupplier.get();
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/retry/ExceptionDependentRetry.java
+++ b/ratis-common/src/main/java/org/apache/ratis/retry/ExceptionDependentRetry.java
@@ -80,13 +80,13 @@ public final class ExceptionDependentRetry implements RetryPolicy {
     this.exceptionNameToPolicyMap = Collections.unmodifiableMap(policyMap);
     this.maxAttempts = maxAttempts;
     this.toStringSupplier = JavaUtils.memoize(() -> {
-      final StringBuilder b = new StringBuilder(JavaUtils.getClassSimpleName(getClass())).append("{")
+      final StringBuilder b = new StringBuilder(JavaUtils.getClassSimpleName(getClass())).append("(")
           .append("maxAttempts=").append(maxAttempts).append("; ")
           .append("defaultPolicy=").append(defaultPolicy).append("; ")
-          .append("map=");
+          .append("map={");
       policyMap.forEach((key, value) -> b.append(key).append("->").append(value).append(", "));
       b.setLength(b.length() - 2);
-      return b.append("}").toString();
+      return b.append("})").toString();
     });
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Provide more useful string output for `ExceptionDependentRetry`.  Example:

```
ExceptionDependentRetry(maxAttempts=3; defaultPolicy=RetryLimited(maxAttempts=5, sleepTime=10s); map={java.io.IOException->RetryLimited(maxAttempts=1, sleepTime=1s), org.apache.ratis.protocol.exceptions.TimeoutIOException->RetryLimited(maxAttempts=2, sleepTime=4s)})
```

https://issues.apache.org/jira/browse/RATIS-1458

## How was this patch tested?

Verified `toString` result by temporarily adding assertions about it in `TestExceptionDependentRetry`.

CI
https://github.com/adoroszlai/incubator-ratis/actions/runs/1535418055