### PR TITLE
RATIS-1540. Support listeners in AdminApi, SetConfigurationRequest and proto.

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/api/AdminApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/AdminApi.java
@@ -23,6 +23,7 @@ import org.apache.ratis.protocol.RaftPeerId;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -30,12 +31,24 @@ import java.util.List;
  * such as setting raft configuration and transferring leadership.
  */
 public interface AdminApi {
-  /** Set the configuration request to the raft service. */
-  RaftClientReply setConfiguration(List<RaftPeer> serversInNewConf) throws IOException;
+  /** The same as setConfiguration(serversInNewConf, Collections.emptyList()). */
+  default RaftClientReply setConfiguration(List<RaftPeer> serversInNewConf) throws IOException {
+    return setConfiguration(serversInNewConf, Collections.emptyList());
+  }
 
   /** The same as setConfiguration(Arrays.asList(serversInNewConf)). */
   default RaftClientReply setConfiguration(RaftPeer[] serversInNewConf) throws IOException {
     return setConfiguration(Arrays.asList(serversInNewConf));
+  }
+
+  /** Set the configuration request to the raft service. */
+  RaftClientReply setConfiguration(List<RaftPeer> serversInNewConf, List<RaftPeer> listenersInNewConf)
+      throws IOException;
+
+  /** The same as setConfiguration(Arrays.asList(serversInNewConf), Arrays.asList(listenersInNewConf)). */
+  default RaftClientReply setConfiguration(RaftPeer[] serversInNewConf, RaftPeer[] listenersInNewConf)
+      throws IOException {
+    return setConfiguration(Arrays.asList(serversInNewConf), Arrays.asList(listenersInNewConf));
   }
 
   /** Transfer leadership to the given server.*/

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/AdminImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/AdminImpl.java
@@ -37,14 +37,15 @@ class AdminImpl implements AdminApi {
   }
 
   @Override
-  public RaftClientReply setConfiguration(List<RaftPeer> peersInNewConf) throws IOException {
+  public RaftClientReply setConfiguration(List<RaftPeer> peersInNewConf, List<RaftPeer> listenersInNewConf)
+      throws IOException {
     Objects.requireNonNull(peersInNewConf, "peersInNewConf == null");
 
     final long callId = CallId.getAndIncrement();
     // also refresh the rpc proxies for these peers
     client.getClientRpc().addRaftPeers(peersInNewConf);
     return client.io().sendRequestWithRetry(() -> new SetConfigurationRequest(
-        client.getId(), client.getLeaderId(), client.getGroupId(), callId, peersInNewConf));
+        client.getId(), client.getLeaderId(), client.getGroupId(), callId, peersInNewConf, listenersInNewConf));
   }
 
   @Override

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
@@ -501,11 +501,12 @@ public interface ClientProtoUtils {
       SetConfigurationRequestProto p) {
     final RaftRpcRequestProto m = p.getRpcRequest();
     final List<RaftPeer> peers = ProtoUtils.toRaftPeers(p.getPeersList());
+    final List<RaftPeer> listeners = ProtoUtils.toRaftPeers(p.getListenersList());
     return new SetConfigurationRequest(
         ClientId.valueOf(m.getRequestorId()),
         RaftPeerId.valueOf(m.getReplyId()),
         ProtoUtils.toRaftGroupId(m.getRaftGroupId()),
-        p.getRpcRequest().getCallId(), peers);
+        p.getRpcRequest().getCallId(), peers, listeners);
   }
 
   static SetConfigurationRequestProto toSetConfigurationRequestProto(
@@ -513,6 +514,7 @@ public interface ClientProtoUtils {
     return SetConfigurationRequestProto.newBuilder()
         .setRpcRequest(toRaftRpcRequestProtoBuilder(request))
         .addAllPeers(ProtoUtils.toRaftPeerProtos(request.getPeersInNewConf()))
+        .addAllListeners(ProtoUtils.toRaftPeerProtos(request.getListenersInNewConf()))
         .build();
   }
 

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/SetConfigurationRequest.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/SetConfigurationRequest.java
@@ -24,16 +24,23 @@ import java.util.List;
 
 public class SetConfigurationRequest extends RaftClientRequest {
   private final List<RaftPeer> peers;
+  private final List<RaftPeer> listeners;
 
   public SetConfigurationRequest(ClientId clientId, RaftPeerId serverId,
-      RaftGroupId groupId, long callId, List<RaftPeer> peers) {
+      RaftGroupId groupId, long callId, List<RaftPeer> peers, List<RaftPeer> listeners) {
     super(clientId, serverId, groupId, callId, true, writeRequestType());
     this.peers = peers != null? Collections.unmodifiableList(peers): Collections.emptyList();
+    this.listeners = listeners !=  null? Collections.unmodifiableList(listeners) : Collections.emptyList();
     Preconditions.assertUnique(this.peers);
+    Preconditions.assertUnique(this.listeners);
   }
 
   public List<RaftPeer> getPeersInNewConf() {
     return peers;
+  }
+
+  public List<RaftPeer> getListenersInNewConf() {
+    return listeners;
   }
 
   @Override

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/SetConfigurationRequest.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/SetConfigurationRequest.java
@@ -27,6 +27,11 @@ public class SetConfigurationRequest extends RaftClientRequest {
   private final List<RaftPeer> listeners;
 
   public SetConfigurationRequest(ClientId clientId, RaftPeerId serverId,
+      RaftGroupId groupId, long callId, List<RaftPeer> peers) {
+    this(clientId, serverId, groupId, callId, peers, Collections.emptyList());
+  }
+
+  public SetConfigurationRequest(ClientId clientId, RaftPeerId serverId,
       RaftGroupId groupId, long callId, List<RaftPeer> peers, List<RaftPeer> listeners) {
     super(clientId, serverId, groupId, callId, true, writeRequestType());
     this.peers = peers != null? Collections.unmodifiableList(peers): Collections.emptyList();

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -51,6 +51,8 @@ message RaftGroupMemberIdProto {
 message RaftConfigurationProto {
   repeated RaftPeerProto peers = 1; // the peers in the current or new conf
   repeated RaftPeerProto oldPeers = 2; // the peers in the old conf
+  repeated RaftPeerProto listeners = 3;
+  repeated RaftPeerProto oldListeners = 4;
 }
 
 message StateMachineEntryProto {
@@ -406,6 +408,7 @@ message RaftClientReplyProto {
 message SetConfigurationRequestProto {
   RaftRpcRequestProto rpcRequest = 1;
   repeated RaftPeerProto peers = 2;
+  repeated RaftPeerProto listeners = 3;
 }
 
 // transfer leadership request

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * The peer configuration of a raft cluster.
@@ -69,7 +70,9 @@ class PeerConfiguration {
 
   PeerConfiguration(Iterable<RaftPeer> peers, Iterable<RaftPeer> listeners) {
     this.peers = newMap(peers, "peers", Collections.emptyMap());
-    this.listeners = newMap(listeners, "listeners", this.peers);
+    this.listeners = Optional.ofNullable(listeners)
+        .map(l -> newMap(listeners, "listeners", this.peers))
+        .orElseGet(Collections::emptyMap);
   }
 
   Collection<RaftPeer> getPeers() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
@@ -88,8 +88,8 @@ final class RaftConfigurationImpl implements RaftConfiguration {
       return this;
     }
 
-    Builder setOldConf(Iterable<RaftPeer> oldPeers) {
-      return setOldConf(new PeerConfiguration(oldPeers));
+    Builder setOldConf(Iterable<RaftPeer> oldPeers, Iterable<RaftPeer> oldListeners) {
+      return setOldConf(new PeerConfiguration(oldPeers, oldListeners));
     }
 
     Builder setOldConf(RaftConfigurationImpl stableConf) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerImplUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerImplUtils.java
@@ -70,11 +70,14 @@ public final class ServerImplUtils {
     return proxy;
   }
 
-  public static RaftConfiguration newRaftConfiguration(List<RaftPeer> conf, long index, List<RaftPeer> oldConf) {
+  public static RaftConfiguration newRaftConfiguration(List<RaftPeer> conf, List<RaftPeer> listener,
+      long index, List<RaftPeer> oldConf, List<RaftPeer> oldListener) {
     final RaftConfigurationImpl.Builder b = RaftConfigurationImpl.newBuilder()
-        .setConf(conf)
+        .setConf(conf, listener)
         .setLogEntryIndex(index);
-    Optional.ofNullable(oldConf).filter(p -> p.size() > 0).ifPresent(b::setOldConf);
+    if (!oldConf.isEmpty() || !oldListener.isEmpty()) {
+      b.setOldConf(oldConf, oldListener);
+    }
     return b.build();
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/LogProtoUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/LogProtoUtils.java
@@ -200,8 +200,9 @@ public final class LogProtoUtils {
     Preconditions.assertTrue(entry.hasConfigurationEntry());
     final RaftConfigurationProto proto = entry.getConfigurationEntry();
     final List<RaftPeer> conf = ProtoUtils.toRaftPeers(proto.getPeersList());
-    final List<RaftPeer> oldConf = proto.getOldPeersCount() == 0? null
-        : ProtoUtils.toRaftPeers(proto.getOldPeersList());
-    return ServerImplUtils.newRaftConfiguration(conf, entry.getIndex(), oldConf);
+    final List<RaftPeer> listener = ProtoUtils.toRaftPeers(proto.getListenersList());
+    final List<RaftPeer> oldConf = ProtoUtils.toRaftPeers(proto.getOldPeersList());
+    final List<RaftPeer> oldListener = ProtoUtils.toRaftPeers(proto.getOldListenersList());
+    return ServerImplUtils.newRaftConfiguration(conf, listener, entry.getIndex(), oldConf, oldListener);
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -739,7 +739,8 @@ public abstract class MiniRaftCluster implements Closeable {
   public SetConfigurationRequest newSetConfigurationRequest(
       ClientId clientId, RaftPeerId leaderId,
       RaftPeer... peers) {
-    return new SetConfigurationRequest(clientId, leaderId, getGroupId(), CallId.getDefault(), Arrays.asList(peers));
+    return new SetConfigurationRequest(clientId, leaderId, getGroupId(), CallId.getDefault(),
+        Arrays.asList(peers), Collections.emptyList());
   }
 
   public void setConfiguration(RaftPeer... peers) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Sub task to support listener: Remove old PeerConfiguration API and change SetConfiguration

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1540

## How was this patch tested?
UT