### PR TITLE
RATIS-1545. RaftLogOutputStream support async flush.

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -348,6 +348,17 @@ public interface RaftServerConfigKeys {
       setInt(properties::setInt, FORCE_SYNC_NUM_KEY, forceSyncNum);
     }
 
+    /** Unsafe-flush allow increasing flush index without waiting the actual flush to complete. */
+    String UNSAFE_FLUSH_ENABLED_KEY = PREFIX + ".unsafe-flush.enabled";
+    boolean UNSAFE_FLUSH_ENABLED_DEFAULT = false;
+    static boolean unsafeFlushEnabled(RaftProperties properties) {
+      return getBoolean(properties::getBoolean,
+              UNSAFE_FLUSH_ENABLED_KEY, UNSAFE_FLUSH_ENABLED_DEFAULT, getDefaultLog());
+    }
+    static void setUnsafeFlushEnabled(RaftProperties properties, boolean unsafeFlush) {
+      setBoolean(properties::setBoolean, UNSAFE_FLUSH_ENABLED_KEY, unsafeFlush);
+    }
+
 
     String FLUSH_INTERVAL_MIN_KEY = PREFIX + ".flush.interval.min";
     TimeDuration FLUSH_INTERVAL_MIN_DEFAULT = TimeDuration.ZERO;

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -359,17 +359,6 @@ public interface RaftServerConfigKeys {
       setBoolean(properties::setBoolean, UNSAFE_FLUSH_ENABLED_KEY, unsafeFlush);
     }
 
-
-    String FLUSH_INTERVAL_MIN_KEY = PREFIX + ".flush.interval.min";
-    TimeDuration FLUSH_INTERVAL_MIN_DEFAULT = TimeDuration.ZERO;
-    static TimeDuration flushIntervalMin(RaftProperties properties) {
-      return getTimeDuration(properties.getTimeDuration(FLUSH_INTERVAL_MIN_DEFAULT.getUnit()),
-              FLUSH_INTERVAL_MIN_KEY, FLUSH_INTERVAL_MIN_DEFAULT, getDefaultLog());
-    }
-    static void setFlushIntervalMin(RaftProperties properties, TimeDuration flushTimeInterval) {
-      setTimeDuration(properties::setTimeDuration, FLUSH_INTERVAL_MIN_KEY, flushTimeInterval);
-    }
-
     /** The policy to handle corrupted raft log. */
     enum CorruptionPolicy {
       /** Rethrow the exception. */

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogOutputStream.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogOutputStream.java
@@ -32,6 +32,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.zip.Checksum;
 
 public class SegmentedRaftLogOutputStream implements Closeable {
@@ -116,6 +118,14 @@ public class SegmentedRaftLogOutputStream implements Closeable {
   public void flush() throws IOException {
     try {
       out.flush();
+    } catch (IOException ioe) {
+      throw new IOException("Failed to flush " + this, ioe);
+    }
+  }
+
+  CompletableFuture<Void> asyncFlush(ExecutorService executor) throws IOException {
+    try {
+      return out.asyncFlush(executor);
     } catch (IOException ioe) {
       throw new IOException("Failed to flush " + this, ioe);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We previously tried to reduce disk IO by introducing a minimum interval between flushes, the relevant pr is here: https://github.com/apache/ratis/pull/611

However, after subsequent tests, we found that **the pr #611 has a bug**, make the raft performance degraded,  because `flushIfNecessary()` function does more operations than just flushing the stream.

Since we enforced the minimum time for each flush, **the raft log to can't be committed in flush intervals, which reduces the performance of raft.**

So we want to separate `out.flush()`  from `flushIfNecessary()` and execute it asynchronously, so that the process of writing to disk will not block the operation of other threads

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/RATIS/issues/RATIS-1545

## How was this patch tested?

We use the ozone freon ockg tool to detect the effect of the changes.

test command:

```
bin/ozone freon ockg  --volume=volume  --bucket=defaultbucket  --thread=10 --number-of-tests=300  --size=`expr 32 \* 1048576` --prefix=stream
```
We tested the speed of writing 32MB and 128MB objects after enabe async flush:

![image](https://user-images.githubusercontent.com/20393870/156537331-9db37ede-30e7-44c9-bbb6-d6c0fe765acc.png)

