### PR TITLE
RATIS-1587. Fix snapshot multi-chunk bug & support snapshot hierarchy

### DIFF
--- a/ratis-proto/src/main/proto/Grpc.proto
+++ b/ratis-proto/src/main/proto/Grpc.proto
@@ -44,7 +44,7 @@ service RaftServerProtocolService {
       returns(stream ratis.common.AppendEntriesReplyProto) {}
 
   rpc installSnapshot(stream ratis.common.InstallSnapshotRequestProto)
-      returns(ratis.common.InstallSnapshotReplyProto) {}
+      returns(stream ratis.common.InstallSnapshotReplyProto) {}
 }
 
 service AdminProtocolService {

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
@@ -21,7 +21,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
-import java.util.UUID;
+import java.nio.file.Path;
 
 import org.apache.ratis.io.CorruptedFileException;
 import org.apache.ratis.io.MD5Hash;
@@ -74,6 +74,7 @@ public class SnapshotManager {
     // TODO: Make sure that subsequent requests for the same installSnapshot are coming in order,
     // and are not lost when whole request cycle is done. Check requestId and requestIndex here
 
+    final Path stateMachineDir = dir.getStateMachineDir().toPath();
     for (FileChunkProto chunk : snapshotChunkRequest.getFileChunksList()) {
       SnapshotInfo pi = stateMachine.getLatestSnapshot();
       if (pi != null && pi.getTermIndex().getIndex() >= lastIncludedIndex) {
@@ -83,9 +84,8 @@ public class SnapshotManager {
       }
 
       String fileName = chunk.getFilename(); // this is relative to the root dir
-      String fileNameToStateMachineDir = fileName.substring(
-              (dir.STATE_MACHINE_DIR_NAME.length()));
-      File tmpSnapshotFile = new File(tmpDir, fileNameToStateMachineDir);
+      final Path relative = stateMachineDir.relativize(new File(dir.getRoot(), fileName).toPath());
+      final File tmpSnapshotFile = new File(tmpDir, relative.toString());
       FileUtils.createDirectories(tmpSnapshotFile);
 
       FileOutputStream out = null;

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
@@ -65,7 +65,7 @@ public class SnapshotManager {
     final RaftStorageDirectory dir = storage.getStorageDir();
 
     // create a unique temporary directory
-    final File tmpDir =  new File(dir.getTmpDir(), UUID.randomUUID().toString());
+    final File tmpDir =  new File(dir.getTmpDir(), "snapshot-" + snapshotChunkRequest.getRequestId());
     FileUtils.createDirectories(tmpDir);
     tmpDir.deleteOnExit();
 
@@ -83,9 +83,10 @@ public class SnapshotManager {
       }
 
       String fileName = chunk.getFilename(); // this is relative to the root dir
-      // TODO: assumes flat layout inside SM dir
-      File tmpSnapshotFile = new File(tmpDir,
-          new File(dir.getRoot(), fileName).getName());
+      String fileNameToStateMachineDir = fileName.substring(
+              (dir.STATE_MACHINE_DIR_NAME.length()));
+      File tmpSnapshotFile = new File(tmpDir, fileNameToStateMachineDir);
+      FileUtils.createDirectories(tmpSnapshotFile);
 
       FileOutputStream out = null;
       try {

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
@@ -1,0 +1,154 @@
+package org.apache.ratis;
+
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.server.impl.MiniRaftCluster;
+import org.apache.ratis.server.impl.RaftServerTestUtil;
+import org.apache.ratis.server.protocol.TermIndex;
+import org.apache.ratis.server.raftlog.RaftLog;
+import org.apache.ratis.server.storage.FileInfo;
+import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
+import org.apache.ratis.statemachine.SnapshotInfo;
+import org.apache.ratis.statemachine.StateMachine;
+import org.apache.ratis.statemachine.impl.FileListSnapshotInfo;
+import org.apache.ratis.util.FileUtils;
+import org.apache.ratis.util.LifeCycle;
+import org.apache.ratis.util.MD5FileUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftCluster>
+        extends BaseTest
+        implements MiniRaftCluster.Factory.Get<CLUSTER> {
+    static final Logger LOG = LoggerFactory.getLogger(InstallSnapshotFromLeaderTests.class);
+    {
+        final RaftProperties prop = getProperties();
+        prop.setClass(MiniRaftCluster.STATEMACHINE_CLASS_KEY,
+                StateMachineWithMultiNestedSnapshotFile.class, StateMachine.class);
+        RaftServerConfigKeys.Log.setPurgeGap(prop, PURGE_GAP);
+        RaftServerConfigKeys.Snapshot.setAutoTriggerThreshold(
+                prop, SNAPSHOT_TRIGGER_THRESHOLD);
+        RaftServerConfigKeys.Snapshot.setAutoTriggerEnabled(prop, true);
+    }
+
+    private static final int SNAPSHOT_TRIGGER_THRESHOLD = 64;
+    private static final int PURGE_GAP = 8;
+
+    @Test
+    public void testMultiFileInstallSnapshot() throws Exception {
+        runWithNewCluster(1, this::testMultiFileInstallSnapshot);
+    }
+
+    private void testMultiFileInstallSnapshot(CLUSTER cluster) throws Exception {
+        try {
+            int i = 0;
+            RaftTestUtil.waitForLeader(cluster);
+            final RaftPeerId leaderId = cluster.getLeader().getId();
+
+            try (final RaftClient client = cluster.createClient(leaderId)) {
+                for (; i < SNAPSHOT_TRIGGER_THRESHOLD * 2 - 1; i++) {
+                    RaftClientReply
+                            reply = client.io().send(new RaftTestUtil.SimpleMessage("m" + i));
+                    Assert.assertTrue(reply.isSuccess());
+                }
+
+                client.getSnapshotManagementApi(leaderId).create(3000);
+            }
+
+            final SnapshotInfo snapshot = cluster.getLeader().getStateMachine().getLatestSnapshot();
+            Assert.assertEquals(2, snapshot.getFiles().size());
+
+            // add two more peers
+            final MiniRaftCluster.PeerChanges change = cluster.addNewPeers(2, true,
+                    true);
+            // trigger setConfiguration
+            cluster.setConfiguration(change.allPeersInNewConf);
+
+            RaftServerTestUtil
+                    .waitAndCheckNewConf(cluster, change.allPeersInNewConf, 0, null);
+
+            // Check the installed snapshot file number on each Follower matches with the
+            // leader snapshot.
+            for (RaftServer.Division follower : cluster.getFollowers()) {
+                Assert.assertEquals(follower.getStateMachine().getLatestSnapshot().getFiles().size(), 2);
+            }
+        } finally {
+            cluster.shutdown();
+        }
+    }
+
+    private static class StateMachineWithMultiNestedSnapshotFile extends SimpleStateMachine4Testing {
+        // contains two snapshot files
+        // sm/snapshot/1.bin
+        // sm/snapshot/sub/2.bin
+        final File snapshotRoot = new File(getSMdir(), "snapshot");
+        final File file1 = new File(snapshotRoot, "1.bin");
+        final File file2 = new File(new File(snapshotRoot, "sub"), "2.bin");
+
+        @Override
+        public synchronized void pause() {
+            if (getLifeCycle().getCurrentState() == LifeCycle.State.RUNNING) {
+                getLifeCycle().transition(LifeCycle.State.PAUSING);
+                getLifeCycle().transition(LifeCycle.State.PAUSED);
+            }
+        }
+
+        @Override
+        public long takeSnapshot() {
+            final TermIndex termIndex = getLastAppliedTermIndex();
+            if (termIndex.getTerm() <= 0 || termIndex.getIndex() <= 0) {
+                return RaftLog.INVALID_LOG_INDEX;
+            }
+
+            final long endIndex = termIndex.getIndex();
+            try {
+                if (snapshotRoot.exists()) {
+                    return endIndex;
+                }
+                FileUtils.createDirectories(snapshotRoot);
+                FileUtils.createDirectories(file1.getParentFile());
+                FileUtils.createDirectories(file2.getParentFile());
+                FileUtils.createNewFile(file1.toPath());
+                FileUtils.createNewFile(file2.toPath());
+            } catch (IOException ioException) {
+                return RaftLog.INVALID_LOG_INDEX;
+            }
+
+            Assert.assertTrue(file1.exists());
+            Assert.assertTrue(file2.exists());
+            return endIndex;
+        }
+
+        @Override
+        public SnapshotInfo getLatestSnapshot() {
+            if (!snapshotRoot.exists() || !file1.exists() || !file2.exists()) {
+                return null;
+            }
+            List<FileInfo> files = new ArrayList<>();
+            try {
+                files.add(new FileInfo(
+                        file1.toPath(),
+                        MD5FileUtil.computeMd5ForFile(file1)));
+                files.add(new FileInfo(
+                        file2.toPath(),
+                        MD5FileUtil.computeMd5ForFile(file2)));
+            } catch (IOException ignored) {}
+            Assert.assertEquals(files.size(), 2);
+
+            TermIndex lastAppliedTermIndex = getLastAppliedTermIndex();
+            return new FileListSnapshotInfo(files,
+                    lastAppliedTermIndex.getTerm(), lastAppliedTermIndex.getIndex());
+        }
+    }
+}

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLeaderInstallSnapshot.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLeaderInstallSnapshot.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.InstallSnapshotFromLeaderTests;

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLeaderInstallSnapshot.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLeaderInstallSnapshot.java
@@ -1,0 +1,7 @@
+package org.apache.ratis.grpc;
+
+import org.apache.ratis.InstallSnapshotFromLeaderTests;
+
+public class TestLeaderInstallSnapshot
+extends InstallSnapshotFromLeaderTests<MiniRaftClusterWithGrpc>
+implements MiniRaftClusterWithGrpc.FactoryGet {}


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Fix snapshot multiple-chunk bug. Currently, when leader install a snapshot(multiple chunks) to a newly joined follower, leader will send multiple InstallSnapshot RPCs. However, each RPC will create a tmp dir with Random UUID, place the chunk in this tmp dir, and only renames the last tmp dir to sm-dir. In this PR, I propose to create tmp dir using request.uuid(), which remains unchanged among multiple RPCs.

* Fix Grpc Stream errors. Currently In grpc.proto, InstallSnapshot is declaimed as client-end streaming rpc, but it is actual bi-directional streaming rpc. In this PR, I addded stream to InstallSnapshot proto so that it becomes bi-directional.

* Support snapshot file hierarchy. Currently all files of a snapshot will be placed in statemachine dir and file hierarchy is flattened. In this PR, I name each file using its original filename (which contains hierarchy information).

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1587

## How was this patch tested?
* Unit Tests. It passed all unit tests in my machine (MacOS 12.13)
* Manual Test. I packaged this version of ratis and tested its snapshot functionality in our project Apache IoTDB, and everything is working as expected