### PR TITLE
RATIS-1495. When DataStreamManagement#read an exception occurs, release ByteBuf

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -385,6 +385,16 @@ public class DataStreamManagement {
       CheckedBiFunction<RaftClientRequest, Set<RaftPeer>, Set<DataStreamOutputRpc>, IOException> getStreams) {
     LOG.debug("{}: read {}", this, request);
     final ByteBuf buf = request.slice();
+    try {
+      readImpl(request, ctx, buf, getStreams);
+    } catch (Throwable t) {
+      buf.release();
+      throw t;
+    }
+  }
+
+  private void readImpl(DataStreamRequestByteBuf request, ChannelHandlerContext ctx, ByteBuf buf,
+      CheckedBiFunction<RaftClientRequest, Set<RaftPeer>, Set<DataStreamOutputRpc>, IOException> getStreams) {
     boolean close = WriteOption.containsOption(request.getWriteOptions(), StandardWriteOption.CLOSE);
     ClientInvocationId key =  ClientInvocationId.valueOf(request.getClientId(), request.getStreamId());
     final StreamInfo info;


### PR DESCRIPTION
## What changes were proposed in this pull request?

When DataStreamManagement#read an exception occurs, release ByteBuf

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1495