### PR TITLE
RATIS-1575. Handle hugo lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.sdf
 *.suo
 *.vcxproj.user
+.hugo_build.lock
 .idea
 .classpath
 .project

--- a/ratis-assembly/src/main/assembly/src.xml
+++ b/ratis-assembly/src/main/assembly/src.xml
@@ -56,6 +56,7 @@
               <exclude>target/</exclude>
               <exclude>test/</exclude>
               <exclude>.classpath</exclude>
+              <exclude>.hugo_build.lock</exclude>
               <exclude>.project</exclude>
               <exclude>.settings/</exclude>
               <exclude>*.iml/</exclude>

--- a/ratis-docs/pom.xml
+++ b/ratis-docs/pom.xml
@@ -64,6 +64,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             </exclude>
             <exclude>themes/ratisdoc/layouts/index.html</exclude>
             <exclude>themes/ratisdoc/theme.toml</exclude>
+            <exclude>.hugo_build.lock</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exclude Hugo's lock file from source tarball, and let Rat and Git ignore it.

https://issues.apache.org/jira/browse/RATIS-1575

## How was this patch tested?

```
$ mvn -DskipTests -Prelease -Papache-release clean package assembly:single 
...
[INFO] BUILD SUCCESS

$ ls -s ratis-docs/.hugo_build.lock
0 ratis-docs/.hugo_build.lock

$ dev-support/checks/rat.sh
...
[INFO] BUILD SUCCESS

$ tar tzvf ratis-assembly/target/apache-ratis-*-src.tar.gz| grep hugo | wc -l
       0

$ git status
On branch RATIS-1575

nothing to commit, working tree clean
```