### PR TITLE
RATIS-1460. Rename assembly id from ratis-shell to shell

### DIFF
--- a/ratis-assembly/pom.xml
+++ b/ratis-assembly/pom.xml
@@ -127,7 +127,7 @@
             <descriptor>src/main/assembly/src.xml</descriptor>
             <descriptor>src/main/assembly/bin.xml</descriptor>
             <descriptor>src/main/assembly/examples-bin.xml</descriptor>
-            <descriptor>src/main/assembly/ratis-shell.xml</descriptor>
+            <descriptor>src/main/assembly/shell-bin.xml</descriptor>
           </descriptors>
         </configuration>
       </plugin>

--- a/ratis-assembly/src/main/assembly/shell-bin.xml
+++ b/ratis-assembly/src/main/assembly/shell-bin.xml
@@ -15,14 +15,14 @@
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
-  <id>ratis-shell</id>
+  <id>shell</id>
   <formats>
     <format>tar.gz</format>
   </formats>
   <fileSets>
     <fileSet>
       <directory>${project.basedir}/../ratis-shell/target/</directory>
-      <outputDirectory>lib/ratis-shell</outputDirectory>
+      <outputDirectory>lib/shell</outputDirectory>
       <fileMode>755</fileMode>
       <includes>
         <include>ratis-shell-*-jar-with-dependencies.jar</include>

--- a/ratis-shell/src/main/libexec/ratis-shell-config.sh
+++ b/ratis-shell/src/main/libexec/ratis-shell-config.sh
@@ -29,7 +29,7 @@ this="${config_bin}/${script}"
 # This will set the default installation for a tarball installation while os distributors can
 # set system installation locations.
 RATIS_SHELL_HOME=$(dirname $(dirname "${this}"))
-RATIS_SHELL_ASSEMBLY_CLIENT_JAR="${RATIS_SHELL_HOME}/lib/ratis-shell/*"
+RATIS_SHELL_ASSEMBLY_CLIENT_JAR="${RATIS_SHELL_HOME}/lib/shell/*"
 RATIS_SHELL_CONF_DIR="${RATIS_SHELL_CONF_DIR:-${RATIS_SHELL_HOME}/conf}"
 RATIS_SHELL_LOGS_DIR="${RATIS_SHELL_LOGS_DIR:-${RATIS_SHELL_HOME}/logs}"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename the assembly id from ratis-shell to shell to keep simple and meaningful.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1460

## How was this patch tested?

```Console
➜  incubator-ratis git:(rename-ratis-shell) ✗ mvn clean install  assembly:single -DskipTests -Dmaven.javadoc.skip=true -Dlicense.skip=true  -Dfindbugs.skip=true -Denforcer.skip=true   -Djsse.enableSNIExtension=false  -Prelease -Papache-release
➜  incubator-ratis git:(rename-ratis-shell) cd ratis-assembly/target 
➜  target git:(rename-ratis-shell) tar -xzvf apache-ratis-2.3.0-SNAPSHOT-shell.tar.gz
x apache-ratis-2.3.0-SNAPSHOT/lib/shell/ratis-shell-2.3.0-SNAPSHOT-jar-with-dependencies.jar
x apache-ratis-2.3.0-SNAPSHOT/LICENSE
x apache-ratis-2.3.0-SNAPSHOT/NOTICE
x apache-ratis-2.3.0-SNAPSHOT/bin/
x apache-ratis-2.3.0-SNAPSHOT/bin/ratis
x apache-ratis-2.3.0-SNAPSHOT/libexec/
x apache-ratis-2.3.0-SNAPSHOT/libexec/ratis-shell-config.sh
x apache-ratis-2.3.0-SNAPSHOT/conf/
x apache-ratis-2.3.0-SNAPSHOT/conf/log4j.properties

➜  target git:(rename-ratis-shell) cd apache-ratis-2.3.0-SNAPSHOT 
➜  apache-ratis-2.3.0-SNAPSHOT git:(rename-ratis-shell) bin/ratis sh
Usage: ratis sh [generic options]
         [elect -address <HOSTNAME:PORT> -peers <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT> [-groupid <RAFT_GROUP_ID>]]
         [group [list] [info]]                                     
         [peer -peers <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT> [-groupid <RAFT_GROUP_ID>] -remove <PEER_HOST:PEER_PORT> -add <PEER_HOST:PEER_PORT>]
         [setPriority -peers <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT> [-groupid <RAFT_GROUP_ID>] -addressPriority <PEER_HOST:PEER_PORT|PRIORITY>]

```
