### PR TITLE
RATIS-1618. Resolve the stream client concurrent reconnection problem

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
@@ -164,10 +164,11 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
         return null; //closed
       }
       final Channel channel = future.syncUninterruptibly().channel();
-      if (channel.isOpen()) {
+      if (channel.isActive()) {
         return channel;
       }
-      return reconnect().syncUninterruptibly().channel();
+      ChannelFuture f = reconnect();
+      return f == null ? null : f.syncUninterruptibly().channel();
     }
 
     private EventLoopGroup getWorkerGroup() {
@@ -201,7 +202,17 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
       getWorkerGroup().schedule(this::reconnect, RECONNECT.getDuration(), RECONNECT.getUnit());
     }
 
-    private ChannelFuture reconnect() {
+    synchronized private ChannelFuture reconnect() {
+      // concurrent reconnect double check
+      ChannelFuture channelFuture = ref.get();
+      if (channelFuture != null) {
+        Channel channel = channelFuture.syncUninterruptibly().channel();
+        if (channel.isActive()) {
+          LOG.info("{} is already connect use exists channel {}", this, channel);
+          return channelFuture;
+        }
+      }
+
       final MemoizedSupplier<ChannelFuture> supplier = MemoizedSupplier.valueOf(this::connect);
       final ChannelFuture previous = ref.getAndUpdate(prev -> prev == null? null: supplier.get());
       if (previous != null) {
@@ -213,9 +224,11 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
     void close() {
       final ChannelFuture previous = ref.getAndSet(null);
       if (previous != null) {
-        previous.channel().close();
+        // wait channel closed, do shutdown workerGroup
+        previous.channel().close().addListener((future) -> workerGroup.shutdownGracefully());
+      } else {
+        workerGroup.shutdownGracefully();
       }
-      workerGroup.shutdownGracefully();
     }
 
     boolean isClosed() {
@@ -293,8 +306,6 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
             .map(replies::remove)
             .orElse(ReplyQueue.EMPTY)
             .forEach(f -> f.completeExceptionally(cause));
-
-        LOG.warn(name + ": exceptionCaught", cause);
         ctx.close();
       }
 
@@ -303,7 +314,6 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
         if (!connection.isClosed()) {
           connection.scheduleReconnect("channel is inactive", null);
         }
-        super.channelInactive(ctx);
       }
     };
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When there is a network problem, reconnection is triggered. 
If sending a lot of messages at the same time, multiple reconnections will be triggered. 
In this case, we need to wait for the result of the first reconnection synchronously

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1618