### PR TITLE
RATIS-1577. Install snapshot failure

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -82,6 +82,7 @@ import java.util.stream.Collectors;
 import static org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto.AppendResult.INCONSISTENCY;
 import static org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto.AppendResult.NOT_LEADER;
 import static org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto.AppendResult.SUCCESS;
+import static org.apache.ratis.server.raftlog.RaftLog.INVALID_LOG_INDEX;
 import static org.apache.ratis.util.LifeCycle.State.EXCEPTION;
 import static org.apache.ratis.util.LifeCycle.State.NEW;
 import static org.apache.ratis.util.LifeCycle.State.PAUSED;
@@ -1020,7 +1021,7 @@ class RaftServerImpl implements RaftServer.Division,
     synchronized (this) {
       final long installSnapshot = snapshotInstallationHandler.getInProgressInstallSnapshotIndex();
       // check snapshot install/load
-      if (installSnapshot != 0) {
+      if (installSnapshot != INVALID_LOG_INDEX) {
         String msg = String.format("%s: Failed do snapshot as snapshot (%s) installation is in progress",
             getMemberId(), installSnapshot);
         LOG.warn(msg);
@@ -1309,7 +1310,7 @@ class RaftServerImpl implements RaftServer.Division,
       if (!recognized) {
         final AppendEntriesReplyProto reply = ServerProtoUtils.toAppendEntriesReplyProto(
             leaderId, getMemberId(), currentTerm, followerCommit, state.getNextIndex(), NOT_LEADER, callId,
-            RaftLog.INVALID_LOG_INDEX, isHeartbeat);
+            INVALID_LOG_INDEX, isHeartbeat);
         if (LOG.isDebugEnabled()) {
           LOG.debug("{}: Not recognize {} (term={}) as leader, state: {} reply: {}",
               getMemberId(), leaderId, leaderTerm, state, ServerStringUtils.toAppendEntriesReplyString(reply));
@@ -1363,7 +1364,7 @@ class RaftServerImpl implements RaftServer.Division,
         updateCommitInfoCache();
         final long n = isHeartbeat? state.getLog().getNextIndex(): entries[entries.length - 1].getIndex() + 1;
         final long matchIndex = entries.length != 0 ? entries[entries.length - 1].getIndex() :
-            RaftLog.INVALID_LOG_INDEX;
+            INVALID_LOG_INDEX;
         reply = ServerProtoUtils.toAppendEntriesReplyProto(leaderId, getMemberId(), currentTerm,
             state.getLog().getLastCommittedIndex(), n, SUCCESS, callId, matchIndex,
             isHeartbeat);
@@ -1384,7 +1385,7 @@ class RaftServerImpl implements RaftServer.Division,
 
     final AppendEntriesReplyProto reply = ServerProtoUtils.toAppendEntriesReplyProto(
         leaderId, getMemberId(), currentTerm, followerCommit, replyNextIndex, INCONSISTENCY, callId,
-        RaftLog.INVALID_LOG_INDEX, isHeartbeat);
+        INVALID_LOG_INDEX, isHeartbeat);
     LOG.info("{}: inconsistency entries. Reply:{}", getMemberId(), ServerStringUtils.toAppendEntriesReplyString(reply));
     return reply;
   }
@@ -1392,7 +1393,7 @@ class RaftServerImpl implements RaftServer.Division,
   private long checkInconsistentAppendEntries(TermIndex previous, LogEntryProto... entries) {
     // Check if a snapshot installation through state machine is in progress.
     final long installSnapshot = snapshotInstallationHandler.getInProgressInstallSnapshotIndex();
-    if (installSnapshot != 0) {
+    if (installSnapshot != INVALID_LOG_INDEX) {
       LOG.info("{}: Failed appendEntries as snapshot ({}) installation is in progress", getMemberId(), installSnapshot);
       return state.getNextIndex();
     }
@@ -1404,7 +1405,7 @@ class RaftServerImpl implements RaftServer.Division,
       final long snapshotIndex = state.getSnapshotIndex();
       final long commitIndex =  state.getLog().getLastCommittedIndex();
       final long nextIndex = Math.max(snapshotIndex, commitIndex);
-      if (nextIndex > 0 && nextIndex >= firstEntryIndex) {
+      if (nextIndex > INVALID_LOG_INDEX && nextIndex >= firstEntryIndex) {
         LOG.info("{}: Failed appendEntries as the first entry (index {})" +
                 " already exists (snapshotIndex: {}, commitIndex: {})",
             getMemberId(), firstEntryIndex, snapshotIndex, commitIndex);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -216,7 +216,7 @@ class SnapshotInstallationHandler {
         // Check if snapshot index is already at par or ahead of the first
         // available log index of the Leader.
         final long snapshotIndex = state.getLog().getSnapshotIndex();
-        if (snapshotIndex >= firstAvailableLogIndex && firstAvailableLogIndex > INVALID_LOG_INDEX) {
+        if (snapshotIndex + 1 >= firstAvailableLogIndex && firstAvailableLogIndex > INVALID_LOG_INDEX) {
           // State Machine has already installed the snapshot. Return the
           // latest snapshot index to the Leader.
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -49,6 +49,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.ratis.server.raftlog.RaftLog.INVALID_LOG_INDEX;
+
 class SnapshotInstallationHandler {
   static final Logger LOG = LoggerFactory.getLogger(SnapshotInstallationHandler.class);
 
@@ -56,8 +58,9 @@ class SnapshotInstallationHandler {
   private final ServerState state;
 
   private final boolean installSnapshotEnabled;
-  private final AtomicLong inProgressInstallSnapshotIndex = new AtomicLong();
-  private final AtomicReference<TermIndex> installedSnapshotTermIndex = new AtomicReference<>(TermIndex.valueOf(0,0));
+  private final AtomicLong inProgressInstallSnapshotIndex = new AtomicLong(INVALID_LOG_INDEX);
+  private final AtomicReference<TermIndex> installedSnapshotTermIndex =
+    new AtomicReference<>(TermIndex.valueOf(0, INVALID_LOG_INDEX));
   private final AtomicBoolean isSnapshotNull = new AtomicBoolean();
 
   SnapshotInstallationHandler(RaftServerImpl server, RaftProperties properties) {
@@ -206,16 +209,16 @@ class SnapshotInstallationHandler {
       state.setLeader(leaderId, "installSnapshot");
       server.updateLastRpcTime(FollowerState.UpdateType.INSTALL_SNAPSHOT_NOTIFICATION);
 
-      if (inProgressInstallSnapshotIndex.compareAndSet(0, firstAvailableLogIndex)) {
+      if (inProgressInstallSnapshotIndex.compareAndSet(INVALID_LOG_INDEX, firstAvailableLogIndex)) {
         LOG.info("{}: Received notification to install snapshot at index {}", getMemberId(), firstAvailableLogIndex);
         // Check if snapshot index is already at par or ahead of the first
         // available log index of the Leader.
         final long snapshotIndex = state.getLog().getSnapshotIndex();
-        if (snapshotIndex + 1 >= firstAvailableLogIndex && firstAvailableLogIndex > 0) {
+        if (snapshotIndex >= firstAvailableLogIndex && firstAvailableLogIndex > INVALID_LOG_INDEX) {
           // State Machine has already installed the snapshot. Return the
           // latest snapshot index to the Leader.
 
-          inProgressInstallSnapshotIndex.compareAndSet(firstAvailableLogIndex, 0);
+          inProgressInstallSnapshotIndex.compareAndSet(firstAvailableLogIndex, INVALID_LOG_INDEX);
           LOG.info("{}: InstallSnapshot notification result: {}, current snapshot index: {}", getMemberId(),
               InstallSnapshotResult.ALREADY_INSTALLED, snapshotIndex);
           return ServerProtoUtils.toInstallSnapshotReplyProto(leaderId, getMemberId(), currentTerm,
@@ -258,7 +261,7 @@ class SnapshotInstallationHandler {
               if (exception != null) {
                 LOG.error("{}: Failed to notify StateMachine to InstallSnapshot. Exception: {}",
                     getMemberId(), exception.getMessage());
-                inProgressInstallSnapshotIndex.compareAndSet(firstAvailableLogIndex, 0);
+                inProgressInstallSnapshotIndex.compareAndSet(firstAvailableLogIndex, INVALID_LOG_INDEX);
                 return;
               }
 
@@ -284,8 +287,8 @@ class SnapshotInstallationHandler {
       }
 
       final long inProgressInstallSnapshotIndexValue = getInProgressInstallSnapshotIndex();
-      Preconditions.assertTrue(
-          inProgressInstallSnapshotIndexValue <= firstAvailableLogIndex && inProgressInstallSnapshotIndexValue > 0,
+      Preconditions.assertTrue(inProgressInstallSnapshotIndexValue <= firstAvailableLogIndex
+              && inProgressInstallSnapshotIndexValue > INVALID_LOG_INDEX,
           "inProgressInstallSnapshotRequest: %s is not eligible, firstAvailableLogIndex: %s",
           getInProgressInstallSnapshotIndex(), firstAvailableLogIndex);
 
@@ -293,22 +296,22 @@ class SnapshotInstallationHandler {
       if (isSnapshotNull.compareAndSet(true, false)) {
         LOG.info("{}: InstallSnapshot notification result: {}", getMemberId(),
             InstallSnapshotResult.SNAPSHOT_UNAVAILABLE);
-        inProgressInstallSnapshotIndex.set(0);
+        inProgressInstallSnapshotIndex.set(INVALID_LOG_INDEX);
         return ServerProtoUtils.toInstallSnapshotReplyProto(leaderId, getMemberId(),
             currentTerm, InstallSnapshotResult.SNAPSHOT_UNAVAILABLE, -1);
       }
 
       // If a snapshot has been installed, return SNAPSHOT_INSTALLED with the installed snapshot index and reset
-      // installedSnapshotIndex to (0,0).
+      // installedSnapshotIndex to (0,-1).
       final TermIndex latestInstalledSnapshotTermIndex = this.installedSnapshotTermIndex
-          .getAndSet(TermIndex.valueOf(0,0));
-      if (latestInstalledSnapshotTermIndex.getIndex() > 0) {
+          .getAndSet(TermIndex.valueOf(0, INVALID_LOG_INDEX));
+      if (latestInstalledSnapshotTermIndex.getIndex() > INVALID_LOG_INDEX) {
         server.getStateMachine().pause();
         state.updateInstalledSnapshotIndex(latestInstalledSnapshotTermIndex);
         state.reloadStateMachine(latestInstalledSnapshotTermIndex.getIndex());
         LOG.info("{}: InstallSnapshot notification result: {}, at index: {}", getMemberId(),
             InstallSnapshotResult.SNAPSHOT_INSTALLED, latestInstalledSnapshotTermIndex);
-        inProgressInstallSnapshotIndex.set(0);
+        inProgressInstallSnapshotIndex.set(INVALID_LOG_INDEX);
         return ServerProtoUtils.toInstallSnapshotReplyProto(leaderId, getMemberId(),
             currentTerm, InstallSnapshotResult.SNAPSHOT_INSTALLED, latestInstalledSnapshotTermIndex.getIndex());
       }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -54,13 +54,15 @@ import static org.apache.ratis.server.raftlog.RaftLog.INVALID_LOG_INDEX;
 class SnapshotInstallationHandler {
   static final Logger LOG = LoggerFactory.getLogger(SnapshotInstallationHandler.class);
 
+  static final TermIndex INVALID_TERM_INDEX = TermIndex.valueOf(0, INVALID_LOG_INDEX);
+
   private final RaftServerImpl server;
   private final ServerState state;
 
   private final boolean installSnapshotEnabled;
   private final AtomicLong inProgressInstallSnapshotIndex = new AtomicLong(INVALID_LOG_INDEX);
   private final AtomicReference<TermIndex> installedSnapshotTermIndex =
-    new AtomicReference<>(TermIndex.valueOf(0, INVALID_LOG_INDEX));
+    new AtomicReference<>(INVALID_TERM_INDEX);
   private final AtomicBoolean isSnapshotNull = new AtomicBoolean();
 
   SnapshotInstallationHandler(RaftServerImpl server, RaftProperties properties) {
@@ -304,7 +306,7 @@ class SnapshotInstallationHandler {
       // If a snapshot has been installed, return SNAPSHOT_INSTALLED with the installed snapshot index and reset
       // installedSnapshotIndex to (0,-1).
       final TermIndex latestInstalledSnapshotTermIndex = this.installedSnapshotTermIndex
-          .getAndSet(TermIndex.valueOf(0, INVALID_LOG_INDEX));
+          .getAndSet(INVALID_TERM_INDEX);
       if (latestInstalledSnapshotTermIndex.getIndex() > INVALID_LOG_INDEX) {
         server.getStateMachine().pause();
         state.updateInstalledSnapshotIndex(latestInstalledSnapshotTermIndex);


### PR DESCRIPTION
## What changes were proposed in this pull request?

After 7167fafe Ozone SCM HA fails to start due to the following error in follower:

```
[grpc-default-executor-0] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:installSnapshot(79)) - 2d9f16d2-1d71-4978-9546-00aa402e881d@group-F84A6C219907: receive installSnapshot: edb17d6c-0f2e-4b73-aa2b-eb8fdf376958->2d9f16d2-1d71-4978-9546-00aa402e881d#0-t2,notify:(t:1, i:0)
[grpc-default-executor-0] INFO  server.RaftServer$Division (ServerState.java:setLeader(287)) - 2d9f16d2-1d71-4978-9546-00aa402e881d@group-F84A6C219907: change Leader from null to edb17d6c-0f2e-4b73-aa2b-eb8fdf376958 at term 2 for installSnapshot, leader elected after 488ms
[grpc-default-executor-0] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:notifyStateMachineToInstallSnapshot(210)) - 2d9f16d2-1d71-4978-9546-00aa402e881d@group-F84A6C219907: Received notification to install snapshot at index 0
[grpc-default-executor-0] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:notifyStateMachineToInstallSnapshot(243)) - 2d9f16d2-1d71-4978-9546-00aa402e881d@group-F84A6C219907: notifyInstallSnapshot: nextIndex is 0 but the leader's first available index is 0.
[grpc-default-executor-0] ERROR impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:installSnapshot(86)) - 2d9f16d2-1d71-4978-9546-00aa402e881d@group-F84A6C219907: installSnapshot failed
java.lang.IllegalStateException: inProgressInstallSnapshotRequest: 0 is not eligible, firstAvailableLogIndex: 0
        at org.apache.ratis.util.Preconditions.assertTrue(Preconditions.java:60)
        at org.apache.ratis.server.impl.SnapshotInstallationHandler.notifyStateMachineToInstallSnapshot(SnapshotInstallationHandler.java:287)
        at org.apache.ratis.server.impl.SnapshotInstallationHandler.installSnapshotImpl(SnapshotInstallationHandler.java:115)
        at org.apache.ratis.server.impl.SnapshotInstallationHandler.installSnapshot(SnapshotInstallationHandler.java:84)
        at org.apache.ratis.server.impl.RaftServerImpl.installSnapshot(RaftServerImpl.java:1427)
```

Note that this patch fixes the problem, but I'm completely not sure if this is the right way to fix it.

https://issues.apache.org/jira/browse/RATIS-1577

## How was this patch tested?

### Regular Ratis CI

https://github.com/adoroszlai/incubator-ratis/actions/runs/2290702895

### Integration with Ozone

Built local Ratis snapshot:

```
ratis_hash=$(git rev-parse --short HEAD)
ratis_version="2.3.0-${ratis_hash}-SNAPSHOT"
mvn versions:set -DnewVersion="${ratis_version}"
mvn -DskipTests clean install
git reset --hard
git clean -fd 
```

~Applied patch to Ozone (needed for compatibility with Ratis `master`).~ (no longer needed)

Ran Ozone test:

```
mvn -Dskip.installnpm -Dskip.installnpx -Dskip.installyarn -Dskip.npm -Dskip.npx -Dskip.yarn -DskipShade \
  -am -pl :ozone-integration-test -Dsurefire.fork.timeout=120 -DfailIfNoTests=false -Dtest=TestStorageContainerManagerHA#testAllSCMAreRunning \
  -Dratis.version="$ratis_version" \
  -Dratis.thirdparty.version=1.0.0 -Dgrpc.protobuf-compile.version=3.19.2 -Dnetty.version=4.1.74.Final -Dio.grpc.version=1.44.0 -Dtcnative.version=2.0.48.Final \
  clean test
```

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 65.43 s - in org.apache.hadoop.ozone.scm.TestStorageContainerManagerHA
```