### PR TITLE
RATIS-1576. Add ratis-shell to source assembly

### DIFF
--- a/ratis-assembly/src/main/assembly/src.xml
+++ b/ratis-assembly/src/main/assembly/src.xml
@@ -40,6 +40,7 @@
         <include>org.apache.ratis:ratis-replicated-map</include>
         <include>org.apache.ratis:ratis-server-api</include>
         <include>org.apache.ratis:ratis-server</include>
+        <include>org.apache.ratis:ratis-shell</include>
         <include>org.apache.ratis:ratis-test</include>
         <include>org.apache.ratis:ratis-metrics</include>
         <include>org.apache.ratis:ratis-tools</include>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Include `ratis-shell` submodule in source tarball to prevent build failure when building Ratis after downloading source tarball.

https://issues.apache.org/jira/browse/RATIS-1576

## How was this patch tested?

```
$ mvn -DskipTests -Prelease -Papache-release clean package assembly:single
...
[INFO] BUILD SUCCESS

$ tar -C ~/tmp -xzf ratis-assembly/target/apache-ratis-2.3.0-SNAPSHOT-src.tar.gz

$ cd ~/tmp/apache-ratis-2.3.0-SNAPSHOT

$ mvn -DskipTests clean package
...
[INFO] BUILD SUCCESS
```