### PR TITLE
RATIS-1579. Verify build from source release tarball in CI

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -18,15 +18,45 @@ on:
   - pull_request
 jobs:
   build:
-    name: compile
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+      - name: Cache for maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+          restore-keys: |
+            maven-repo-${{ hashFiles('**/pom.xml') }}
+            maven-repo-
+      - name: Run a full build
+        run: ./dev-support/checks/build.sh -Prelease -Papache-release assembly:single
+      - name: Store source tarball for compilation
+        uses: actions/upload-artifact@v2
+        with:
+          name: ratis-src
+          path: ratis-assembly/target/apache-ratis-*-src.tar.gz
+          retention-days: 1
+      - name: Delete temporary build artifacts
+        run: rm -rf ~/.m2/repository/org/apache/ratis
+        if: always()
+  compile:
+    needs:
+      - build
     runs-on: ubuntu-18.04
     strategy:
       matrix:
         java: [ 8, 11 ]
       fail-fast: false
     steps:
-      - name: Checkout project
-        uses: actions/checkout@v2
+      - name: Download source tarball
+        uses: actions/download-artifact@v2
+        with:
+          name: ratis-src
+      - name: Untar sources
+        run: |
+          tar --strip-components 1 -xzvf apache-ratis-*-src.tar.gz
       - name: Cache for maven dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -31,7 +31,7 @@ jobs:
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Run a full build
-        run: ./dev-support/checks/build.sh -Prelease -Papache-release assembly:single
+        run: ./dev-support/checks/build.sh -Prelease assembly:single
       - name: Store source tarball for compilation
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -30,6 +30,10 @@ jobs:
           restore-keys: |
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
       - name: Run a full build
         run: ./dev-support/checks/build.sh -Prelease assembly:single
       - name: Store source tarball for compilation
@@ -47,7 +51,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        java: [ 8, 11 ]
+        java: [ 11 ]
       fail-fast: false
     steps:
       - name: Download source tarball

--- a/dev-support/checks/build.sh
+++ b/dev-support/checks/build.sh
@@ -17,5 +17,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../.." || exit 1
 
 export MAVEN_OPTS="-Xmx4096m"
-mvn -V -B -Dmaven.javadoc.skip=true -DskipTests clean install
+mvn -V -B -Dmaven.javadoc.skip=true -DskipTests clean install "$@"
 exit $?

--- a/ratis-assembly/src/main/assembly/src.xml
+++ b/ratis-assembly/src/main/assembly/src.xml
@@ -74,6 +74,19 @@
       <outputDirectory>dev-support</outputDirectory>
       <fileMode>0644</fileMode>
       <directoryMode>0755</directoryMode>
+      <excludes>
+        <exclude>**/*.sh</exclude>
+      </excludes>
+    </fileSet>
+    <!-- Ensure shell scripts are executable -->
+    <fileSet>
+      <directory>${project.basedir}/../dev-support</directory>
+      <outputDirectory>dev-support</outputDirectory>
+      <fileMode>0755</fileMode>
+      <directoryMode>0755</directoryMode>
+      <includes>
+        <include>**/*.sh</include>
+      </includes>
     </fileSet>
     <!-- Include files in root dir -->
     <fileSet>


### PR DESCRIPTION
## What changes were proposed in this pull request?

CI should ensure that source tarball contents can be compiled (see RATIS-1576 for example where it was broken).

This PR includes the following changes:

 * _build_ check produces tarballs and stores the one with sources for other checks to consume
 * _compile_ check builds from the source tarball instead of git repo
 * source tarball sets `+x` permission on `dev-support` scripts

https://issues.apache.org/jira/browse/RATIS-1579

## How was this patch tested?

https://github.com/adoroszlai/incubator-ratis/actions/runs/2296722458