### PR TITLE
RATIS-1614. Upgrade Ratis Thirdparty to 1.0.1

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,30 +3,5 @@ Copyright 2017-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
---
-
-This product uses the dropwizard-hadoop-metrics2.
-
-Copyright 2016 Josh Elser
-
-Licensed under the Apache License v2.0
-
---
-
-Notice for Dropwizard:
-
-Metrics
-Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
-
-This product includes software developed by Coda Hale and Yammer, Inc.
-
-This product includes code derived from the JSR-166 project (ThreadLocalRandom, Striped64,
-LongAdder), which was released with the following comments:
-
-    Written by Doug Lea with assistance from members of JCP JSR-166
-    Expert Group and released to the public domain, as explained at
-    http://creativecommons.org/publicdomain/zero/1.0/
-
 --
 

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
     <maven.min.version>3.3.9</maven.min.version>
 
     <!-- Contains all shaded thirdparty dependencies -->
-    <ratis.thirdparty.version>1.0.0</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.1</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
     <shaded.protobuf.version>3.19.2</shaded.protobuf.version>
@@ -217,8 +217,8 @@
     <testsThreadCount>4</testsThreadCount>
 
     <!--metrics-->
-    <dropwizard.version>4.2.9</dropwizard.version>
-    <dropwizard.ganglia.version>3.2.6</dropwizard.ganglia.version>
+    <shaded.dropwizard.version>4.2.9</shaded.dropwizard.version>
+    <shaded.dropwizard.ganglia.version>3.2.6</shaded.dropwizard.ganglia.version>
   </properties>
 
   <dependencyManagement>
@@ -407,25 +407,25 @@
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
-        <version>${dropwizard.version}</version>
+        <version>${shaded.dropwizard.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-jvm</artifactId>
-        <version>${dropwizard.version}</version>
+        <version>${shaded.dropwizard.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-jmx</artifactId>
-        <version>${dropwizard.version}</version>
+        <version>${shaded.dropwizard.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-ganglia</artifactId>
-        <version>${dropwizard.ganglia.version}</version>
+        <version>${shaded.dropwizard.ganglia.version}</version>
       </dependency>
 
       <dependency>

--- a/ratis-assembly/src/main/resources/NOTICE
+++ b/ratis-assembly/src/main/resources/NOTICE
@@ -316,10 +316,3 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------------------------------------------------------------------
-This product uses the dropwizard-hadoop-metrics2.
-
-Copyright 2016 Josh Elser
-
-Licensed under the Apache License v2.0
-
---


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Ratis Thirdparty to 1.0.1, which has the following (non-test) changes:

RATIS-1585. Bump gson to 2.8.9 
RATIS-1591. Bump netty to 4.1.77
RATIS-1595. Shade dropwizard 4.x in ratis-thirdparty
RATIS-1601. Use the shaded dropwizard metrics and remove the dependency

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1614
https://issues.apache.org/jira/browse/RATIS-1601

## How was this patch tested?
https://github.com/codings-dan/incubator-ratis/actions/runs/2616031344