### PR TITLE
RATIS-1477. Exclude log4j JMSAppender.class in jar.

### DIFF
--- a/ratis-examples/pom.xml
+++ b/ratis-examples/pom.xml
@@ -162,6 +162,7 @@
                     <exlcude>META-INF/*.SF</exlcude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
+                    <exclude>**/org/apache/log4j/net/JMSAppender.class</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/ratis-experiments/pom.xml
+++ b/ratis-experiments/pom.xml
@@ -129,6 +129,7 @@
                     <exlcude>META-INF/*.SF</exlcude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
+                    <exclude>**/org/apache/log4j/net/JMSAppender.class</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/ratis-shell/pom.xml
+++ b/ratis-shell/pom.xml
@@ -91,6 +91,7 @@
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
+                    <exclude>**/org/apache/log4j/net/JMSAppender.class</exclude>
                   </excludes>
                 </filter>
               </filters>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1477