### PR TITLE
RATIS-1621. Fix intermittent failure in TestLeaderElectionMetrics

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/server/metrics/TestLeaderElectionMetrics.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/metrics/TestLeaderElectionMetrics.java
@@ -58,7 +58,7 @@ public class TestLeaderElectionMetrics extends BaseTest {
         (s, metric) -> s.contains(LAST_LEADER_ELECTION_ELAPSED_TIME));
     LOG.info("{} gauges: {}", LAST_LEADER_ELECTION_ELAPSED_TIME, gauges);
     final Long leaderElectionLatency = (Long)gauges.values().iterator().next().getValue();
-    assertTrue("leaderElectionLatency = " + leaderElectionLatency, leaderElectionLatency > 0L);
+    assertTrue("leaderElectionLatency = " + leaderElectionLatency, leaderElectionLatency >= 0L);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes an assertion in TestLeaderElectionMetrics.testOnLeaderElectionCompletion() to check that leaderElectionLatency >= 0 (was leaderElectionLatency > 0).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1621

## How was this patch tested?

I ran TestLeaderElectionMetrics.testOnLeaderElectionCompletion() a couple of thousand times (no failures).