### PR TITLE
RATIS-1572. Upgrade Ratis Thirdparty to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,11 +204,11 @@
     <maven.min.version>3.3.9</maven.min.version>
 
     <!-- Contains all shaded thirdparty dependencies -->
-    <ratis.thirdparty.version>0.7.0</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.0</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
-    <shaded.protobuf.version>3.12.0</shaded.protobuf.version>
-    <shaded.grpc.version>1.33.0</shaded.grpc.version>
+    <shaded.protobuf.version>3.19.2</shaded.protobuf.version>
+    <shaded.grpc.version>1.44.0</shaded.grpc.version>
 
     <!-- Test properties -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Ratis Thirdparty to 1.0.0, which has the following (non-test) changes:

* RATIS-1515. Upgrade gRPC to 1.44.0, Netty to 4.1.74
* RATIS-1514. Bundle specific netty artifacts instead of netty-all
* RATIS-1507. Clean up the vulnerabilities from dependencies.
* RATIS-1468. Remove unused log4j dependency from thirdparty pom.xml
* RATIS-1443. Shade all Netty Native libraries

https://issues.apache.org/jira/browse/RATIS-1572

## How was this patch tested?

https://github.com/adoroszlai/incubator-ratis/actions/runs/2276551769