### PR TITLE
RATIS-1522. OrderedStreamAsync uses a separate of send thread pool

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/RaftClientConfigKeys.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/RaftClientConfigKeys.java
@@ -113,6 +113,16 @@ public interface RaftClientConfigKeys {
     static void setRequestTimeout(RaftProperties properties, TimeDuration timeoutDuration) {
       setTimeDuration(properties::setTimeDuration, REQUEST_TIMEOUT_KEY, timeoutDuration);
     }
+
+    String SEND_REQUEST_WORKERS_KEY = PREFIX + ".send.request.workers";
+    int SEND_REQUEST_WORKERS_DEFAULT = 10;
+    static int sendRequestWorker(RaftProperties properties) {
+      return getInt(properties::getInt, SEND_REQUEST_WORKERS_KEY,
+          SEND_REQUEST_WORKERS_DEFAULT, getDefaultLog(), requireMin(1));
+    }
+    static void setSendRequestWorker(RaftProperties properties, int sendRequestWorkers) {
+      setInt(properties::setInt, SEND_REQUEST_WORKERS_KEY, sendRequestWorkers);
+    }
   }
 
   interface MessageStream {


### PR DESCRIPTION
## What changes were proposed in this pull request?

OrderedStreamAsync uses a separate of send thread pool

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1522