### PR TITLE
RATIS-1446. Avoid leader election for invalid conf

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
@@ -52,6 +53,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.ratis.util.LifeCycle.State.NEW;
 import static org.apache.ratis.util.LifeCycle.State.RUNNING;
@@ -273,6 +275,10 @@ class LeaderElection implements Runnable {
       throws InterruptedException {
     final ResultAndTerm r;
     final Collection<RaftPeer> others = conf.getOtherPeers(server.getId());
+    if (!conf.containsInBothConfs(server.getId())) {
+      r = new ResultAndTerm(Result.REJECTED, electionTerm);
+      return r;
+    }
     if (others.isEmpty()) {
       r = new ResultAndTerm(Result.PASSED, electionTerm);
     } else {
@@ -345,18 +351,12 @@ class LeaderElection implements Runnable {
   }
 
   private Set<RaftPeerId> getHigherPriorityPeers(RaftConfiguration conf) {
-    Set<RaftPeerId> higherPriorityPeers = new HashSet<>();
-
-    int currPriority = conf.getPeer(server.getId()).getPriority();
-    final Collection<RaftPeer> peers = conf.getAllPeers();
-
-    for (RaftPeer peer : peers) {
-      if (peer.getPriority() > currPriority) {
-        higherPriorityPeers.add(peer.getId());
-      }
-    }
-
-    return higherPriorityPeers;
+    final Optional<Integer> priority = Optional.ofNullable(conf.getPeer(server.getId()))
+        .map(RaftPeer::getPriority);
+    return conf.getAllPeers().stream()
+        .filter(peer -> priority.filter(p -> peer.getPriority() > p).isPresent())
+        .map(RaftPeer::getId)
+        .collect(Collectors.toSet());
   }
 
   private ResultAndTerm waitForResults(Phase phase, long electionTerm, int submitted,

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -272,7 +272,7 @@ class LeaderElection implements Runnable {
 
   private ResultAndTerm submitRequestAndWaitResult(Phase phase, RaftConfigurationImpl conf, long electionTerm)
       throws InterruptedException {
-    if (!conf.containsInConf(server.getId()) && phase == Phase.ELECTION) {
+    if (!conf.containsInConf(server.getId())) {
       return new ResultAndTerm(Result.NOT_IN_CONF, electionTerm);
     }
     final ResultAndTerm r;

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -319,6 +319,7 @@ class LeaderElection implements Runnable {
         switch (r.getResult()) {
           case PASSED:
             return true;
+          case NOT_IN_CONF:
           case SHUTDOWN:
             server.getRaftServer().close();
             return false;
@@ -326,7 +327,6 @@ class LeaderElection implements Runnable {
             continue; // should retry
           case REJECTED:
           case DISCOVERED_A_NEW_TERM:
-          case NOT_IN_CONF:
             final long term = r.maxTerm(server.getState().getCurrentTerm());
             server.changeToFollowerAndPersistMetadata(term, r);
             return false;

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -914,11 +914,10 @@ class LeaderStateImpl implements LeaderState {
     final RaftConfigurationImpl conf = server.getRaftConf();
     final RaftPeer leader = conf.getPeer(server.getId());
     if (leader == null) {
-      LOG.error("{} find leader {} not in the conf {}",
-          this, server.getId(), conf);
+      LOG.error("{} the leader {} is not in the conf {}", this, server.getId(), conf);
       return;
     }
-    int leaderPriority = conf.getPeer(server.getId()).getPriority();
+    int leaderPriority = leader.getPriority();
 
     for (LogAppender logAppender : senders.getSenders()) {
       FollowerInfo followerInfo = logAppender.getFollower();

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -920,13 +920,17 @@ class LeaderStateImpl implements LeaderState {
     int leaderPriority = leader.getPriority();
 
     for (LogAppender logAppender : senders.getSenders()) {
-      FollowerInfo followerInfo = logAppender.getFollower();
-      final RaftPeer follower = followerInfo.getPeer();
+      final FollowerInfo followerInfo = logAppender.getFollower();
+      final RaftPeerId followerID = followerInfo.getPeer().getId();
+      final RaftPeer follower = conf.getPeer(followerID);
+      if (follower == null) {
+        LOG.error("{} the follower {} is not in the conf {}", this, server.getId(), conf);
+        continue;
+      }
       final int followerPriority = follower.getPriority();
       if (followerPriority <= leaderPriority) {
         continue;
       }
-      final RaftPeerId followerID = follower.getId();
       final TermIndex leaderLastEntry = server.getState().getLastEntry();
       if (leaderLastEntry == null) {
         LOG.info("{} send StartLeaderElectionRequest to follower:{} on term:{} because follower's priority:{} " +

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -583,6 +583,12 @@ class RaftServerImpl implements RaftServer.Division,
     if (state.shouldNotifyExtendedNoLeader()) {
       stateMachine.followerEvent().notifyExtendedNoLeader(getRoleInfoProto());
     }
+    // Candidate shall not start leader election in these cases in case of
+    // possible NPE caused by conf.getPeer().getPriority()
+    if (!getRaftConf().containsInBothConfs(getId())) {
+      LOG.warn("{} find invalid configuration {}, skip start leader election", this, getRaftConf());
+      return;
+    }
     // start election
     role.startLeaderElection(this, forceStartLeaderElection);
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -583,12 +583,6 @@ class RaftServerImpl implements RaftServer.Division,
     if (state.shouldNotifyExtendedNoLeader()) {
       stateMachine.followerEvent().notifyExtendedNoLeader(getRoleInfoProto());
     }
-    // Candidate shall not start leader election in these cases in case of
-    // possible NPE caused by conf.getPeer().getPriority()
-    if (!getRaftConf().containsInBothConfs(getId())) {
-      LOG.warn("{} find invalid configuration {}, skip start leader election", this, getRaftConf());
-      return;
-    }
     // start election
     role.startLeaderElection(this, forceStartLeaderElection);
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/VoteContext.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/VoteContext.java
@@ -144,7 +144,11 @@ class VoteContext {
     }
 
     // Check priority
-    final int priority = impl.getRaftConf().getPeer(impl.getId()).getPriority();
+    final RaftPeer peer = conf.getPeer(impl.getId());
+    if (peer == null) {
+      return reject("our server " + impl.getId() + " is not in the conf " + conf);
+    }
+    final int priority = peer.getPriority();
     if (priority <= candidate.getPriority()) {
       return log(true, "our priority " + priority + " <= candidate's priority " + candidate.getPriority());
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Candidate shall not start leader election in these cases in case of possible NPE caused by conf.getPeer().getPriority().
With this patch, the candidate will become a follower again when receiving the future appendEntries request.

 Phenomenon:
The bootstrapped follower becomes the leader after the election timeout somehow, with an empty raft conf. Then in the process of ```yieldLeaderToHigherPriorityPeer```, NPE happens as (null).getPriority(). 
Setconfiguration action takes place at the end of appendEntriesAsync. If we make it possible to raise electiontimeout before this action, we can replay the NPE case.

```
1private void yieldLeaderToHigherPriorityPeer() {
2  if (!server.getInfo().isLeader()) {
3    return;
4  }
5  final RaftConfigurationImpl conf = server.getRaftConf();
6  int leaderPriority = conf.getPeer(server.getId()).getPriority(); 
```

Possible reason:
Network delay/loss? The leader did not send entries in time or the follower did not receive entries. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1446

## How was this patch tested?
Manual simulation in UT.
