### PR TITLE
RATIS-1491. TestNettyDataStreamChainTopologyWithGrpcCluster timed out after 100 seconds

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/OutputStreamBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/OutputStreamBaseTest.java
@@ -70,11 +70,6 @@ public abstract class OutputStreamBaseTest<CLUSTER extends MiniRaftCluster>
     return b;
   }
 
-  @Override
-  public int getGlobalTimeoutSeconds() {
-    return 300;
-  }
-
   @Test
   public void testSimpleWrite() throws Exception {
     runWithNewCluster(NUM_SERVERS, this::runTestSimpleWrite);

--- a/ratis-server/src/test/java/org/apache/ratis/OutputStreamBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/OutputStreamBaseTest.java
@@ -70,7 +70,12 @@ public abstract class OutputStreamBaseTest<CLUSTER extends MiniRaftCluster>
     return b;
   }
 
-  @Test(timeout = 300000)
+  @Override
+  public int getGlobalTimeoutSeconds() {
+    return 300;
+  }
+
+  @Test
   public void testSimpleWrite() throws Exception {
     runWithNewCluster(NUM_SERVERS, this::runTestSimpleWrite);
   }

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamAsyncClusterTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamAsyncClusterTests.java
@@ -48,12 +48,17 @@ public abstract class DataStreamAsyncClusterTests<CLUSTER extends MiniRaftCluste
     extends DataStreamClusterTests<CLUSTER> {
   final Executor executor = Executors.newFixedThreadPool(16);
 
+  @Override
+  public int getGlobalTimeoutSeconds() {
+    return 300;
+  }
+
   @Test
   public void testMultipleStreamsSingleServer() throws Exception {
     runWithNewCluster(1, this::runTestDataStream);
   }
 
-  @Test(timeout = 300000)
+  @Test
   public void testMultipleStreamsMultipleServers() throws Exception {
     // Avoid changing leader
     final TimeDuration min = RaftServerConfigKeys.Rpc.timeoutMin(getProperties());
@@ -68,7 +73,7 @@ public abstract class DataStreamAsyncClusterTests<CLUSTER extends MiniRaftCluste
     RaftServerConfigKeys.Rpc.setTimeoutMax(getProperties(), max);
   }
 
-  @Test(timeout = 300000)
+  @Test
   public void testMultipleStreamsMultipleServersStepDownLeader() throws Exception {
     runWithNewCluster(3, this::runTestDataStreamStepDownLeader);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Fix timeout in `DataStreamAsyncClusterTests`.

`testMultipleStreamsMultipleServersStepDownLeader` has 300 seconds timeout, but is frequently stopped after 100 seconds:

```
Tests run: 4, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 205.692 s <<< FAILURE! - in org.apache.ratis.datastream.TestNettyDataStreamChainTopologyWithGrpcCluster
testMultipleStreamsMultipleServersStepDownLeader(org.apache.ratis.datastream.TestNettyDataStreamChainTopologyWithGrpcCluster)  Time elapsed: 100.021 s  <<< ERROR!
org.junit.runners.model.TestTimedOutException: test timed out after 100 seconds
```

Timeout specified in `@Test(timeout = ...)` is limited by the `BaseTest#globalTimeout` rule, which defaults to 100 seconds.  We need to override `getGlobalTimeout()` to increase the rule's timeout.

### Remove ineffective timeout from `OutputStreamBaseTest`.

`OutputStreamBaseTest` also has a test case which intends to increase timeout to 300 seconds.  But this test case normally runs in less than 30 seconds:

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 23.712 s - in org.apache.ratis.grpc.TestRaftOutputStreamWithGrpc
Tests run: 4, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 23.956 s - in org.apache.ratis.grpc.TestGrpcOutputStream
```

and intermittently times out even with 300 seconds (after applying the fix described above for `OutputStreamBaseTests`):

```
Tests run: 4, Failures: 0, Errors: 1, Skipped: 1, Time elapsed: 302.175 s <<< FAILURE! - in org.apache.ratis.grpc.TestGrpcOutputStream
```

So I think we should apply the default 100 seconds timeout to save time in the failure case, and fix the test instead (filed RATIS-1493 for this).

https://issues.apache.org/jira/browse/RATIS-1491

## How was this patch tested?

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 147.409 s - in org.apache.ratis.datastream.TestNettyDataStreamStarTopologyWithGrpcCluster
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 154.069 s - in org.apache.ratis.datastream.TestNettyDataStreamChainTopologyWithGrpcCluster
```

https://github.com/adoroszlai/incubator-ratis/runs/4849875094

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 136.271 s - in org.apache.ratis.datastream.TestNettyDataStreamStarTopologyWithGrpcCluster
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 138.918 s - in org.apache.ratis.datastream.TestNettyDataStreamChainTopologyWithGrpcCluster
```

https://github.com/adoroszlai/incubator-ratis/runs/4854999261