### PR TITLE
RATIS-1627. InstallSnapshotRequests add properties : totalSize

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/InstallSnapshotRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/InstallSnapshotRequests.java
@@ -59,6 +59,8 @@ class InstallSnapshotRequests implements Iterable<InstallSnapshotRequestProto> {
   private int fileIndex = 0;
   /** The current file. */
   private FileChunkReader current;
+  /** The total size of snapshot files. */
+  private long totalSize;
 
   InstallSnapshotRequests(RaftServer.Division server, RaftPeerId followerId,
       String requestId, SnapshotInfo snapshot, int snapshotChunkMaxSize) {
@@ -67,6 +69,8 @@ class InstallSnapshotRequests implements Iterable<InstallSnapshotRequestProto> {
     this.requestId = requestId;
     this.snapshot = snapshot;
     this.snapshotChunkMaxSize = snapshotChunkMaxSize;
+    this.totalSize = snapshot.getFiles().stream().mapToLong(FileInfo::getFileSize).reduce(Long::sum).orElseThrow(
+            () -> new IllegalStateException("Failed to compute total size for snapshot " + snapshot));
   }
 
   @Override
@@ -117,8 +121,6 @@ class InstallSnapshotRequests implements Iterable<InstallSnapshotRequestProto> {
   }
 
   private InstallSnapshotRequestProto newInstallSnapshotRequest(FileChunkProto chunk, boolean done) {
-    final long totalSize = snapshot.getFiles().stream().mapToLong(FileInfo::getFileSize).reduce(Long::sum).orElseThrow(
-        () -> new IllegalStateException("Failed to compute total size for snapshot " + snapshot));
     synchronized (server) {
       final SnapshotChunkProto.Builder b = LeaderProtoUtils.toSnapshotChunkProtoBuilder(
           requestId, requestIndex++, snapshot.getTermIndex(), chunk, totalSize, done);

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/InstallSnapshotRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/InstallSnapshotRequests.java
@@ -51,6 +51,8 @@ class InstallSnapshotRequests implements Iterable<InstallSnapshotRequestProto> {
 
   /** Maximum chunk size. */
   private final int snapshotChunkMaxSize;
+  /** The total size of snapshot files. */
+  private final long totalSize;
 
   /** The index of the current request. */
   private int requestIndex = 0;
@@ -59,8 +61,6 @@ class InstallSnapshotRequests implements Iterable<InstallSnapshotRequestProto> {
   private int fileIndex = 0;
   /** The current file. */
   private FileChunkReader current;
-  /** The total size of snapshot files. */
-  private long totalSize;
 
   InstallSnapshotRequests(RaftServer.Division server, RaftPeerId followerId,
       String requestId, SnapshotInfo snapshot, int snapshotChunkMaxSize) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

in method : org.apache.ratis.server.leader.InstallSnapshotRequests#newInstallSnapshotRequest; 

it is unnecessary to compute repeatedly the total size of snapshot .

## What is the link to the Apache JIRA

RATIS-1627. InstallSnapshotRequests add properties : totalSize

https://issues.apache.org/jira/browse/RATIS-1627

## How was this patch tested?

