### PR TITLE
RATIS-1563: Better error message when stateMachine.data().read(entry) fails.

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -74,9 +74,8 @@ public interface StateMachine extends Closeable {
      *
      * @return a future for the read task.
      */
-    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     default CompletableFuture<ByteString> read(LogEntryProto entry) {
-      return CompletableFuture.completedFuture(null);
+      throw new UnsupportedOperationException("This method is NOT supported.");
     }
 
     /**

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -375,7 +375,14 @@ public abstract class RaftLogBase implements RaftLog {
 
     EntryWithDataImpl(LogEntryProto logEntry, CompletableFuture<ByteString> future) {
       this.logEntry = logEntry;
-      this.future = future;
+      this.future = future == null? null: future.thenApply(this::checkStateMachineData);
+    }
+
+    private ByteString checkStateMachineData(ByteString data) {
+      if (data == null) {
+        throw new IllegalStateException("State machine data is null for log entry " + logEntry);
+      }
+      return data;
     }
 
     @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
 
@@ -295,7 +296,7 @@ public class SegmentedRaftLog extends RaftLogBase {
       if (stateMachine != null) {
         future = stateMachine.data().read(entry).exceptionally(ex -> {
           stateMachine.event().notifyLogFailed(ex, entry);
-          return null;
+          throw new CompletionException("Failed to read state machine data for log entry " + entry, ex);
         });
       }
       return newEntryWithData(entry, future);


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1563