### PR TITLE
RATIS-1534. SegmentedRaftLogWorker support async flush

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -348,6 +348,17 @@ public interface RaftServerConfigKeys {
       setInt(properties::setInt, FORCE_SYNC_NUM_KEY, forceSyncNum);
     }
 
+
+    String ASYNC_FLUSH_ENABLE_KEY = PREFIX + ".async.flush";
+    boolean ASYNC_FLUSH_ENABLE_DEFAULT = false;
+    static boolean asyncFlushEnabled(RaftProperties properties) {
+      return getBoolean(properties::getBoolean,
+              ASYNC_FLUSH_ENABLE_KEY, ASYNC_FLUSH_ENABLE_DEFAULT, getDefaultLog());
+    }
+    static void setAsyncFlush(RaftProperties properties, boolean asyncFlush) {
+      setBoolean(properties::setBoolean, ASYNC_FLUSH_ENABLE_KEY, asyncFlush);
+    }
+
     /** The policy to handle corrupted raft log. */
     enum CorruptionPolicy {
       /** Rethrow the exception. */


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request adds a configurable change that allows raft logEntry to not flush to disk immediately after a write. Instead, it will check whether flush is required in the run loop of RaftLogWorker, and we set a minimum flush interval to reduce the number of disk io.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1534

## How was this patch tested?

We use the ozone freon ockg tool to detect the effect of the changes, testing the command:

```
bin/ozone freon ockg  --volume=volume  --bucket=defaultbucket  --thread=10 --number-of-tests=300  --size=`expr 32 \* 1048576` --prefix=stream
```

We tested the speed of writing 32MB and 128MB objects before and after enabling asynchronous flush

![image](https://user-images.githubusercontent.com/20393870/155646950-a2373a74-7ae8-4fba-845f-2b5dddb5143f.png)



After using async log flush, the average write speed will increase by about 25%
