### PR TITLE
RATIS-1574. Add follower information to LeaderEventApi.notifyFollowerSlowness(..)

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -27,6 +27,7 @@ import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
+import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -207,7 +208,7 @@ public interface StateMachine extends Closeable {
      *
      * @see org.apache.ratis.server.RaftServerConfigKeys.Rpc#SLOWNESS_TIMEOUT_KEY
      */
-    default void notifyFollowerSlowness(RoleInfoProto roleInfoProto) {}
+    default void notifyFollowerSlowness(RoleInfoProto roleInfoProto, RaftPeer slowFollower) {}
 
     /**
      * Notify {@link StateMachine} that this server is no longer the leader.

--- a/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -204,11 +204,16 @@ public interface StateMachine extends Closeable {
      * Notify the {@link StateMachine} that the given follower is slow.
      * This notification is based on "raft.server.rpc.slowness.timeout".
      *
-     * @param roleInfoProto information about the current node role and rpc delay information
+     * @param leaderInfo information about the current node role and rpc delay information
+     * @param slowFollower The follower being slow.
      *
      * @see org.apache.ratis.server.RaftServerConfigKeys.Rpc#SLOWNESS_TIMEOUT_KEY
      */
-    default void notifyFollowerSlowness(RoleInfoProto roleInfoProto, RaftPeer slowFollower) {}
+    default void notifyFollowerSlowness(RoleInfoProto leaderInfo, RaftPeer slowFollower) {}
+
+    /** @deprecated Use {@link #notifyFollowerSlowness(RoleInfoProto, RaftPeer)}. */
+    @Deprecated
+    default void notifyFollowerSlowness(RoleInfoProto leaderInfo) {}
 
     /**
      * Notify {@link StateMachine} that this server is no longer the leader.

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -1117,7 +1117,7 @@ class LeaderStateImpl implements LeaderState {
   public void checkHealth(FollowerInfo follower) {
     final TimeDuration elapsedTime = follower.getLastRpcResponseTime().elapsedTime();
     if (elapsedTime.compareTo(server.properties().rpcSlownessTimeout()) > 0) {
-      server.getStateMachine().leaderEvent().notifyFollowerSlowness(server.getInfo().getRoleInfoProto());
+      server.getStateMachine().leaderEvent().notifyFollowerSlowness(server.getInfo().getRoleInfoProto(), follower.getPeer());
     }
     final RaftPeerId followerId = follower.getPeer().getId();
     raftServerMetrics.recordFollowerHeartbeatElapsedTime(followerId, elapsedTime.toLong(TimeUnit.NANOSECONDS));

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -24,6 +24,7 @@ import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto.LogEntryBodyCase;
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
+import org.apache.ratis.proto.RaftProtos.RoleInfoProto;
 import org.apache.ratis.proto.RaftProtos.StartLeaderElectionReplyProto;
 import org.apache.ratis.proto.RaftProtos.StartLeaderElectionRequestProto;
 import org.apache.ratis.protocol.Message;
@@ -1117,7 +1118,9 @@ class LeaderStateImpl implements LeaderState {
   public void checkHealth(FollowerInfo follower) {
     final TimeDuration elapsedTime = follower.getLastRpcResponseTime().elapsedTime();
     if (elapsedTime.compareTo(server.properties().rpcSlownessTimeout()) > 0) {
-      server.getStateMachine().leaderEvent().notifyFollowerSlowness(server.getInfo().getRoleInfoProto(), follower.getPeer());
+      final RoleInfoProto leaderInfo = server.getInfo().getRoleInfoProto();
+      server.getStateMachine().leaderEvent().notifyFollowerSlowness(leaderInfo);
+      server.getStateMachine().leaderEvent().notifyFollowerSlowness(leaderInfo, follower.getPeer());
     }
     final RaftPeerId followerId = follower.getPeer().getId();
     raftServerMetrics.recordFollowerHeartbeatElapsedTime(followerId, elapsedTime.toLong(TimeUnit.NANOSECONDS));

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
@@ -417,12 +417,6 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
   }
 
   @Override
-  public void notifyFollowerSlowness(RoleInfoProto leaderInfo) {
-    LOG.info("{}: notifySlowness {}, {}", this, groupId, leaderInfo);
-    slownessInfo = leaderInfo;
-  }
-
-  @Override
   public void notifyFollowerSlowness(RoleInfoProto leaderInfo, RaftPeer slowFollower) {
     LOG.info("{}: notifySlowness {}, {}, {}", this, groupId, leaderInfo, slowFollower);
     slownessInfo = leaderInfo;

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
@@ -26,6 +26,7 @@ import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
+import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.server.RaftServer;
@@ -416,8 +417,8 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
   }
 
   @Override
-  public void notifyFollowerSlowness(RoleInfoProto roleInfoProto) {
-    LOG.info("{}: notifySlowness {}, {}", this, groupId, roleInfoProto);
+  public void notifyFollowerSlowness(RoleInfoProto roleInfoProto, RaftPeer slowFollower) {
+    LOG.info("{}: notifySlowness {}, {}, {}", this, groupId, roleInfoProto, slowFollower);
     slownessInfo = roleInfoProto;
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
@@ -417,9 +417,15 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
   }
 
   @Override
-  public void notifyFollowerSlowness(RoleInfoProto roleInfoProto, RaftPeer slowFollower) {
-    LOG.info("{}: notifySlowness {}, {}, {}", this, groupId, roleInfoProto, slowFollower);
-    slownessInfo = roleInfoProto;
+  public void notifyFollowerSlowness(RoleInfoProto leaderInfo) {
+    LOG.info("{}: notifySlowness {}, {}", this, groupId, leaderInfo);
+    slownessInfo = leaderInfo;
+  }
+
+  @Override
+  public void notifyFollowerSlowness(RoleInfoProto leaderInfo, RaftPeer slowFollower) {
+    LOG.info("{}: notifySlowness {}, {}, {}", this, groupId, leaderInfo, slowFollower);
+    slownessInfo = leaderInfo;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

When notifying follower's slowness, if the leader knows who is slow using StateMachine, then it will help users to handle it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1574