### PR TITLE
RATIS-1610. NettyRpcService should not bind the port in the constructor.

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
@@ -44,6 +44,7 @@ import org.apache.ratis.proto.netty.NettyProtos.RaftNettyServerReplyProto;
 import org.apache.ratis.proto.netty.NettyProtos.RaftNettyServerRequestProto;
 import org.apache.ratis.util.CodeInjectionForTesting;
 import org.apache.ratis.util.JavaUtils;
+import org.apache.ratis.util.MemoizedSupplier;
 import org.apache.ratis.util.ProtoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,7 +85,7 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
 
   private final EventLoopGroup bossGroup = new NioEventLoopGroup();
   private final EventLoopGroup workerGroup = new NioEventLoopGroup();
-  private final ChannelFuture channelFuture;
+  private final MemoizedSupplier<ChannelFuture> channel;
 
   @ChannelHandler.Sharable
   class InboundHandler extends SimpleChannelInboundHandler<RaftNettyServerRequestProto> {
@@ -116,12 +117,12 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
     };
 
     final int port = NettyConfigKeys.Server.port(server.getProperties());
-    channelFuture = new ServerBootstrap()
+    this.channel = JavaUtils.memoize(() -> new ServerBootstrap()
         .group(bossGroup, workerGroup)
         .channel(NioServerSocketChannel.class)
         .handler(new LoggingHandler(LogLevel.INFO))
         .childHandler(initializer)
-        .bind(port);
+        .bind(port));
   }
 
   @Override
@@ -130,13 +131,16 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
   }
 
   private Channel getChannel() {
-    return channelFuture.awaitUninterruptibly().channel();
+    if (!channel.isInitialized()) {
+      throw new IllegalStateException(getId() + ": Failed to getChannel since the service is not yet started");
+    }
+    return channel.get().awaitUninterruptibly().channel();
   }
 
   @Override
   public void startImpl() throws IOException {
     try {
-      channelFuture.syncUninterruptibly();
+      channel.get().syncUninterruptibly();
     } catch(Exception t) {
       throw new IOException(getId() + ": Failed to start " + JavaUtils.getClassSimpleName(getClass()), t);
     }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1610