### PR TITLE
RATIS-1526. Add ratis-shell pause&resume leader election command

### DIFF
--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/AbstractRatisCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/AbstractRatisCommand.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.util.*;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -195,5 +196,19 @@ public abstract class AbstractRatisCommand implements Command {
       printf("%s. Error: %s%n", message, e);
       throw new IOException(message, e);
     }
+  }
+
+  protected List<RaftPeerId> getIds(String[] optionValues, BiConsumer<RaftPeerId, InetSocketAddress> consumer) {
+    if (optionValues == null) {
+      return Collections.emptyList();
+    }
+    final List<RaftPeerId> ids = new ArrayList<>();
+    for (String address : optionValues) {
+      final InetSocketAddress serverAddress = parseInetSocketAddress(address);
+      final RaftPeerId peerId = RaftUtils.getPeerId(serverAddress);
+      consumer.accept(peerId, serverAddress);
+      ids.add(peerId);
+    }
+    return ids;
   }
 }

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/ElectionCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/ElectionCommand.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.shell.cli.sh.command;
+
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.ratis.shell.cli.Command;
+import org.apache.ratis.shell.cli.sh.election.PauseCommand;
+import org.apache.ratis.shell.cli.sh.election.ResumeCommand;
+import org.apache.ratis.shell.cli.sh.election.TransferCommand;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ElectionCommand extends AbstractRatisCommand{
+
+  private static final List<Function<Context, AbstractRatisCommand>> SUB_COMMAND_CONSTRUCTORS
+      = Collections.unmodifiableList(Arrays.asList(
+      TransferCommand::new, PauseCommand::new, ResumeCommand::new));
+
+  private final Map<String, Command> subs;
+  public static final String ADDRESS_OPTION_NAME = "address";
+
+  /**
+   * @param context command context
+   */
+  public ElectionCommand(Context context) {
+    super(context);
+    this.subs = Collections.unmodifiableMap(SUB_COMMAND_CONSTRUCTORS.stream()
+        .map(constructor -> constructor.apply(context))
+        .collect(Collectors.toMap(Command::getCommandName, Function.identity())));
+  }
+
+  @Override
+  public String getCommandName() {
+    return "election";
+  }
+
+  @Override
+  public String getUsage() {
+
+    StringBuilder usage = new StringBuilder(getCommandName());
+    for (String cmd : subs.keySet()) {
+      usage.append(" [").append(cmd).append("]");
+    }
+    return usage.toString();
+  }
+
+  @Override
+  public String getDescription() {
+    return description();
+  }
+
+  @Override
+  public Map<String, Command> getSubCommands() {
+    return subs;
+  }
+
+  @Override
+  public Options getOptions() {
+    return super.getOptions()
+        .addOption(
+        Option.builder()
+            .option(ADDRESS_OPTION_NAME)
+            .hasArg()
+            .required()
+            .desc("the server address")
+            .build());
+  }
+
+  /**
+   * @return command's description
+   */
+  public static String description() {
+    return "Manage ratis leader election; see the sub-commands for the details.";
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/ElectionCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/ElectionCommand.java
@@ -79,12 +79,12 @@ public class ElectionCommand extends AbstractRatisCommand{
   public Options getOptions() {
     return super.getOptions()
         .addOption(
-        Option.builder()
-            .option(ADDRESS_OPTION_NAME)
-            .hasArg()
-            .required()
-            .desc("the server address")
-            .build());
+            Option.builder()
+                .option(ADDRESS_OPTION_NAME)
+                .hasArg()
+                .required()
+                .desc("the server address")
+                .build());
   }
 
   /**

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/GroupCommand.java
@@ -17,38 +17,27 @@
  */
 package org.apache.ratis.shell.cli.sh.command;
 
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.ratis.shell.cli.Command;
 import org.apache.ratis.shell.cli.sh.group.GroupInfoCommand;
 import org.apache.ratis.shell.cli.sh.group.GroupListCommand;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Command for the ratis group
  */
-public class GroupCommand extends AbstractRatisCommand {
+public class GroupCommand extends AbstractParentCommand {
 
   private static final List<Function<Context, AbstractRatisCommand>> SUB_COMMAND_CONSTRUCTORS
           = Collections.unmodifiableList(Arrays.asList(
           GroupInfoCommand::new, GroupListCommand::new));
-
-  private final Map<String, Command> subs;
-
   /**
    * @param context command context
    */
   public GroupCommand(Context context) {
-    super(context);
-    this.subs = Collections.unmodifiableMap(SUB_COMMAND_CONSTRUCTORS.stream()
-            .map(constructor -> constructor.apply(context))
-            .collect(Collectors.toMap(Command::getCommandName, Function.identity())));
+    super(context, SUB_COMMAND_CONSTRUCTORS);
   }
 
   @Override
@@ -57,34 +46,8 @@ public class GroupCommand extends AbstractRatisCommand {
   }
 
   @Override
-  public String getUsage() {
-
-    StringBuilder usage = new StringBuilder(getCommandName());
-    for (String cmd : subs.keySet()) {
-      usage.append(" [").append(cmd).append("]");
-    }
-    return usage.toString();
-  }
-
-  @Override
   public String getDescription() {
     return description();
-  }
-
-  @Override
-  public Map<String, Command> getSubCommands() {
-    return subs;
-  }
-
-  @Override
-  public Options getOptions() {
-    return super.getOptions().addOption(
-        Option.builder()
-            .option(GROUPID_OPTION_NAME)
-            .hasArg()
-            .required()
-            .desc("the group id")
-            .build());
   }
 
   /**

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/LeaderElectionCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/LeaderElectionCommand.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.shell.cli.sh.command;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.shell.cli.RaftUtils;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class LeaderElectionCommand extends AbstractRatisCommand{
+  public static final String ADDRESS_OPTION_NAME = "address";
+  public static final String PAUSE_OPTION_NAME = "pause";
+  public static final String RESUME_OPTION_NAME = "resume";
+
+  /**
+   * @param context command context
+   */
+  public LeaderElectionCommand(Context context) {
+    super(context);
+  }
+
+  @Override
+  public String getCommandName() {
+    return "leaderElection";
+  }
+
+  @Override
+  public int run(CommandLine cl) throws IOException {
+    super.run(cl);
+
+    String strAddr = cl.getOptionValue(ADDRESS_OPTION_NAME);
+    final RaftPeerId peerId;
+    Optional<RaftPeer> peer =
+        getRaftGroup().getPeers().stream().filter(p -> p.getAddress().equals(strAddr)).findAny();
+    if (peer.isPresent()) {
+      peerId = peer.get().getId();
+    } else {
+      printf("Can't find a sever with the address:%s", strAddr);
+      return -1;
+    }
+    try(final RaftClient raftClient = RaftUtils.createClient(getRaftGroup())) {
+      RaftClientReply reply;
+      if (cl.hasOption(PAUSE_OPTION_NAME) && cl.hasOption(RESUME_OPTION_NAME)) {
+        printf("Can't pause and resume leader election to a sever at the same time");
+        return -1;
+      } else if (cl.hasOption(PAUSE_OPTION_NAME)) {
+        reply = raftClient.getLeaderElectionManagementApi(peerId).pause();
+        processReply(reply, () -> String.format("Failed to pause leader election of peer %s", strAddr));
+      } else if (cl.hasOption(RESUME_OPTION_NAME)) {
+        reply = raftClient.getLeaderElectionManagementApi(peerId).resume();
+        processReply(reply, () -> String.format("Failed to resume leader election of peer %s", strAddr));
+      } else {
+        printf("Failed to execute command, missing option %s or s%", PAUSE_OPTION_NAME, RESUME_OPTION_NAME);
+        return -1;
+      }
+      printf(String.format("Successful execute command on peer %s", strAddr));
+    }
+    return 0;
+  }
+
+  @Override
+  public String getUsage() {
+    return String.format("%s -%s <HOSTNAME:PORT>"
+            + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
+            + " [-%s <RAFT_GROUP_ID>]"
+            + " [-%s, -%s]",
+        getCommandName(), ADDRESS_OPTION_NAME, PEER_OPTION_NAME,
+        GROUPID_OPTION_NAME, PAUSE_OPTION_NAME, RESUME_OPTION_NAME);
+  }
+
+  @Override
+  public String getDescription() {
+    return description();
+  }
+
+  @Override
+  public Options getOptions() {
+    return super.getOptions()
+        .addOption(Option.builder()
+            .option(ADDRESS_OPTION_NAME)
+            .hasArg()
+            .required()
+            .desc("Server address that will be paused or resume its leader election")
+            .build())
+        .addOption(Option.builder()
+            .option(PAUSE_OPTION_NAME)
+            .desc("Pause leader election on the specific server")
+            .build())
+        .addOption(Option.builder()
+            .option(RESUME_OPTION_NAME)
+            .desc("Resume leader election on the specific server")
+            .build());
+  }
+
+  /**
+   * @return command's description
+   */
+  public static String description() {
+    return "Pause or resume leader election to the server <hostname>:<port>";
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/PeerCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/PeerCommand.java
@@ -17,38 +17,29 @@
  */
 package org.apache.ratis.shell.cli.sh.command;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.ratis.client.RaftClient;
-import org.apache.ratis.protocol.RaftClientReply;
-import org.apache.ratis.protocol.RaftPeer;
-import org.apache.ratis.protocol.RaftPeerId;
-import org.apache.ratis.shell.cli.RaftUtils;
+import org.apache.ratis.shell.cli.sh.peer.AddCommand;
+import org.apache.ratis.shell.cli.sh.peer.RemoveCommand;
+import org.apache.ratis.shell.cli.sh.peer.SetPriorityCommand;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.function.Function;
 
 /**
- * Command for remove and add ratis server.
+ * Command for the ratis peer
  */
-public class PeerCommand extends AbstractRatisCommand {
-  public static final String REMOVE_OPTION_NAME = "remove";
-  public static final String ADD_OPTION_NAME = "add";
+public class PeerCommand extends AbstractParentCommand{
+
+  private static final List<Function<Context, AbstractRatisCommand>> SUB_COMMAND_CONSTRUCTORS
+      = Collections.unmodifiableList(Arrays.asList(AddCommand::new, RemoveCommand::new,
+      SetPriorityCommand::new));
 
   /**
    * @param context command context
    */
   public PeerCommand(Context context) {
-    super(context);
+    super(context, SUB_COMMAND_CONSTRUCTORS);
   }
 
   @Override
@@ -57,82 +48,14 @@ public class PeerCommand extends AbstractRatisCommand {
   }
 
   @Override
-  public int run(CommandLine cl) throws IOException {
-    super.run(cl);
-    final Map<RaftPeerId, InetSocketAddress> peersInfo = new HashMap<>();
-    final List<RaftPeerId> toRemove = getIds(cl.getOptionValues(REMOVE_OPTION_NAME), (a, b) -> {});
-    final List<RaftPeerId> toAdd = getIds(cl.getOptionValues(ADD_OPTION_NAME), peersInfo::put);
-    if (toRemove.isEmpty() && toAdd.isEmpty()) {
-      throw new IllegalArgumentException(String.format("Both -%s and -%s options are empty",
-          REMOVE_OPTION_NAME, ADD_OPTION_NAME));
-    }
-
-    try (RaftClient client = RaftUtils.createClient(getRaftGroup())) {
-      final Stream<RaftPeer> remaining = getRaftGroup().getPeers().stream()
-          .filter(raftPeer -> !toRemove.contains(raftPeer.getId()))
-          .filter(raftPeer -> !toAdd.contains(raftPeer.getId()));
-      final Stream<RaftPeer> adding = toAdd.stream().map(raftPeerId -> RaftPeer.newBuilder()
-          .setId(raftPeerId)
-          .setAddress(peersInfo.get(raftPeerId))
-          .setPriority(0)
-          .build());
-      final List<RaftPeer> peers = Stream.concat(remaining, adding).collect(Collectors.toList());
-      System.out.println("New peer list: " + peers);
-      RaftClientReply reply = client.admin().setConfiguration(peers);
-      processReply(reply, () -> "failed to change raft peer");
-    }
-    return 0;
-  }
-
-  private static List<RaftPeerId> getIds(String[] optionValues, BiConsumer<RaftPeerId, InetSocketAddress> consumer) {
-    if (optionValues == null) {
-      return Collections.emptyList();
-    }
-    final List<RaftPeerId> ids = new ArrayList<>();
-    for (String address : optionValues) {
-      final InetSocketAddress serverAddress = parseInetSocketAddress(address);
-      final RaftPeerId peerId = RaftUtils.getPeerId(serverAddress);
-      consumer.accept(peerId, serverAddress);
-      ids.add(peerId);
-    }
-    return ids;
-  }
-
-  @Override
-  public String getUsage() {
-    return String.format("%s"
-                    + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
-                    + " [-%s <RAFT_GROUP_ID>]"
-                    + " -%s <PEER_HOST:PEER_PORT>"
-                    + " -%s <PEER_HOST:PEER_PORT>",
-            getCommandName(), PEER_OPTION_NAME, GROUPID_OPTION_NAME,
-            REMOVE_OPTION_NAME, ADD_OPTION_NAME);
-  }
-
-  @Override
   public String getDescription() {
     return description();
-  }
-
-  @Override
-  public Options getOptions() {
-    return super.getOptions()
-            .addOption(Option.builder()
-                    .option(REMOVE_OPTION_NAME)
-                    .hasArg()
-                    .desc("peer address to be removed")
-                    .build())
-            .addOption(Option.builder()
-                    .option(ADD_OPTION_NAME)
-                    .hasArg()
-                    .desc("peer address to be added")
-                    .build());
   }
 
   /**
    * @return command's description
    */
   public static String description() {
-    return "Remove or Add peers of a ratis group";
+    return "Manage ratis peers; see the sub-commands for the details.";
   }
 }

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/SnapshotCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/command/SnapshotCommand.java
@@ -17,36 +17,25 @@
  */
 package org.apache.ratis.shell.cli.sh.command;
 
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.ratis.shell.cli.Command;
 import org.apache.ratis.shell.cli.sh.snapshot.TakeSnapshotCommand;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Command for the ratis snapshot
  */
-public class SnapshotCommand extends AbstractRatisCommand {
-
+public class SnapshotCommand extends AbstractParentCommand {
   private static final List<Function<Context, AbstractRatisCommand>> SUB_COMMAND_CONSTRUCTORS
       = Collections.unmodifiableList(Arrays.asList(TakeSnapshotCommand::new));
-
-  private final Map<String, Command> subs;
 
   /**
    * @param context command context
    */
   public SnapshotCommand(Context context) {
-    super(context);
-    this.subs = Collections.unmodifiableMap(SUB_COMMAND_CONSTRUCTORS.stream()
-        .map(constructor -> constructor.apply(context))
-        .collect(Collectors.toMap(Command::getCommandName, Function.identity())));
+    super(context, SUB_COMMAND_CONSTRUCTORS);
   }
 
   @Override
@@ -55,34 +44,8 @@ public class SnapshotCommand extends AbstractRatisCommand {
   }
 
   @Override
-  public String getUsage() {
-
-    StringBuilder usage = new StringBuilder(getCommandName());
-    for (String cmd : subs.keySet()) {
-      usage.append(" [").append(cmd).append("]");
-    }
-    return usage.toString();
-  }
-
-  @Override
   public String getDescription() {
     return description();
-  }
-
-  @Override
-  public Map<String, Command> getSubCommands() {
-    return subs;
-  }
-
-  @Override
-  public Options getOptions() {
-    return super.getOptions().addOption(
-        Option.builder()
-            .option(GROUPID_OPTION_NAME)
-            .hasArg()
-            .required()
-            .desc("the group id")
-            .build());
   }
 
   /**

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/election/PauseCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/election/PauseCommand.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.shell.cli.sh.election;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.shell.cli.RaftUtils;
+import org.apache.ratis.shell.cli.sh.command.AbstractRatisCommand;
+import org.apache.ratis.shell.cli.sh.command.Context;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Command for pause leader election on specific server
+ */
+public class PauseCommand extends AbstractRatisCommand {
+
+  public static final String ADDRESS_OPTION_NAME = "address";
+  /**
+   * @param context command context
+   */
+  public PauseCommand(Context context) {
+    super(context);
+  }
+
+  @Override
+  public String getCommandName() {
+    return "pause";
+  }
+
+  @Override
+  public int run(CommandLine cl) throws IOException {
+    super.run(cl);
+
+    String strAddr = cl.getOptionValue(ADDRESS_OPTION_NAME);
+    final RaftPeerId peerId;
+    Optional<RaftPeer> peer =
+        getRaftGroup().getPeers().stream().filter(p -> p.getAddress().equals(strAddr)).findAny();
+    if (peer.isPresent()) {
+      peerId = peer.get().getId();
+    } else {
+      printf("Can't find a sever with the address:%s", strAddr);
+      return -1;
+    }
+    try(final RaftClient raftClient = RaftUtils.createClient(getRaftGroup())) {
+      RaftClientReply reply = raftClient.getLeaderElectionManagementApi(peerId).pause();
+      processReply(reply, () -> String.format("Failed to pause leader election on peer %s", strAddr));
+      printf(String.format("Successful pause leader election on peer %s", strAddr));
+    }
+    return 0;
+  }
+
+  @Override
+  public String getUsage() {
+    return String.format("%s -%s <HOSTNAME:PORT>"
+            + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
+            + " [-%s <RAFT_GROUP_ID>]",
+        getCommandName(), ADDRESS_OPTION_NAME, PEER_OPTION_NAME,
+        GROUPID_OPTION_NAME);
+  }
+
+  @Override
+  public String getDescription() {
+    return description();
+  }
+
+  @Override
+  public Options getOptions() {
+    return super.getOptions().addOption(
+        Option.builder()
+            .option(ADDRESS_OPTION_NAME)
+            .hasArg()
+            .required()
+            .desc("Server address that will be paused its leader election")
+            .build()
+    );
+  }
+
+  /**
+   * @return command's description
+   */
+  public static String description() {
+    return "Pause leader election to the server <hostname>:<port>";
+  }
+}

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/election/PauseCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/election/PauseCommand.java
@@ -29,7 +29,6 @@ import org.apache.ratis.shell.cli.sh.command.AbstractRatisCommand;
 import org.apache.ratis.shell.cli.sh.command.Context;
 
 import java.io.IOException;
-import java.util.Optional;
 
 /**
  * Command for pause leader election on specific server
@@ -54,13 +53,12 @@ public class PauseCommand extends AbstractRatisCommand {
     super.run(cl);
 
     String strAddr = cl.getOptionValue(ADDRESS_OPTION_NAME);
-    final RaftPeerId peerId;
-    Optional<RaftPeer> peer =
-        getRaftGroup().getPeers().stream().filter(p -> p.getAddress().equals(strAddr)).findAny();
-    if (peer.isPresent()) {
-      peerId = peer.get().getId();
-    } else {
-      printf("Can't find a sever with the address:%s", strAddr);
+    final RaftPeerId peerId = getRaftGroup().getPeers().stream()
+        .filter(p -> p.getAddress().equals(strAddr)).findAny()
+        .map(RaftPeer::getId)
+        .orElse(null);
+    if (peerId == null) {
+      printf("Peer not found: %s", strAddr);
       return -1;
     }
     try(final RaftClient raftClient = RaftUtils.createClient(getRaftGroup())) {

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/election/TransferCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/election/TransferCommand.java
@@ -128,5 +128,4 @@ public class TransferCommand extends AbstractRatisCommand {
   public static String description() {
     return "Transfers leadership to the <hostname>:<port>";
   }
-
 }

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/election/TransferCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/election/TransferCommand.java
@@ -15,16 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.ratis.shell.cli.sh.command;
+package org.apache.ratis.shell.cli.sh.election;
 
-import org.apache.commons.cli.Option;
-import org.apache.ratis.shell.cli.RaftUtils;
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.shell.cli.RaftUtils;
+import org.apache.ratis.shell.cli.sh.command.AbstractRatisCommand;
+import org.apache.ratis.shell.cli.sh.command.Context;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,21 +34,20 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Command for transferring the leadership to another peer.
+ * Command for transferring the ratis leader to specific server.
  */
-public class ElectCommand extends AbstractRatisCommand {
+public class TransferCommand extends AbstractRatisCommand {
   public static final String ADDRESS_OPTION_NAME = "address";
-
   /**
    * @param context command context
    */
-  public ElectCommand(Context context) {
+  public TransferCommand(Context context) {
     super(context);
   }
 
   @Override
   public String getCommandName() {
-    return "elect";
+    return "transfer";
   }
 
   @Override
@@ -98,8 +99,8 @@ public class ElectCommand extends AbstractRatisCommand {
   @Override
   public String getUsage() {
     return String.format("%s -%s <HOSTNAME:PORT>"
-        + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
-        + " [-%s <RAFT_GROUP_ID>]",
+            + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
+            + " [-%s <RAFT_GROUP_ID>]",
         getCommandName(), ADDRESS_OPTION_NAME, PEER_OPTION_NAME,
         GROUPID_OPTION_NAME);
   }
@@ -127,4 +128,5 @@ public class ElectCommand extends AbstractRatisCommand {
   public static String description() {
     return "Transfers leadership to the <hostname>:<port>";
   }
+
 }

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/peer/AddCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/peer/AddCommand.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.ratis.shell.cli.sh.election;
+package org.apache.ratis.shell.cli.sh.peer;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -29,53 +29,59 @@ import org.apache.ratis.shell.cli.sh.command.AbstractRatisCommand;
 import org.apache.ratis.shell.cli.sh.command.Context;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
- * Command for resuming leader election on specific server
+ * Command for add ratis server.
  */
-public class ResumeCommand extends AbstractRatisCommand {
+public class AddCommand extends AbstractRatisCommand {
 
   public static final String ADDRESS_OPTION_NAME = "address";
   /**
    * @param context command context
    */
-  public ResumeCommand(Context context) {
+  public AddCommand(Context context) {
     super(context);
   }
 
   @Override
   public String getCommandName() {
-    return "resume";
+    return "add";
   }
 
   @Override
   public int run(CommandLine cl) throws IOException {
     super.run(cl);
-
-    String strAddr = cl.getOptionValue(ADDRESS_OPTION_NAME);
-    final RaftPeerId peerId = getRaftGroup().getPeers().stream()
-        .filter(p -> p.getAddress().equals(strAddr)).findAny()
-        .map(RaftPeer::getId)
-        .orElse(null);
-    if (peerId == null) {
-      printf("Can't find a sever with the address:%s", strAddr);
-      return -1;
-    }
-    try(final RaftClient raftClient = RaftUtils.createClient(getRaftGroup())) {
-      RaftClientReply reply = raftClient.getLeaderElectionManagementApi(peerId).resume();
-      processReply(reply, () -> String.format("Failed to resume leader election on peer %s", strAddr));
-      printf(String.format("Successful pause leader election on peer %s", strAddr));
+    final Map<RaftPeerId, InetSocketAddress> peersInfo = new HashMap<>();
+    final List<RaftPeerId> ids =
+        getIds(cl.getOptionValue(ADDRESS_OPTION_NAME).split(","), peersInfo::put);
+    try (RaftClient client = RaftUtils.createClient(getRaftGroup())) {
+      final Stream<RaftPeer> remaining = getRaftGroup().getPeers().stream();
+      final Stream<RaftPeer> adding = ids.stream().map(raftPeerId -> RaftPeer.newBuilder()
+          .setId(raftPeerId)
+          .setAddress(peersInfo.get(raftPeerId))
+          .setPriority(0)
+          .build());
+      final List<RaftPeer> peers = Stream.concat(remaining, adding).collect(Collectors.toList());
+      System.out.println("New peer list: " + peers);
+      RaftClientReply reply = client.admin().setConfiguration(peers);
+      processReply(reply, () -> "Failed to change raft peer");
     }
     return 0;
   }
 
   @Override
   public String getUsage() {
-    return String.format("%s -%s <HOSTNAME:PORT>"
+    return String.format("%s"
             + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
-            + " [-%s <RAFT_GROUP_ID>]",
-        getCommandName(), ADDRESS_OPTION_NAME, PEER_OPTION_NAME,
-        GROUPID_OPTION_NAME);
+            + " [-%s <RAFT_GROUP_ID>]"
+            + " -%s <PEER_HOST:PEER_PORT>",
+        getCommandName(), PEER_OPTION_NAME, GROUPID_OPTION_NAME, ADDRESS_OPTION_NAME);
   }
 
   @Override
@@ -90,15 +96,14 @@ public class ResumeCommand extends AbstractRatisCommand {
             .option(ADDRESS_OPTION_NAME)
             .hasArg()
             .required()
-            .desc("Server address that will be resumed its leader election")
-            .build()
-    );
+            .desc("The address information of ratis peers")
+            .build());
   }
 
   /**
    * @return command's description
    */
   public static String description() {
-    return "Resume leader election to the server <hostname>:<port>";
+    return "Add peers to a ratis group";
   }
 }

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/peer/SetPriorityCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/peer/SetPriorityCommand.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.ratis.shell.cli.sh.command;
+package org.apache.ratis.shell.cli.sh.peer;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -24,6 +24,8 @@ import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.shell.cli.RaftUtils;
+import org.apache.ratis.shell.cli.sh.command.AbstractRatisCommand;
+import org.apache.ratis.shell.cli.sh.command.Context;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,10 +33,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- *  Command for setting priority of the specific ratis server.
- */
 public class SetPriorityCommand extends AbstractRatisCommand {
+
   public static final String PEER_WITH_NEW_PRIORITY_OPTION_NAME = "addressPriority";
 
   /**
@@ -69,13 +69,13 @@ public class SetPriorityCommand extends AbstractRatisCommand {
           peers.add(RaftPeer.newBuilder(peer).build());
         } else {
           peers.add(RaftPeer.newBuilder(peer)
-                          .setPriority(addressPriorityMap.get(peer.getAddress()))
-                          .build()
+              .setPriority(addressPriorityMap.get(peer.getAddress()))
+              .build()
           );
         }
       }
       RaftClientReply reply = client.admin().setConfiguration(peers);
-      processReply(reply, () -> "failed to set master priorities ");
+      processReply(reply, () -> "Failed to set master priorities ");
     }
     return 0;
   }
@@ -83,10 +83,10 @@ public class SetPriorityCommand extends AbstractRatisCommand {
   @Override
   public String getUsage() {
     return String.format("%s"
-                    + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
-                    + " [-%s <RAFT_GROUP_ID>]"
-                    + " -%s <PEER_HOST:PEER_PORT|PRIORITY>",
-            getCommandName(), PEER_OPTION_NAME, GROUPID_OPTION_NAME, PEER_WITH_NEW_PRIORITY_OPTION_NAME);
+            + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
+            + " [-%s <RAFT_GROUP_ID>]"
+            + " -%s <PEER_HOST:PEER_PORT|PRIORITY>",
+        getCommandName(), PEER_OPTION_NAME, GROUPID_OPTION_NAME, PEER_WITH_NEW_PRIORITY_OPTION_NAME);
   }
 
   @Override
@@ -97,12 +97,12 @@ public class SetPriorityCommand extends AbstractRatisCommand {
   @Override
   public Options getOptions() {
     return super.getOptions().addOption(
-            Option.builder()
-                 .option(PEER_WITH_NEW_PRIORITY_OPTION_NAME)
-                 .hasArg()
-                 .required()
-                 .desc("Peers information with priority")
-                 .build());
+        Option.builder()
+            .option(PEER_WITH_NEW_PRIORITY_OPTION_NAME)
+            .hasArg()
+            .required()
+            .desc("Peers information with priority")
+            .build());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a sub command to pause and resume leader election on the specific peer.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1526

## How was this patch tested?
UT
