### PR TITLE
RATIS-1478 NettyClientStreamRpc error reply handling

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
@@ -160,7 +160,8 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
         final DataStreamReply reply = (DataStreamReply) msg;
         LOG.debug("{}: read {}", this, reply);
         clientInvocationId = ClientInvocationId.valueOf(reply.getClientId(), reply.getStreamId());
-        final ReplyQueue queue = reply.isSuccess() ? replies.get(clientInvocationId) : replies.remove(clientInvocationId);
+        final ReplyQueue queue = reply.isSuccess() ? replies.get(clientInvocationId) :
+                replies.remove(clientInvocationId);
         if (queue != null) {
           final CompletableFuture<DataStreamReply> f = queue.poll();
           if (f != null) {

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
@@ -112,6 +112,10 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
       return queue.poll();
     }
 
+    int size() {
+      return queue.size();
+    }
+
     @Override
     public Iterator<CompletableFuture<DataStreamReply>> iterator() {
       return queue.iterator();
@@ -156,11 +160,18 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
         final DataStreamReply reply = (DataStreamReply) msg;
         LOG.debug("{}: read {}", this, reply);
         clientInvocationId = ClientInvocationId.valueOf(reply.getClientId(), reply.getStreamId());
-        final ReplyQueue queue = replies.get(clientInvocationId);
+        final ReplyQueue queue = reply.isSuccess() ? replies.get(clientInvocationId) : replies.remove(clientInvocationId);
         if (queue != null) {
           final CompletableFuture<DataStreamReply> f = queue.poll();
           if (f != null) {
             f.complete(reply);
+
+            if (!reply.isSuccess() && queue.size() > 0) {
+              final IllegalStateException e = new IllegalStateException(
+                  this + ": an earlier request failed with " + reply);
+              queue.forEach(future -> future.completeExceptionally(e));
+            }
+
             final Integer emptyId = queue.getEmptyId();
             if (emptyId != null) {
               timeoutScheduler.onTimeout(replyQueueGracePeriod,
@@ -175,6 +186,8 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
 
       @Override
       public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        LOG.warn(name + ": exceptionCaught", cause);
+
         Optional.ofNullable(clientInvocationId)
             .map(replies::remove)
             .orElse(ReplyQueue.EMPTY)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The stream client sends a packet to the server reply and returns not success. Subsequent requests do not need to be sent to the server because it is a stream.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1478