### PR TITLE
RATIS-1622. Fix high CPU load when some followers are down

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -158,10 +158,18 @@ public class GrpcLogAppender extends LogAppenderBase {
   public long getWaitTimeMs() {
     if (haveTooManyPendingRequests()) {
       return getHeartbeatWaitTimeMs(); // Should wait for a short time
-    } else if (shouldSendAppendEntries()) {
+    } else if (shouldSendAppendEntries() && !isSlowFollower()) {
+      // For normal nodes, new entries should be sent ASAP
+      // however for slow followers (eapecially when the follower is down),
+      // keep sending without any wait time only ends up in high CPU load
       return 0L;
     }
     return Math.min(10L, getHeartbeatWaitTimeMs());
+  }
+
+  private boolean isSlowFollower() {
+    final TimeDuration elapsedTime = getFollower().getLastRpcResponseTime().elapsedTime();
+    return elapsedTime.compareTo(getServer().properties().rpcSlownessTimeout()) > 0;
   }
 
   private void mayWait() {

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -160,7 +160,7 @@ public class GrpcLogAppender extends LogAppenderBase {
       return getHeartbeatWaitTimeMs(); // Should wait for a short time
     } else if (shouldSendAppendEntries() && !isSlowFollower()) {
       // For normal nodes, new entries should be sent ASAP
-      // however for slow followers (eapecially when the follower is down),
+      // however for slow followers (especially when the follower is down),
       // keep sending without any wait time only ends up in high CPU load
       return 0L;
     }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
@@ -67,9 +67,7 @@ public interface RaftServer extends Closeable, RpcType.Get,
 
     /** @return the {@link RaftPeer} for this division. */
     default RaftPeer getPeer() {
-      return Optional.ofNullable(getGroup())
-          .map(g -> g.getPeer(getId()))
-          .orElseGet(() -> getRaftServer().getPeer());
+      return getRaftConf().getPeer(getId());
     }
 
     /** @return the information about this division. */

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
@@ -21,7 +21,6 @@ import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
-import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.protocol.*;
 import org.apache.ratis.rpc.RpcType;
 import org.apache.ratis.server.metrics.RaftServerMetrics;

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
@@ -41,7 +41,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Objects;
-import java.util.Optional;
 
 /** Raft server interface */
 public interface RaftServer extends Closeable, RpcType.Get,

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
@@ -21,6 +21,7 @@ import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
+import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.protocol.*;
 import org.apache.ratis.rpc.RpcType;
 import org.apache.ratis.server.metrics.RaftServerMetrics;
@@ -41,6 +42,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Optional;
 
 /** Raft server interface */
 public interface RaftServer extends Closeable, RpcType.Get,
@@ -66,7 +68,8 @@ public interface RaftServer extends Closeable, RpcType.Get,
 
     /** @return the {@link RaftPeer} for this division. */
     default RaftPeer getPeer() {
-      return getRaftConf().getPeer(getId());
+      return Optional.ofNullable(getRaftConf().getPeer(getId()))
+        .orElseGet(() -> getRaftServer().getPeer());
     }
 
     /** @return the information about this division. */

--- a/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
@@ -379,7 +379,7 @@ public abstract class ServerRestartTests<CLUSTER extends MiniRaftCluster>
       final long mid = size / 2;
       raf.seek(mid);
       for (long i = mid; i < size; i++) {
-        raf.write(0);
+        raf.write(-1);
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid using 0 delay for slow or dead followers when new entries comes.

## What is the link to the Apache JIRA

[RATIS-1622: High cpu usage of LogAppenderDaemon](https://issues.apache.org/jira/browse/RATIS-1622)

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Tested manually by using the following steps:
* Start a cluster of 5 nodes
* shutdown node 5 and 5
* make some change to get new log entry
* monitor the CPU usage of the leader node.

The CPU load is significantly reduced from 90% to 10%(in Docker environment, and cpus is limited to 1 for each node).

However, some unit tests fails locally. I'll open this to see if any tests will fail in CI.
