### PR TITLE
RATIS-1587. Fix snapshot multi-chunk bug & support snapshot hierarchy

### DIFF
--- a/ratis-proto/src/main/proto/Grpc.proto
+++ b/ratis-proto/src/main/proto/Grpc.proto
@@ -44,7 +44,7 @@ service RaftServerProtocolService {
       returns(stream ratis.common.AppendEntriesReplyProto) {}
 
   rpc installSnapshot(stream ratis.common.InstallSnapshotRequestProto)
-      returns(ratis.common.InstallSnapshotReplyProto) {}
+      returns(stream ratis.common.InstallSnapshotReplyProto) {}
 }
 
 service AdminProtocolService {

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
@@ -65,7 +65,7 @@ public class SnapshotManager {
     final RaftStorageDirectory dir = storage.getStorageDir();
 
     // create a unique temporary directory
-    final File tmpDir =  new File(dir.getTmpDir(), UUID.randomUUID().toString());
+    final File tmpDir =  new File(dir.getTmpDir(), "snapshot-" + snapshotChunkRequest.getRequestId());
     FileUtils.createDirectories(tmpDir);
     tmpDir.deleteOnExit();
 
@@ -83,9 +83,10 @@ public class SnapshotManager {
       }
 
       String fileName = chunk.getFilename(); // this is relative to the root dir
-      // TODO: assumes flat layout inside SM dir
-      File tmpSnapshotFile = new File(tmpDir,
-          new File(dir.getRoot(), fileName).getName());
+      String fileNameToStateMachineDir = fileName.substring(
+              (dir.STATE_MACHINE_DIR_NAME.length()));
+      File tmpSnapshotFile = new File(tmpDir, fileNameToStateMachineDir);
+      FileUtils.createDirectories(tmpSnapshotFile);
 
       FileOutputStream out = null;
       try {


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Fix snapshot multiple-chunk bug. Currently, when leader install a snapshot(multiple chunks) to a newly joined follower, leader will send multiple InstallSnapshot RPCs. However, each RPC will create a tmp dir with Random UUID, place the chunk in this tmp dir, and **only renames the last tmp dir to sm-dir**. In this PR, I propose to create tmp dir using request.uuid(), which remains unchanged among multiple RPCs.

2. Fix Grpc Stream errors. Currently In grpc.proto, InstallSnapshot is declaimed as client-end streaming rpc, but it is actual bi-directional streaming rpc. In this PR, I addded `stream` to InstallSnapshot proto so that it becomes bi-directional.

3. Support snapshot file hierarchy. Currently all files of a snapshot will be placed in statemachine dir and file hierarchy is flattened. In this PR, I name each file using its original filename (which contains hierarchy information).

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1587

## How was this patch tested?
1. Unit Tests. It passed all unit tests in my machine (MacOS 12.13)
2. Manual Test. I packaged this version of ratis and tested its snapshot functionality in our project Apache IoTDB, and everything is working as expected
