### PR TITLE
RATIS-1634. Close SegmentedRaftLogReader if init failed.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogInputStream.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogInputStream.java
@@ -90,13 +90,16 @@ public class SegmentedRaftLogInputStream implements Closeable {
 
   private void init() throws IOException {
     state.open();
+    boolean initSuccess = false;
     try {
-      final SegmentedRaftLogReader r = new SegmentedRaftLogReader(logFile, raftLogMetrics);
-      if (r.verifyHeader()) {
-        reader = r;
-      }
+      reader = new SegmentedRaftLogReader(logFile, raftLogMetrics);
+      initSuccess = reader.verifyHeader();
     } finally {
-      if (reader == null) {
+      if (!initSuccess) {
+        if(reader != null) {
+          reader.close();
+          reader = null;
+        }
         state.close();
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In SegmentedRaftLogInputStream#init, the SegmentedRaftLogReader instance is not correctly closed if the log is corrupted. The LogSegment#readSegmentFile function will try to delete empty segment, however it may fail on Windows because previously it's not closed. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1634

## How was this patch tested?

Already coverd in unit test ServerRestartTests#testRestartWithCorruptedLogHeader.