### PR TITLE
RATIS-1633. Improve the grpc config output log information.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
@@ -154,6 +154,14 @@ public interface ConfUtils {
   }
 
   @SafeVarargs
+  static int getInt(
+      BiFunction<String, Integer, Integer> integerGetter,
+      String key, int defaultValue, int fallbackValue,
+      Consumer<String> logger, BiConsumer<String, Integer>... assertions) {
+    return get(integerGetter, key, defaultValue, fallbackValue, logger, assertions);
+  }
+
+  @SafeVarargs
   static long getLong(
       BiFunction<String, Long, Long> longGetter,
       String key, long defaultValue, Consumer<String> logger, BiConsumer<String, Long>... assertions) {
@@ -212,6 +220,19 @@ public interface ConfUtils {
     final T value = getter.apply(key, defaultValue);
     logGet(key, value, defaultValue, logger);
     Arrays.asList(assertions).forEach(a -> a.accept(key, value));
+    return value;
+  }
+
+  @SafeVarargs
+  static <T> T get(BiFunction<String, T, T> getter,
+      String key, T defaultValue, T fallbackValue,
+      Consumer<String> logger, BiConsumer<String, T>... assertions) {
+    T value = getter.apply(key, defaultValue);
+    value = value != defaultValue ? value : fallbackValue;
+    logGet(key, value, defaultValue, logger);
+
+    T finalValue = value;
+    Arrays.asList(assertions).forEach(a -> a.accept(key, finalValue));
     return value;
   }
 

--- a/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
@@ -227,12 +227,9 @@ public interface ConfUtils {
   static <T> T get(BiFunction<String, T, T> getter,
       String key, T defaultValue, T fallbackValue,
       Consumer<String> logger, BiConsumer<String, T>... assertions) {
-    T value = getter.apply(key, defaultValue);
+    T value = get(getter, key, defaultValue, null, assertions);
     value = value != defaultValue ? value : fallbackValue;
     logGet(key, value, defaultValue, logger);
-
-    T finalValue = value;
-    Arrays.asList(assertions).forEach(a -> a.accept(key, finalValue));
     return value;
   }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
@@ -100,9 +100,9 @@ public interface GrpcConfigKeys {
     String PORT_KEY = PREFIX + ".port";
     int PORT_DEFAULT = -1;
     static int port(RaftProperties properties) {
-      final int port = getInt(properties::getInt,
-          PORT_KEY, PORT_DEFAULT, getDefaultLog(), requireMin(-1), requireMax(65536));
-      return port != PORT_DEFAULT ? port : Server.port(properties);
+      final int fallbackServerPort = Server.port(properties, null);
+      return getInt(properties::getInt,
+          PORT_KEY, PORT_DEFAULT, fallbackServerPort, getDefaultLog(), requireMin(-1), requireMax(65536));
     }
     static void setPort(RaftProperties properties, int port) {
       setInt(properties::setInt, PORT_KEY, port);
@@ -124,9 +124,9 @@ public interface GrpcConfigKeys {
     String PORT_KEY = PREFIX + ".port";
     int PORT_DEFAULT = -1;
     static int port(RaftProperties properties) {
-      final int port = getInt(properties::getInt,
-          PORT_KEY, PORT_DEFAULT, getDefaultLog(), requireMin(-1), requireMax(65536));
-      return port != PORT_DEFAULT ? port : Server.port(properties);
+      final int fallbackServerPort = Server.port(properties, null);
+      return getInt(properties::getInt,
+          PORT_KEY, PORT_DEFAULT, fallbackServerPort, getDefaultLog(), requireMin(-1), requireMax(65536));
     }
     static void setPort(RaftProperties properties, int port) {
       setInt(properties::setInt, PORT_KEY, port);
@@ -148,9 +148,14 @@ public interface GrpcConfigKeys {
     String PORT_KEY = PREFIX + ".port";
     int PORT_DEFAULT = 0;
     static int port(RaftProperties properties) {
-      return getInt(properties::getInt,
-          PORT_KEY, PORT_DEFAULT, getDefaultLog(), requireMin(0), requireMax(65536));
+      return port(properties, getDefaultLog());
     }
+
+    static int port(RaftProperties properties, Consumer<String> logger) {
+      return getInt(properties::getInt,
+          PORT_KEY, PORT_DEFAULT, logger, requireMin(0), requireMax(65536));
+    }
+
     static void setPort(RaftProperties properties, int port) {
       setInt(properties::setInt, PORT_KEY, port);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When run the rpc server, always output redundant and wrong log, like admin.port、client.port.
```
2022-07-22 09:24:21 INFO  RaftServer:46 - raft.rpc.type = GRPC (default)
2022-07-22 09:24:21 INFO  GrpcFactory:48 - PERFORMANCE WARNING: useCacheForAllThreads is true that may cause Netty to create a lot garbage objects and, as a result, trigger GC.
	It is recommended to disable useCacheForAllThreads by setting -Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false in command line.
2022-07-22 09:24:21 INFO  GrpcConfigKeys:46 - raft.grpc.admin.port = -1 (default)
2022-07-22 09:24:21 INFO  GrpcConfigKeys:46 - raft.grpc.server.port = 10024 (custom)
2022-07-22 09:24:21 INFO  GrpcConfigKeys:46 - raft.grpc.client.port = -1 (default)
2022-07-22 09:24:21 INFO  GrpcConfigKeys:46 - raft.grpc.server.port = 10024 (custom)
2022-07-22 09:24:21 INFO  GrpcConfigKeys:46 - raft.grpc.server.port = 10024 (custom)
2022-07-22 09:24:21 INFO  GrpcService:46 - raft.grpc.message.size.max = 64MB (=67108864) (default)
2022-07-22 09:24:21 INFO  RaftServerConfigKeys:46 - raft.server.log.appender.buffer.byte-limit = 4MB (=4194304) (default)
2022-07-22 09:24:21 INFO  GrpcService:46 - raft.grpc.flow.control.window = 1MB (=1048576) (default)
```

After patch
```
2022-07-21 17:36:03 INFO  RaftServer:46 - raft.rpc.type = GRPC (default)
2022-07-21 17:36:03 INFO  GrpcFactory:48 - PERFORMANCE WARNING: useCacheForAllThreads is true that may cause Netty to create a lot garbage objects and, as a result, trigger GC.
	It is recommended to disable useCacheForAllThreads by setting -Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false in command line.
2022-07-21 17:36:03 INFO  GrpcConfigKeys:46 - raft.grpc.admin.port = 10024 (custom)
2022-07-21 17:36:03 INFO  GrpcConfigKeys:46 - raft.grpc.client.port = 10024 (custom)
2022-07-21 17:36:03 INFO  GrpcConfigKeys:46 - raft.grpc.server.port = 10024 (custom)
2022-07-21 17:36:03 INFO  GrpcService:46 - raft.grpc.message.size.max = 64MB (=67108864) (default)
2022-07-21 17:36:03 INFO  RaftServerConfigKeys:46 - raft.server.log.appender.buffer.byte-limit = 4MB (=4194304) (default)
2022-07-21 17:36:03 INFO  GrpcService:46 - raft.grpc.flow.control.window = 1MB (=1048576) (default)
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1633

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
