### PR TITLE
RATIS-1548. use stateMachine#lastAppliedIndex instead of stateMachinUpdater#lastAppliedIndex when checking snapshot should be taken

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
@@ -317,7 +317,7 @@ class StateMachineUpdater implements Runnable {
       return getLastAppliedIndex() - snapshotIndex.get() > 0;
     }
     return state == State.RUNNING &&
-        stateMachine.getLastAppliedTermIndex().getIndex() - snapshotIndex.get() >= autoSnapshotThreshold;
+        getStateMachineLastAppliedIndex() - snapshotIndex.get() >= autoSnapshotThreshold;
   }
 
   private long getLastAppliedIndex() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
@@ -316,7 +316,8 @@ class StateMachineUpdater implements Runnable {
     } else if (shouldStop()) {
       return getLastAppliedIndex() - snapshotIndex.get() > 0;
     }
-    return state == State.RUNNING && getLastAppliedIndex() - snapshotIndex.get() >= autoSnapshotThreshold;
+    return state == State.RUNNING &&
+        stateMachine.getLastAppliedTermIndex().getIndex() - snapshotIndex.get() >= autoSnapshotThreshold;
   }
 
   private long getLastAppliedIndex() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

for now, the following is used to check whether a snapshot should be taken
`return state == State.RUNNING && getLastAppliedIndex() - snapshotIndex.get() >= autoSnapshotThreshold; `

but `getLastAppliedIndex` is the index recorded by stateMachineUpdater, not state machine itself. in some other case (for example, om), the lastAppliedIndex of state machine will not be updated immediately after `applyTransaction` is called . in om , lastAppliedIndex will be updated until the ready queue of double buffer is flushed.

so here `stateMachineUpdater#getLastAppliedIndex()` does not always equal to `stateMachine#lastAppliedIndex`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1548

## How was this patch tested?

current UT
