### PR TITLE
RATIS-1501. Exclude log4j JMSSink, JDBCAppender, and Chainsaw from the generated jar.

### DIFF
--- a/ratis-examples/pom.xml
+++ b/ratis-examples/pom.xml
@@ -163,7 +163,10 @@
                     <exlcude>META-INF/*.SF</exlcude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
+                    <exclude>**/org/apache/log4j/chainsaw/**</exclude>
+                    <exclude>**/org/apache/log4j/jdbc/JDBCAppender.class</exclude>
                     <exclude>**/org/apache/log4j/net/JMSAppender.class</exclude>
+                    <exclude>**/org/apache/log4j/net/JMSSink.class</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/ratis-experiments/pom.xml
+++ b/ratis-experiments/pom.xml
@@ -129,7 +129,10 @@
                     <exlcude>META-INF/*.SF</exlcude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
+                    <exclude>**/org/apache/log4j/chainsaw/**</exclude>
+                    <exclude>**/org/apache/log4j/jdbc/JDBCAppender.class</exclude>
                     <exclude>**/org/apache/log4j/net/JMSAppender.class</exclude>
+                    <exclude>**/org/apache/log4j/net/JMSSink.class</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/ratis-shell/pom.xml
+++ b/ratis-shell/pom.xml
@@ -91,7 +91,10 @@
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
+                    <exclude>**/org/apache/log4j/chainsaw/**</exclude>
+                    <exclude>**/org/apache/log4j/jdbc/JDBCAppender.class</exclude>
                     <exclude>**/org/apache/log4j/net/JMSAppender.class</exclude>
+                    <exclude>**/org/apache/log4j/net/JMSSink.class</exclude>
                   </excludes>
                 </filter>
               </filters>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1501