### PR TITLE
RATIS-1597. Compute MD5 during snapshot streaming

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
@@ -153,14 +153,12 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
                 return null;
             }
             List<FileInfo> files = new ArrayList<>();
-            try {
-                files.add(new FileInfo(
-                        file1.toPath(),
-                        MD5FileUtil.computeMd5ForFile(file1)));
-                files.add(new FileInfo(
-                        file2.toPath(),
-                        MD5FileUtil.computeMd5ForFile(file2)));
-            } catch (IOException ignored) {}
+            files.add(new FileInfo(
+                    file1.toPath(),
+                    null));
+            files.add(new FileInfo(
+                    file2.toPath(),
+                    null));
             Assert.assertEquals(files.size(), 2);
 
             SnapshotInfo info = super.getLatestSnapshot();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently in InstallSnapshot, statemachine has to pre-compute each file's md5 digest and provide it in `FileInfo`. When snapshot file is large, this computing is time-consuming and may cause leader timeout. 
In this PR I propose to move the computing task along within the InstallSnapshot stream process. That is, for each SnapshotChunk,  we can read the chunk & compute its moving MD5 digest in the same time. This can enable us to read file & compute file MD5 in one sequential scan and thus save IO costs.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/RATIS/issues/RATIS-1597

## Compatible Change
Current application code won't be affected by this PR. If a digest is given in `FileInfo`, we still use the given digest. However, when digest is not provided (null) in `FileInfo`, the digest will be calculated by the above way.

## How was this patch tested?

It passes the UnitTest in InstallSnapshotFromLeaderTests.java
