### PR TITLE
RATIS-1669. Combine shell lib folder and root jars folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 target
 build
 patchprocess
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -394,6 +394,11 @@
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>1.7.29</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
         <scope>test</scope>
         <version>1.7.29</version>

--- a/ratis-assembly/src/main/assembly/bin.xml
+++ b/ratis-assembly/src/main/assembly/bin.xml
@@ -76,36 +76,5 @@
       <fileMode>0644</fileMode>
       <directoryMode>0755</directoryMode>
     </fileSet>
-    <!-- Include dev support tools -->
-<!--    <fileSet>-->
-<!--      <directory>${project.basedir}/../dev-support</directory>-->
-<!--      <outputDirectory>dev-support</outputDirectory>-->
-<!--      <fileMode>0644</fileMode>-->
-<!--      <directoryMode>0755</directoryMode>-->
-<!--    </fileSet>-->
-<!--    <fileSet>-->
-<!--      <directory>${project.basedir}/../ratis-shell/target/</directory>-->
-<!--      <outputDirectory>ratis-shell/lib/shell</outputDirectory>-->
-<!--      <fileMode>755</fileMode>-->
-<!--      <includes>-->
-<!--        <include>ratis-shell-*-jar-with-dependencies.jar</include>-->
-<!--      </includes>-->
-<!--    </fileSet>-->
-<!--    <fileSet>-->
-<!--      <directory>${project.basedir}/../ratis-shell/src/main/bin</directory>-->
-<!--      <outputDirectory>ratis-shell/bin</outputDirectory>-->
-<!--      <fileMode>755</fileMode>-->
-<!--    </fileSet>-->
-<!--    <fileSet>-->
-<!--      <directory>${project.basedir}/../ratis-shell/src/main/libexec</directory>-->
-<!--      <outputDirectory>ratis-shell/libexec</outputDirectory>-->
-<!--      <fileMode>0644</fileMode>-->
-<!--      <directoryMode>0755</directoryMode>-->
-<!--    </fileSet>-->
-<!--    <fileSet>-->
-<!--      <directory>${project.basedir}/../ratis-shell/src/main/conf</directory>-->
-<!--      <outputDirectory>ratis-shell/conf</outputDirectory>-->
-<!--      <fileMode>644</fileMode>-->
-<!--    </fileSet>-->
   </fileSets>
 </assembly>

--- a/ratis-assembly/src/main/assembly/examples-bin.xml
+++ b/ratis-assembly/src/main/assembly/examples-bin.xml
@@ -52,8 +52,8 @@
       <fileMode>0644</fileMode>
     </fileSet>
     <fileSet>
-      <directory>${project.basedir}/src/main/resources</directory>
-      <outputDirectory>.</outputDirectory>
+      <directory>${project.basedir}/../ratis-examples</directory>
+      <outputDirectory>examples</outputDirectory>
       <includes>
         <include>README.md</include>
       </includes>
@@ -65,19 +65,13 @@
       <includes>
         <include>*.*</include>
       </includes>
-      <fileMode>755</fileMode>
+      <fileMode>0755</fileMode>
     </fileSet>
-    <!-- Include dev support tools -->
-<!--    <fileSet>-->
-<!--      <directory>${project.basedir}/../dev-support</directory>-->
-<!--      <outputDirectory>dev-support</outputDirectory>-->
-<!--      <fileMode>0644</fileMode>-->
-<!--      <directoryMode>0755</directoryMode>-->
-<!--    </fileSet>-->
     <fileSet>
       <directory>${project.basedir}/../ratis-examples/src/main/resources</directory>
       <outputDirectory>examples/conf</outputDirectory>
       <includes>
+        <include>conf.properties</include>
         <include>log4j.properties</include>
       </includes>
       <fileMode>644</fileMode>

--- a/ratis-assembly/src/main/assembly/shell-bin.xml
+++ b/ratis-assembly/src/main/assembly/shell-bin.xml
@@ -22,11 +22,14 @@
   <fileSets>
     <fileSet>
       <directory>${project.basedir}/../ratis-shell/target/</directory>
