### PR TITLE
RATIS-1629. Fix flaky TestRaftReconfigurationWithSimulatedRpc#testKillLeaderDuringReconf

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -426,13 +426,11 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
       final CompletableFuture<Void> setConf = new CompletableFuture<>();
       clientThread = new Thread(() -> {
         try(final RaftClient client = cluster.createClient(leaderId)) {
-          for(int i = 0; clientRunning.get() && !setConf.isDone(); i++) {
-            final RaftClientReply reply = client.admin().setConfiguration(c2.allPeersInNewConf);
-            if (reply.isSuccess()) {
-              setConf.complete(null);
-            }
-            LOG.info("setConf attempt #{} failed, {}", i, cluster.printServers());
+          final RaftClientReply reply = client.admin().setConfiguration(c2.allPeersInNewConf);
+          if (reply.isSuccess()) {
+            setConf.complete(null);
           }
+          LOG.info("setConf failed, {}", cluster.printServers());
         } catch(Exception e) {
           LOG.error("Failed to setConf", e);
           setConf.completeExceptionally(e);


### PR DESCRIPTION
Another approach of fix using retry.
See: https://github.com/apache/ratis/pull/686