### PR TITLE
RATIS-1582. Add notify install snapshot finished event to inform the

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -21,7 +21,7 @@ import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.GrpcConfigKeys;
 import org.apache.ratis.grpc.GrpcUtil;
 import org.apache.ratis.grpc.metrics.GrpcServerMetrics;
-import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.proto.RaftProtos.InstallSnapshotResult;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
@@ -390,12 +390,12 @@ public class GrpcLogAppender extends LogAppenderBase {
       if (followerNextIndex >= leaderStartIndex) {
         LOG.info("{}: Follower can catch up leader after install the snapshot, as leader's start index is {}",
             this, followerNextIndex);
-        notifyInstallSnapshotFinished(RaftProtos.InstallSnapshotResult.SUCCESS);
+        notifyInstallSnapshotFinished(InstallSnapshotResult.SUCCESS, followerSnapshotIndex);
       }
     }
 
-    void notifyInstallSnapshotFinished(RaftProtos.InstallSnapshotResult result) {
-      getServer().getStateMachine().event().notifyInstallSnapshotFinished(result);
+    void notifyInstallSnapshotFinished(InstallSnapshotResult result, long snapshotIndex) {
+      getServer().getStateMachine().event().notifySnapshotInstalled(result, snapshotIndex);
     }
 
     boolean isDone() {
@@ -467,7 +467,7 @@ public class GrpcLogAppender extends LogAppenderBase {
         case SNAPSHOT_UNAVAILABLE:
           LOG.info("{}: Follower could not install snapshot as it is not available.", this);
           getFollower().setAttemptedToInstallSnapshot();
-          notifyInstallSnapshotFinished(RaftProtos.InstallSnapshotResult.SNAPSHOT_UNAVAILABLE);
+          notifyInstallSnapshotFinished(InstallSnapshotResult.SNAPSHOT_UNAVAILABLE, RaftLog.INVALID_LOG_INDEX);
           removePending(reply);
           break;
         case UNRECOGNIZED:

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -21,6 +21,7 @@ import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.GrpcConfigKeys;
 import org.apache.ratis.grpc.GrpcUtil;
 import org.apache.ratis.grpc.metrics.GrpcServerMetrics;
+import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
@@ -389,12 +390,12 @@ public class GrpcLogAppender extends LogAppenderBase {
       if (followerNextIndex >= leaderStartIndex) {
         LOG.info("{}: Follower can catch up leader after install the snapshot, as leader's start index is {}",
             this, followerNextIndex);
-        notifyInstallSnapshotFinished();
+        notifyInstallSnapshotFinished(RaftProtos.InstallSnapshotResult.SUCCESS);
       }
     }
 
-    void notifyInstallSnapshotFinished() {
-      getServer().getStateMachine().event().notifyInstallSnapshotFinished();
+    void notifyInstallSnapshotFinished(RaftProtos.InstallSnapshotResult result) {
+      getServer().getStateMachine().event().notifyInstallSnapshotFinished(result);
     }
 
     boolean isDone() {
@@ -466,7 +467,7 @@ public class GrpcLogAppender extends LogAppenderBase {
         case SNAPSHOT_UNAVAILABLE:
           LOG.info("{}: Follower could not install snapshot as it is not available.", this);
           getFollower().setAttemptedToInstallSnapshot();
-          notifyInstallSnapshotFinished();
+          notifyInstallSnapshotFinished(RaftProtos.InstallSnapshotResult.SNAPSHOT_UNAVAILABLE);
           removePending(reply);
           break;
         case UNRECOGNIZED:

--- a/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -194,7 +194,7 @@ public interface StateMachine extends Closeable {
      * Notify the {@link StateMachine} that the progress of install snapshot is
      * completely done. Could trigger the cleanup of snapshots.
      */
-    default void notifyInstallSnapshotFinished() {}
+    default void notifyInstallSnapshotFinished(RaftProtos.InstallSnapshotResult result) {}
   }
 
   /**

--- a/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -18,10 +18,7 @@
 package org.apache.ratis.statemachine;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.ratis.proto.RaftProtos;
-import org.apache.ratis.proto.RaftProtos.LogEntryProto;
-import org.apache.ratis.proto.RaftProtos.RaftConfigurationProto;
-import org.apache.ratis.proto.RaftProtos.RoleInfoProto;
+import org.apache.ratis.proto.RaftProtos.*;
 import org.apache.ratis.protocol.ClientInvocationId;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
@@ -157,9 +154,9 @@ public interface StateMachine extends Closeable {
 
     /**
      * Notify the {@link StateMachine} a term-index update event.
-     * This method will be invoked when a {@link RaftProtos.MetadataProto}
-     * or {@link RaftProtos.RaftConfigurationProto} is processed.
-     * For {@link RaftProtos.StateMachineLogEntryProto}, this method will not be invoked.
+     * This method will be invoked when a {@link MetadataProto}
+     * or {@link RaftConfigurationProto} is processed.
+     * For {@link StateMachineLogEntryProto}, this method will not be invoked.
      *
      * @param term The term of the log entry
      * @param index The index of the log entry
@@ -168,7 +165,7 @@ public interface StateMachine extends Closeable {
 
     /**
      * Notify the {@link StateMachine} a configuration change.
-     * This method will be invoked when a {@link RaftProtos.RaftConfigurationProto} is processed.
+     * This method will be invoked when a {@link RaftConfigurationProto} is processed.
      *
      * @param term term of the current log entry
      * @param index index which is being updated
@@ -194,7 +191,7 @@ public interface StateMachine extends Closeable {
      * Notify the {@link StateMachine} that the progress of install snapshot is
      * completely done. Could trigger the cleanup of snapshots.
      */
-    default void notifyInstallSnapshotFinished(RaftProtos.InstallSnapshotResult result) {}
+    default void notifySnapshotInstalled(InstallSnapshotResult result, long snapshotIndex) {}
   }
 
   /**
@@ -523,7 +520,7 @@ public interface StateMachine extends Closeable {
    * @param proto state machine proto
    * @return the string representation of the proto.
    */
-  default String toStateMachineLogEntryString(RaftProtos.StateMachineLogEntryProto proto) {
+  default String toStateMachineLogEntryString(StateMachineLogEntryProto proto) {
     return JavaUtils.getClassSimpleName(proto.getClass()) +  ":" + ClientInvocationId.valueOf(proto);
   }
 }

--- a/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -189,6 +189,12 @@ public interface StateMachine extends Closeable {
      * @param failedEntry The failed log entry, if there is any.
      */
     default void notifyLogFailed(Throwable cause, LogEntryProto failedEntry) {}
+
+    /**
+     * Notify the {@link StateMachine} that the progress of install snapshot is
+     * completely done. Could trigger the cleanup of snapshots.
+     */
+    default void notifyInstallSnapshotFinished() {}
   }
 
   /**

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1361,7 +1361,7 @@ class RaftServerImpl implements RaftServer.Division,
       boolean successInstalledSnapshot = snapshotInstallationHandler.checkSuccessInstalledSnapshot();
       if (successInstalledSnapshot) {
         LOG.info("{}: Follower has completed install the snapshot, notify InstallSnapshotFinished.", this);
-        stateMachine.event().notifyInstallSnapshotFinished();
+        stateMachine.event().notifyInstallSnapshotFinished(InstallSnapshotResult.SUCCESS);
       }
     }
     return JavaUtils.allOf(futures).whenCompleteAsync(

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1358,10 +1358,10 @@ class RaftServerImpl implements RaftServer.Division,
 
     if (!isHeartbeat) {
       CodeInjectionForTesting.execute(LOG_SYNC, getId(), null);
-      boolean successInstalledSnapshot = snapshotInstallationHandler.checkSuccessInstalledSnapshot();
-      if (successInstalledSnapshot) {
-        LOG.info("{}: Follower has completed install the snapshot, notify InstallSnapshotFinished.", this);
-        stateMachine.event().notifyInstallSnapshotFinished(InstallSnapshotResult.SUCCESS);
+      final long installedIndex = snapshotInstallationHandler.getInstalledIndex();
+      if (installedIndex >= RaftLog.LEAST_VALID_LOG_INDEX) {
+        LOG.info("{}: Follower has completed install the snapshot {}.", this, installedIndex);
+        stateMachine.event().notifySnapshotInstalled(InstallSnapshotResult.SUCCESS, installedIndex);
       }
     }
     return JavaUtils.allOf(futures).whenCompleteAsync(

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1358,6 +1358,11 @@ class RaftServerImpl implements RaftServer.Division,
 
     if (!isHeartbeat) {
       CodeInjectionForTesting.execute(LOG_SYNC, getId(), null);
+      boolean successInstalledSnapshot = snapshotInstallationHandler.checkSuccessInstalledSnapshot();
+      if (successInstalledSnapshot) {
+        LOG.info("{}: Follower has completed install the snapshot, notify InstallSnapshotFinished.", this);
+        stateMachine.event().notifyInstallSnapshotFinished();
+      }
     }
     return JavaUtils.allOf(futures).whenCompleteAsync(
         (r, t) -> followerState.ifPresent(fs -> fs.updateLastRpcTime(FollowerState.UpdateType.APPEND_COMPLETE))

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -304,7 +304,7 @@ class SnapshotInstallationHandler {
         LOG.info("{}: InstallSnapshot notification result: {}", getMemberId(),
             InstallSnapshotResult.SNAPSHOT_UNAVAILABLE);
         inProgressInstallSnapshotIndex.set(INVALID_LOG_INDEX);
-        server.getStateMachine().event().notifyInstallSnapshotFinished();
+        server.getStateMachine().event().notifyInstallSnapshotFinished(InstallSnapshotResult.SNAPSHOT_UNAVAILABLE);
         return ServerProtoUtils.toInstallSnapshotReplyProto(leaderId, getMemberId(),
             currentTerm, InstallSnapshotResult.SNAPSHOT_UNAVAILABLE, -1);
       }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -64,7 +64,7 @@ class SnapshotInstallationHandler {
   private final AtomicReference<TermIndex> installedSnapshotTermIndex =
     new AtomicReference<>(INVALID_TERM_INDEX);
   private final AtomicBoolean isSnapshotNull = new AtomicBoolean();
-  private final AtomicLong installedIndex = new AtomicLong();
+  private final AtomicLong installedIndex = new AtomicLong(INVALID_LOG_INDEX);
 
   SnapshotInstallationHandler(RaftServerImpl server, RaftProperties properties) {
     this.server = server;

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -81,6 +81,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
   private static final AtomicReference<SnapshotInfo> leaderSnapshotInfoRef = new AtomicReference<>();
 
   private static final AtomicInteger numSnapshotRequests = new AtomicInteger();
+  private static final AtomicInteger numNotifyInstallSnapshotFinished = new AtomicInteger();
 
   private static class StateMachine4InstallSnapshotNotificationTests extends SimpleStateMachine4Testing {
     @Override
@@ -120,6 +121,35 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
 
       return CompletableFuture.supplyAsync(supplier);
     }
+
+    @Override
+    public void notifyInstallSnapshotFinished() {
+      numNotifyInstallSnapshotFinished.incrementAndGet();
+      final SingleFileSnapshotInfo leaderSnapshotInfo = (SingleFileSnapshotInfo) leaderSnapshotInfoRef.get();
+      File leaderSnapshotFile = leaderSnapshotInfo.getFile().getPath().toFile();
+      synchronized (this) {
+        try {
+          if (getServer().get().getDivision(this.getGroupId()).getInfo().isLeader()) {
+            LOG.info("Receive the notification to clean up snapshot as leader");
+            if (leaderSnapshotFile.exists()) {
+              // For test purpose, we do not delete the leader's snapshot actually, which could be
+              // sent to more than one peer during the test
+              LOG.info("leader snapshot {} existed", leaderSnapshotFile);
+            }
+          } else {
+            LOG.info("Receive the notification to clean up snapshot as follower");
+            File followerSnapshotFile = new File(getSMdir(), leaderSnapshotFile.getName());
+            if (followerSnapshotFile.exists()) {
+              FileUtils.deleteFile(followerSnapshotFile);
+              LOG.info("follower snapshot {} deleted", followerSnapshotFile);
+            }
+          }
+        } catch (Exception ex) {
+          LOG.error("Failed to notify installSnapshot Finished", ex);
+        }
+      }
+    }
+
   }
 
   /**
@@ -182,6 +212,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
       }
 
       final SnapshotInfo leaderSnapshotInfo = cluster.getLeader().getStateMachine().getLatestSnapshot();
+      LOG.info("LeaderSnapshotInfo: {}", leaderSnapshotInfo.getTermIndex());
       final boolean set = leaderSnapshotInfoRef.compareAndSet(null, leaderSnapshotInfo);
       Assert.assertTrue(set);
 
@@ -361,7 +392,99 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
       cluster.shutdown();
     }
   }
-  
+
+  @Test
+  public void testInstallSnapshotFinishedEvent() throws Exception{
+    runWithNewCluster(1, this::testInstallSnapshotFinishedEvent);
+  }
+
+  private void testInstallSnapshotFinishedEvent(CLUSTER cluster) throws Exception{
+    leaderSnapshotInfoRef.set(null);
+    numNotifyInstallSnapshotFinished.set(0);
+    final List<LogSegmentPath> logs;
+    int i = 0;
+    try {
+      RaftTestUtil.waitForLeader(cluster);
+      final RaftPeerId leaderId = cluster.getLeader().getId();
+
+      try(final RaftClient client = cluster.createClient(leaderId)) {
+        for (; i < SNAPSHOT_TRIGGER_THRESHOLD * 2 - 1; i++) {
+          RaftClientReply
+              reply = client.io().send(new RaftTestUtil.SimpleMessage("m" + i));
+          Assert.assertTrue(reply.isSuccess());
+        }
+      }
+
+      // wait for the snapshot to be done
+      final RaftServer.Division leader = cluster.getLeader();
+      final long nextIndex = leader.getRaftLog().getNextIndex();
+      LOG.info("nextIndex = {}", nextIndex);
+      final List<File> snapshotFiles = RaftSnapshotBaseTest.getSnapshotFiles(cluster,
+          nextIndex - SNAPSHOT_TRIGGER_THRESHOLD, nextIndex);
+      JavaUtils.attemptRepeatedly(() -> {
+        Assert.assertTrue(snapshotFiles.stream().anyMatch(RaftSnapshotBaseTest::exists));
+        return null;
+      }, 10, ONE_SECOND, "snapshotFile.exist", LOG);
+      logs = LogSegmentPath.getLogSegmentPaths(leader.getRaftStorage());
+    } finally {
+      cluster.shutdown();
+    }
+
+    // delete the log segments from the leader
+    LOG.info("Delete logs {}", logs);
+    for (LogSegmentPath path : logs) {
+      FileUtils.deleteFully(path.getPath()); // the log may be already puged
+    }
+
+    // restart the peer
+    LOG.info("Restarting the cluster");
+    cluster.restart(false);
+    try {
+      RaftSnapshotBaseTest.assertLeaderContent(cluster);
+
+      // generate some more traffic
+      try(final RaftClient client = cluster.createClient(cluster.getLeader().getId())) {
+        Assert.assertTrue(client.io().send(new RaftTestUtil.SimpleMessage("m" + i)).isSuccess());
+      }
+
+      final SnapshotInfo leaderSnapshotInfo = cluster.getLeader().getStateMachine().getLatestSnapshot();
+      LOG.info("LeaderSnapshotInfo: {}", leaderSnapshotInfo.getTermIndex());
+      final boolean set = leaderSnapshotInfoRef.compareAndSet(null, leaderSnapshotInfo);
+      Assert.assertTrue(set);
+
+      // add one new peer
+      final MiniRaftCluster.PeerChanges change = cluster.addNewPeers(1, true, true);
+      // trigger setConfiguration
+      cluster.setConfiguration(change.allPeersInNewConf);
+
+      RaftServerTestUtil
+          .waitAndCheckNewConf(cluster, change.allPeersInNewConf, 0, null);
+
+      // Check the installed snapshot index on each Follower matches with the
+      // leader snapshot.
+      for (RaftServer.Division follower : cluster.getFollowers()) {
+        Assert.assertEquals(leaderSnapshotInfo.getIndex(),
+            RaftServerTestUtil.getLatestInstalledSnapshotIndex(follower));
+      }
+
+      // notification should be sent to both the leader and the follower
+      File leaderSnapshotFile = leaderSnapshotInfo.getFiles().get(0).getPath().toFile();
+      SimpleStateMachine4Testing followerStateMachine =
+          (SimpleStateMachine4Testing) cluster.getFollowers().get(0).getStateMachine();
+      File followerSnapshotFile = new File(followerStateMachine.getStateMachineStorage().getSmDir(),
+          leaderSnapshotFile.getName());
+      Assert.assertEquals(numNotifyInstallSnapshotFinished.get(), 2);
+      Assert.assertTrue(leaderSnapshotFile.exists());
+      Assert.assertFalse(followerSnapshotFile.exists());
+
+      // restart the peer and check if it can correctly handle conf change
+      cluster.restartServer(cluster.getLeader().getId(), false);
+      RaftSnapshotBaseTest.assertLeaderContent(cluster);
+    } finally {
+      cluster.shutdown();
+    }
+  }
+
   /**
    * Test for install snapshot during a peer bootstrap: start a one node cluster
    * (disable install snapshot option) and let it generate a snapshot. Add

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -123,7 +123,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
     }
 
     @Override
-    public void notifyInstallSnapshotFinished(RaftProtos.InstallSnapshotResult result) {
+    public void notifySnapshotInstalled(RaftProtos.InstallSnapshotResult result, long installIndex) {
       if (result != RaftProtos.InstallSnapshotResult.SUCCESS &&
           result != RaftProtos.InstallSnapshotResult.SNAPSHOT_UNAVAILABLE) {
         return;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the notify install snapshot would not inform when the whole progress is done

From the Ozone side, the statemachine's notifyInstallSnapshotFromLeader is a single request and process. It is fine before we find out that the installation of the snapshot could get stuck due to the whole RocksDB replacement each time (the leader could have purged the raft log during transferring the snapshot and thus triggers another snapshot installation when the previous install request is done). To solve this, we come up with the incremental snapshot idea, which could transfer the incremental part of RocksDB in the next install request, and needs to preserve the checkpoints.  The incremental snapshot needs to compare the checkpoints and hence the checkpoints cannot be deleted after the first request to install a snapshot.

The cleanup time of these checkpoints is hard to determine. It is difficult for the follower to tell whether the latest installed snapshot is the last one and apply the logs immediately. The cleanup time depends on the leader's state, and only the leader knows if it is the time to notify the snapshot again or just send append entries. Only when the leader thinks that the follower has already caught up could trigger the cleanup( error case is not included here).

Thus, we shall have an event to help trigger the cleanup of the checkpoints for the Ozone or generally inform the completeness of the install snapshot, which means no more install snapshot requests will be sent and the follower has caught up.

We trigger this event for both the leader and the follower.
As for the leader
1. when the leader receives the snapshot result `SNAPSHOT_INSTALLED`
2. when the leader receives the snapshot result  `SNAPSHOT_UNAVAILABLE`

As for the follower
1. when the follower tries appending new entries after successfully installed one snapshot for the first time
2. when the follower knows the statemachine's snapshot is unavailable

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1582

## How was this patch tested?
Manual test for ozone.
