### PR TITLE
RATIS-531. TestServerRestartWithGrpc.runTestRestartCommitIndex is flaky

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
@@ -277,7 +277,8 @@ public abstract class ServerRestartTests<CLUSTER extends MiniRaftCluster>
     for(RaftServer.Division s : cluster.iterateDivisions()) {
       if (!s.getId().equals(leaderId)) {
         ids.add(s.getId());
-        RaftTestUtil.assertSameLog(leaderLog, s.getRaftLog());
+        JavaUtils.attempt(() -> RaftTestUtil.assertSameLog(leaderLog, s.getRaftLog()),
+            10, HUNDRED_MILLIS, "assertRaftLog-" + s.getId(), LOG);
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Wait a bit for follower log to catch up to avoid intermittent failure in the test.

https://issues.apache.org/jira/browse/RATIS-531

## How was this patch tested?

Passed 100x:
https://github.com/adoroszlai/incubator-ratis/runs/4409665940
https://github.com/adoroszlai/incubator-ratis/runs/4410084395

Regular CI:
https://github.com/adoroszlai/incubator-ratis/actions/runs/1535984617