### PR TITLE
RATIS-1656. Leftover usage of ForkJoinPool.commonPool() in RaftServerImpl

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1413,7 +1413,7 @@ class RaftServerImpl implements RaftServer.Division,
             getRaftServer().getPeer());
       }
     }
-    return JavaUtils.allOf(futures).whenCompleteAsync(
+    return JavaUtils.allOf(futures).whenComplete(
         (r, t) -> followerState.ifPresent(fs -> fs.updateLastRpcTime(FollowerState.UpdateType.APPEND_COMPLETE))
     ).thenApply(v -> {
       final AppendEntriesReplyProto reply;

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1413,8 +1413,9 @@ class RaftServerImpl implements RaftServer.Division,
             getRaftServer().getPeer());
       }
     }
-    return JavaUtils.allOf(futures).whenComplete(
-        (r, t) -> followerState.ifPresent(fs -> fs.updateLastRpcTime(FollowerState.UpdateType.APPEND_COMPLETE))
+    return JavaUtils.allOf(futures).whenCompleteAsync(
+        (r, t) -> followerState.ifPresent(fs -> fs.updateLastRpcTime(FollowerState.UpdateType.APPEND_COMPLETE)),
+        serverExecutor
     ).thenApply(v -> {
       final AppendEntriesReplyProto reply;
       synchronized(this) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -115,7 +115,9 @@ class RaftServerProxy implements RaftServer {
         return;
       }
       isClosed = true;
-      map.entrySet().parallelStream().forEach(entry -> close(entry.getKey(), entry.getValue()));
+      ConcurrentUtils.parallelForEachAsync(map.entrySet(),
+          entry -> close(entry.getKey(), entry.getValue()),
+          executor);
     }
 
     private void close(RaftGroupId groupId, CompletableFuture<RaftServerImpl> future) {

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -51,6 +51,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -85,6 +87,9 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
   private static final AtomicInteger numNotifyInstallSnapshotFinished = new AtomicInteger();
 
   private static class StateMachine4InstallSnapshotNotificationTests extends SimpleStateMachine4Testing {
+
+    private final Executor stateMachineExecutor = Executors.newSingleThreadExecutor();
+
     @Override
     public CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(
         RaftProtos.RoleInfoProto roleInfoProto,
@@ -120,7 +125,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
         return leaderSnapshotInfo.getTermIndex();
       };
 
-      return CompletableFuture.supplyAsync(supplier);
+      return CompletableFuture.supplyAsync(supplier, stateMachineExecutor);
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

`RaftServerImpl#appendEntriesAsync` is still using the common pool here:

https://github.com/apache/ratis/blob/3db8f9eac82efedd51322a0d213300c9a0940bb6/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java#L1416-L1417

Preceding steps in `appendEntriesAsync` are already running on `serverExecutor`, so I think there is no need to further defer this step.

https://issues.apache.org/jira/browse/RATIS-1656

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/incubator-ratis/actions/runs/2789205160