### PR TITLE
RATIS-1462. RaftServer started failed when rpc timeout use different unit

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/TimeDuration.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/TimeDuration.java
@@ -338,7 +338,7 @@ public final class TimeDuration implements Comparable<TimeDuration> {
   @Override
   public int compareTo(TimeDuration that) {
     if (this.unit.compareTo(that.unit) > 0) {
-      return that.compareTo(this);
+      return Integer.compare(0, that.compareTo(this));
     }
     if (this.unit == that.unit) {
       return Long.compare(this.duration, that.duration);

--- a/ratis-test/src/test/java/org/apache/ratis/util/TestTimeDuration.java
+++ b/ratis-test/src/test/java/org/apache/ratis/util/TestTimeDuration.java
@@ -30,6 +30,7 @@ import static org.apache.ratis.util.TimeDuration.Abbreviation;
 import static org.apache.ratis.util.TimeDuration.parse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class TestTimeDuration {
   {
@@ -242,6 +243,18 @@ public class TestTimeDuration {
 
     Assert.assertSame(TimeUnit.NANOSECONDS, TimeDuration.lowerUnit(TimeUnit.NANOSECONDS));
     Assert.assertSame(TimeUnit.DAYS, TimeDuration.higherUnit(TimeUnit.DAYS));
+  }
+
+  @Test(timeout = 1000)
+  public void testCompareTo() {
+    assertTrue(TimeDuration.ONE_SECOND.compareTo(TimeDuration.ONE_MINUTE) < 0);
+    assertTrue(TimeDuration.ONE_MINUTE.compareTo(TimeDuration.ONE_SECOND) > 0);
+
+    assertTrue(TimeDuration.valueOf(15, TimeUnit.SECONDS).compareTo(TimeDuration.ONE_MINUTE) < 0);
+    assertTrue(TimeDuration.ONE_MINUTE.compareTo(TimeDuration.valueOf(15, TimeUnit.SECONDS)) > 0);
+
+    assertEquals(0, TimeDuration.valueOf(60, TimeUnit.SECONDS).compareTo(TimeDuration.ONE_MINUTE));
+    assertEquals(0, TimeDuration.ONE_MINUTE.compareTo(TimeDuration.valueOf(60, TimeUnit.SECONDS)));
   }
 
   private static void assertHigherLower(TimeUnit lower, TimeUnit higher) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
RaftServer started failed when rpc timeout use different unit. 

The code analysis shows that the compareTo method of the TimeDuration class has a bug. 
When the unit of this is greater than that, that.compareTo(this) is called, but the return value is not set to a negative value.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1462


## How was this patch tested?
unit tests.
