### PR TITLE
RATIS-1453. The client will hung when streaming writes.

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
@@ -135,7 +135,7 @@ public abstract class Client extends SubCommandBase {
           new GrpcFactory(new org.apache.ratis.conf.Parameters())
               .newRaftClientRpc(ClientId.randomId(), raftProperties));
       RaftPeer[] peers = getPeers();
-      builder.setPrimaryDataStreamServer(peers[i % peers.length]);
+      builder.setPrimaryDataStreamServer(peers[0]);
       RaftClient client = builder.build();
       fileStoreClients.add(new FileStoreClient(client));
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hung occured during the filestore test, which has been described in Issues. The reason for this problem is that we need to use the first node in -- peers as the primary.

For example, if we pick the last node, then in the routetable he doesn't have the next node, so it can't write down. 


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1453