-      <outputDirectory>lib/shell</outputDirectory>
-      <fileMode>755</fileMode>
+      <outputDirectory>jars</outputDirectory>
       <includes>
-        <include>ratis-shell-*-jar-with-dependencies.jar</include>
+        <include>ratis-shell-${project.version}.jar</include>
       </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../ratis-shell/target/lib/</directory>
+      <outputDirectory>jars</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/..</directory>
@@ -48,12 +51,12 @@
     <fileSet>
       <directory>${project.basedir}/../ratis-shell/src/main/bin</directory>
       <outputDirectory>bin</outputDirectory>
-      <fileMode>755</fileMode>
+      <fileMode>0755</fileMode>
     </fileSet>
     <fileSet>
       <directory>${project.basedir}/../ratis-shell/src/main/libexec</directory>
       <outputDirectory>libexec</outputDirectory>
-      <fileMode>0644</fileMode>
+      <fileMode>0755</fileMode>
       <directoryMode>0755</directoryMode>
     </fileSet>
     <fileSet>

--- a/ratis-examples/pom.xml
+++ b/ratis-examples/pom.xml
@@ -147,9 +147,8 @@
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>**/org/apache/log4j/chainsaw/**</exclude>
-                    <exclude>**/org/apache/log4j/jdbc/JDBCAppender.class</exclude>
-                    <exclude>**/org/apache/log4j/net/JMSAppender.class</exclude>
-                    <exclude>**/org/apache/log4j/net/JMSSink.class</exclude>
+                    <exclude>**/org/apache/log4j/jdbc/**</exclude>
+                    <exclude>**/org/apache/log4j/net/**</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/ratis-shell/pom.xml
+++ b/ratis-shell/pom.xml
@@ -27,10 +27,12 @@
     <dependency>
       <artifactId>ratis-client</artifactId>
       <groupId>org.apache.ratis</groupId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <artifactId>ratis-common</artifactId>
       <groupId>org.apache.ratis</groupId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -43,6 +45,10 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
       <version>0.10.2</version>
@@ -52,7 +58,28 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>
+                ${project.build.directory}/lib
+              </outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+        </configuration>
         <executions>
           <execution>
             <phase>package</phase>
@@ -60,7 +87,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
+              <finalName>${project.artifactId}-${project.version}</finalName>
 
               <filters>
                 <filter>
@@ -71,9 +98,9 @@
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>**/org/apache/log4j/chainsaw/**</exclude>
-                    <exclude>**/org/apache/log4j/jdbc/JDBCAppender.class</exclude>
-                    <exclude>**/org/apache/log4j/net/JMSAppender.class</exclude>
-                    <exclude>**/org/apache/log4j/net/JMSSink.class</exclude>
+                    <exclude>**/org/apache/log4j/jdbc/**</exclude>
+                    <exclude>**/org/apache/log4j/net/**</exclude>
+                    <exclude>**/org/slf4j/**</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/ratis-shell/pom.xml
+++ b/ratis-shell/pom.xml
@@ -74,50 +74,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <createDependencyReducedPom>false</createDependencyReducedPom>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <finalName>${project.artifactId}-${project.version}</finalName>
-
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>LICENSE</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                    <exclude>**/org/apache/log4j/chainsaw/**</exclude>
-                    <exclude>**/org/apache/log4j/jdbc/**</exclude>
-                    <exclude>**/org/apache/log4j/net/**</exclude>
-                    <exclude>**/org/slf4j/**</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <manifestEntries>
-                    <Main-Class>org.apache.ratis.shell.cli.sh.RatisShell</Main-Class>
-                  </manifestEntries>
-                </transformer>
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/ratis-shell/src/main/libexec/ratis-shell-config.sh
+++ b/ratis-shell/src/main/libexec/ratis-shell-config.sh
@@ -32,6 +32,7 @@ RATIS_SHELL_HOME=$(dirname $(dirname "${this}"))
 RATIS_SHELL_ASSEMBLY_CLIENT_JAR="${RATIS_SHELL_HOME}/lib/shell/*"
 RATIS_SHELL_CONF_DIR="${RATIS_SHELL_CONF_DIR:-${RATIS_SHELL_HOME}/conf}"
 RATIS_SHELL_LOGS_DIR="${RATIS_SHELL_LOGS_DIR:-${RATIS_SHELL_HOME}/logs}"
+RATIS_SHELL_LIB_DIR="${RATIS_SHELL_LIB_DIR:-${RATIS_SHELL_HOME}/jars}"
 
 if [[ -e "${RATIS_SHELL_CONF_DIR}/ratis-shell-env.sh" ]]; then
   . "${RATIS_SHELL_CONF_DIR}/ratis-shell-env.sh"
@@ -57,6 +58,16 @@ if [[ ${JAVA_MAJORMINOR} != 001008 && ${JAVA_MAJOR} != 011 ]]; then
   echo "Error: ratis-shell requires Java 8 or Java 11, currently Java $JAVA_VERSION found."
   exit 1
 fi
+
+local RATIS_SHELL_CLASSPATH
+
+while read -d '' -r jarfile ; do
+    if [[ "$RATIS_SHELL_CLASSPATH" == "" ]]; then
+        RATIS_SHELL_CLASSPATH="$jarfile";
+    else
+        RATIS_SHELL_CLASSPATH="$RATIS_SHELL_CLASSPATH":"$jarfile"
+    fi
+done < <(find "$RATIS_SHELL_LIB_DIR" ! -type d -name '*.jar' -print0 | sort -z)
 
 RATIS_SHELL_CLIENT_CLASSPATH="${RATIS_SHELL_CONF_DIR}/:${RATIS_SHELL_CLASSPATH}:${RATIS_SHELL_ASSEMBLY_CLIENT_JAR}"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The shell jar in the lib folder, while other jars in jars folder, we can put them together.

```
[dcadmin@dcadmin-work ratis]$ ll -a ratis-assembly/target/apache-ratis-3.0.0-SNAPSHOT
total 36
drwxr-xr-x 11 dcadmin dcadmin   178 Jan 22  2020 .
drwxrwxr-x  7 dcadmin dcadmin   264 Aug  8 11:31 ..
drwxr-xr-x  2 dcadmin dcadmin    19 Jan 22  2020 bin
drwxr-xr-x  2 dcadmin dcadmin    30 Jan 22  2020 conf
drwxr-xr-x  2 dcadmin dcadmin  4096 Jan 22  2020 jars
drwxr-xr-x  3 dcadmin dcadmin    19 Jan 22  2020 lib
drwxr-xr-x  2 dcadmin dcadmin    35 Jan 22  2020 libexec
-rw-r--r--  1 dcadmin dcadmin 13394 Jan 22  2020 LICENSE
-rw-r--r--  1 dcadmin dcadmin  5246 Jan 22  2020 NOTICE
-rw-r--r--  1 dcadmin dcadmin  1201 Jan 22  2020 README.md
drwxr-xr-x 21 dcadmin dcadmin  4096 Jan 22  2020 src 
```

After patch
```
[dcadmin@dcadmin-work apache-ratis-3.0.0-SNAPSHOT-bin]$ ll
total 32
drwxr-xr-x 2 dcadmin dcadmin    19 Jan 22  2020 bin
drwxr-xr-x 2 dcadmin dcadmin    30 Jan 22  2020 conf
drwxrwxr-x 5 dcadmin dcadmin    40 Aug 10 19:40 examples
drwxrwxr-x 2 dcadmin dcadmin  4096 Aug 10 19:40 jars
drwxr-xr-x 2 dcadmin dcadmin    35 Jan 22  2020 libexec
-rw-r--r-- 1 dcadmin dcadmin 13394 Jan 22  2020 LICENSE
drwxrwxr-x 2 dcadmin dcadmin    29 Aug 10 19:41 logs
-rw-r--r-- 1 dcadmin dcadmin  5537 Jan 22  2020 NOTICE
-rw-r--r-- 1 dcadmin dcadmin  1201 Jan 22  2020 README.md


[dcadmin@dcadmin-work apache-ratis-3.0.0-SNAPSHOT-bin]$ ll jars
total 24064
-rw-r--r-- 1 dcadmin dcadmin    58284 Jan 22  2020 commons-cli-1.5.0.jar
-rw-r--r-- 1 dcadmin dcadmin   851531 Jan 22  2020 javassist-3.28.0-GA.jar
-rw-r--r-- 1 dcadmin dcadmin    19936 Jan 22  2020 jsr305-3.0.2.jar
-rw-r--r-- 1 dcadmin dcadmin   489884 Jan 22  2020 log4j-1.2.17.jar
-rw-r--r-- 1 dcadmin dcadmin   116713 Jan 22  2020 ratis-client-3.0.0-SNAPSHOT.jar
-rw-r--r-- 1 dcadmin dcadmin   333006 Jan 22  2020 ratis-common-3.0.0-SNAPSHOT.jar
-rw-r--r-- 1 dcadmin dcadmin   126676 Jan 22  2020 ratis-grpc-3.0.0-SNAPSHOT.jar
-rw-r--r-- 1 dcadmin dcadmin    27006 Jan 22  2020 ratis-metrics-3.0.0-SNAPSHOT.jar
-rw-r--r-- 1 dcadmin dcadmin   111495 Jan 22  2020 ratis-netty-3.0.0-SNAPSHOT.jar
-rw-r--r-- 1 dcadmin dcadmin  1419397 Jan 22  2020 ratis-proto-3.0.0-SNAPSHOT.jar
-rw-r--r-- 1 dcadmin dcadmin     7266 Jan 22  2020 ratis-replicated-map-3.0.0-SNAPSHOT.jar
-rw-r--r-- 1 dcadmin dcadmin    46664 Jan 22  2020 ratis-resource-bundle-3.0.0-SNAPSHOT.jar
-rw-r--r-- 1 dcadmin dcadmin   416433 Jan 22  2020 ratis-server-3.0.0-SNAPSHOT.jar
-rw-r--r-- 1 dcadmin dcadmin    90772 Jan 22  2020 ratis-server-api-3.0.0-SNAPSHOT.jar
-rw-r--r-- 1 dcadmin dcadmin  1602623 Jan 22  2020 ratis-shell-3.0.0-SNAPSHOT-jar-with-dependencies.jar
-rw-r--r-- 1 dcadmin dcadmin     6826 Jan 22  2020 ratis-test-3.0.0-SNAPSHOT.jar
-rw-r--r-- 1 dcadmin dcadmin 18685030 Jan 22  2020 ratis-thirdparty-misc-1.0.1.jar
-rw-r--r-- 1 dcadmin dcadmin    11618 Jan 22  2020 ratis-tools-3.0.0-SNAPSHOT.jar
-rw-r--r-- 1 dcadmin dcadmin   130398 Jan 22  2020 reflections-0.10.2.jar
-rw-r--r-- 1 dcadmin dcadmin    41424 Jan 22  2020 slf4j-api-1.7.29.jar
-rw-r--r-- 1 dcadmin dcadmin    12211 Jan 22  2020 slf4j-log4j12-1.7.29.jar
[dcadmin@dcadmin-work apache-ratis-3.0.0-SNAPSHOT-bin]$ 
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1669

## How was this patch tested?

run `bin/ratis` command.

```
[dcadmin@dcadmin-work apache-ratis-3.0.0-SNAPSHOT-bin]$ bin/ratis sh
Usage: ratis sh [generic options]
	 [election [transfer] [stepDown] [pause] [resume]]         
	 [group [info] [list]]                                     
	 [peer [add] [remove] [setPriority]]                       
	 [snapshot [create]]                                       
```