### PR TITLE
RATIS-1658. Prepare unit check for running some tests repeatedly

### DIFF
--- a/dev-support/checks/unit.sh
+++ b/dev-support/checks/unit.sh
@@ -19,17 +19,44 @@ set -o pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../.." || exit 1
 
+: ${ITERATIONS:="1"}
+
+declare -i ITERATIONS
+if [[ ${ITERATIONS} -le 0 ]]; then
+  ITERATIONS=1
+fi
+
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../target/unit"}
 mkdir -p "$REPORT_DIR"
 
 export MAVEN_OPTS="-Xmx4096m"
-mvn -B -fae test "$@" | tee "${REPORT_DIR}/output.log"
-rc=$?
 
-# shellcheck source=dev-support/checks/_mvn_unit_report.sh
-source "$DIR/_mvn_unit_report.sh"
+rc=0
+for i in $(seq 1 ${ITERATIONS}); do
+  if [[ ${ITERATIONS} -gt 1 ]]; then
+    original_report_dir="${REPORT_DIR}"
+    REPORT_DIR="${original_report_dir}/iteration${i}"
+    mkdir -p "${REPORT_DIR}"
+  fi
 
-if [[ -s "$REPORT_DIR/summary.txt" ]] ; then
-    exit 1
-fi
+  mvn -B -fae test "$@" \
+    | tee "${REPORT_DIR}/output.log"
+  irc=$?
+
+  # shellcheck source=dev-support/checks/_mvn_unit_report.sh
+  source "${DIR}/_mvn_unit_report.sh"
+  if [[ ${irc} == 0 ]] && [[ -s "${REPORT_DIR}/summary.txt" ]]; then
+    irc=1
+  fi
+
+  if [[ ${ITERATIONS} -gt 1 ]]; then
+    REPORT_DIR="${original_report_dir}"
+    echo "Iteration ${i} exit code: ${irc}" | tee -a "${REPORT_DIR}/summary.txt"
+  fi
+
+  if [[ ${rc} == 0 ]]; then
+    rc=${irc}
+  fi
+done
+
 exit ${rc}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow running multiple iterations of tests in `unit.sh` simply by setting `ITERATIONS` environment variable.

Results (summary, output of failed tests) for all iterations are saved in separate subdirectories.

https://issues.apache.org/jira/browse/RATIS-1658

## How was this patch tested?

Locally:

```
$ ITERATIONS=3 ./dev-support/checks/unit.sh -Dtest=TestLogAppenderWithGrpc
...

$ find target/unit -type f | sort
target/unit/iteration1/failures
target/unit/iteration1/output.log
target/unit/iteration1/summary.txt
target/unit/iteration2/failures
target/unit/iteration2/output.log
target/unit/iteration2/summary.txt
target/unit/iteration3/failures
target/unit/iteration3/output.log
target/unit/iteration3/summary.txt
target/unit/summary.txt

$ cat target/unit/summary.txt
Iteration 1 exit code: 0
Iteration 2 exit code: 0
Iteration 3 exit code: 0
```

Sample usage in CI:
https://github.com/adoroszlai/incubator-ratis/blob/87eafcd2e19a49c1b251207955f19d5c9f3d0296/.github/workflows/post-commit.yml#L45-L47

Repeated run in CI:
https://github.com/adoroszlai/incubator-ratis/runs/7666927698?check_suite_focus=true#step:6:5

Regular CI:
https://github.com/adoroszlai/incubator-ratis/actions/runs/2794766233