### PR TITLE
RATIS-1638. Separate first election timeout

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
@@ -214,6 +214,15 @@ public interface ConfUtils {
     return value;
   }
 
+  @SafeVarargs
+  static TimeDuration getTimeDuration(
+        BiFunction<String, TimeDuration, TimeDuration> getter,
+        String key, TimeDuration defaultValue, String fallbackKey, TimeDuration fallbackValue,
+        Consumer<String> logger, BiConsumer<String, TimeDuration>... assertions) {
+    return get(getter, key, defaultValue, fallbackKey, fallbackValue, logger, assertions);
+  }
+
+
   static TlsConf getTlsConf(
       Function<String, TlsConf> tlsConfGetter,
       String key, Consumer<String> logger) {

--- a/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
@@ -219,7 +219,9 @@ public interface ConfUtils {
         BiFunction<String, TimeDuration, TimeDuration> getter,
         String key, TimeDuration defaultValue, String fallbackKey, TimeDuration fallbackValue,
         Consumer<String> logger, BiConsumer<String, TimeDuration>... assertions) {
-    return get(getter, key, defaultValue, fallbackKey, fallbackValue, logger, assertions);
+    final TimeDuration value = get(getter, key, defaultValue, fallbackKey, fallbackValue, logger, assertions);
+    requireNonNegativeTimeDuration().accept(key, value);
+    return value;
   }
 
 

--- a/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
@@ -247,10 +247,11 @@ public interface ConfUtils {
     T value = get(getter, key, defaultValue, null, assertions);
     if (value != defaultValue) {
       logGet(key, value, defaultValue, logger);
+      return value;
     } else {
       logFallback(key, fallbackKey, fallbackValue, logger);
+      return fallbackValue;
     }
-    return value;
   }
 
   static InetSocketAddress getInetSocketAddress(

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -608,9 +608,12 @@ public interface RaftServerConfigKeys {
 
     String TIMEOUT_MIN_KEY = PREFIX + ".timeout.min";
     TimeDuration TIMEOUT_MIN_DEFAULT = TimeDuration.valueOf(150, TimeUnit.MILLISECONDS);
-    static TimeDuration timeoutMin(RaftProperties properties) {
+    static TimeDuration timeoutMin(RaftProperties properties, Consumer<String> logger) {
       return getTimeDuration(properties.getTimeDuration(TIMEOUT_MIN_DEFAULT.getUnit()),
-          TIMEOUT_MIN_KEY, TIMEOUT_MIN_DEFAULT, getDefaultLog());
+          TIMEOUT_MIN_KEY, TIMEOUT_MIN_DEFAULT, logger);
+    }
+    static TimeDuration timeoutMin(RaftProperties properties) {
+      return timeoutMin(properties, getDefaultLog());
     }
     static void setTimeoutMin(RaftProperties properties, TimeDuration minDuration) {
       setTimeDuration(properties::setTimeDuration, TIMEOUT_MIN_KEY, minDuration);
@@ -618,35 +621,39 @@ public interface RaftServerConfigKeys {
 
     String TIMEOUT_MAX_KEY = PREFIX + ".timeout.max";
     TimeDuration TIMEOUT_MAX_DEFAULT = TimeDuration.valueOf(300, TimeUnit.MILLISECONDS);
-    static TimeDuration timeoutMax(RaftProperties properties) {
+    static TimeDuration timeoutMax(RaftProperties properties, Consumer<String> logger) {
       return getTimeDuration(properties.getTimeDuration(TIMEOUT_MAX_DEFAULT.getUnit()),
-          TIMEOUT_MAX_KEY, TIMEOUT_MAX_DEFAULT, getDefaultLog());
+          TIMEOUT_MAX_KEY, TIMEOUT_MAX_DEFAULT, logger);
+    }
+    static TimeDuration timeoutMax(RaftProperties properties) {
+      return timeoutMax(properties, getDefaultLog());
     }
     static void setTimeoutMax(RaftProperties properties, TimeDuration maxDuration) {
       setTimeDuration(properties::setTimeDuration, TIMEOUT_MAX_KEY, maxDuration);
     }
 
     /** separate first timeout so that the startup unavailable time can be reduced */
-    String FIRST_TIMEOUT_MIN_KEY = PREFIX + ".first.timeout.min";
-    TimeDuration FIRST_TIMEOUT_MIN_DEFAULT = TimeDuration.valueOf(150, TimeUnit.MILLISECONDS);
-    static TimeDuration firstTimeoutMin(RaftProperties properties) {
-      final TimeDuration fallbackFirstTimeoutMin = Rpc.timeoutMin(properties);
-      return getTimeDuration(properties.getTimeDuration(fallbackFirstTimeoutMin.getUnit()),
-          FIRST_TIMEOUT_MIN_KEY, fallbackFirstTimeoutMin, getDefaultLog());
+    String FIRST_ELECTION_TIMEOUT_MIN_KEY = PREFIX + ".first-election.timeout.min";
+    TimeDuration FIRST_ELECTION_TIMEOUT_MIN_DEFAULT = null;
+    static TimeDuration firstElectionTimeoutMin(RaftProperties properties) {
+      final TimeDuration fallbackFirstElectionTimeoutMin = Rpc.timeoutMin(properties, null);
+      return getTimeDuration(properties.getTimeDuration(fallbackFirstElectionTimeoutMin.getUnit()),
+          FIRST_ELECTION_TIMEOUT_MIN_KEY, FIRST_ELECTION_TIMEOUT_MIN_DEFAULT,
+          Rpc.TIMEOUT_MIN_KEY, fallbackFirstElectionTimeoutMin, getDefaultLog());
     }
-    static void setFirstTimeoutMin(RaftProperties properties, TimeDuration firstMinDuration) {
-      setTimeDuration(properties::setTimeDuration, FIRST_TIMEOUT_MIN_KEY, firstMinDuration);
+    static void setFirstElectionTimeoutMin(RaftProperties properties, TimeDuration firstMinDuration) {
+      setTimeDuration(properties::setTimeDuration, FIRST_ELECTION_TIMEOUT_MIN_KEY, firstMinDuration);
     }
 
-    String FIRST_TIMEOUT_MAX_KEY = PREFIX + ".first.timeout.max";
-    TimeDuration FIRST_TIMEOUT_MAX_DEFAULT = TimeDuration.valueOf(300, TimeUnit.MILLISECONDS);
-    static TimeDuration firstTimeoutMax(RaftProperties properties) {
-      final TimeDuration fallbackFirstTimeoutMax = Rpc.timeoutMax(properties);
-      return getTimeDuration(properties.getTimeDuration(fallbackFirstTimeoutMax.getUnit()),
-          FIRST_TIMEOUT_MAX_KEY, fallbackFirstTimeoutMax, getDefaultLog());
+    String FIRST_ELECTION_TIMEOUT_MAX_KEY = PREFIX + ".first-election.timeout.max";
+    TimeDuration FIRST_ELECTION_TIMEOUT_MAX_DEFAULT = null;
+    static TimeDuration firstElectionTimeoutMax(RaftProperties properties) {
+      final TimeDuration fallbackFirstElectionTimeoutMax = Rpc.timeoutMax(properties, null);
+      return getTimeDuration(properties.getTimeDuration(fallbackFirstElectionTimeoutMax.getUnit()),
+          FIRST_ELECTION_TIMEOUT_MAX_KEY, fallbackFirstElectionTimeoutMax, getDefaultLog());
     }
-    static void setFirstTimeoutMax(RaftProperties properties, TimeDuration firstMaxDuration) {
-      setTimeDuration(properties::setTimeDuration, FIRST_TIMEOUT_MAX_KEY, firstMaxDuration);
+    static void setFirstElectionTimeoutMax(RaftProperties properties, TimeDuration firstMaxDuration) {
+      setTimeDuration(properties::setTimeDuration, FIRST_ELECTION_TIMEOUT_MAX_KEY, firstMaxDuration);
     }
 
     String REQUEST_TIMEOUT_KEY = PREFIX + ".request.timeout";

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -626,6 +626,29 @@ public interface RaftServerConfigKeys {
       setTimeDuration(properties::setTimeDuration, TIMEOUT_MAX_KEY, maxDuration);
     }
 
+    /** separate first timeout so that the startup unavailable time can be reduced */
+    String FIRST_TIMEOUT_MIN_KEY = PREFIX + ".first.timeout.min";
+    TimeDuration FIRST_TIMEOUT_MIN_DEFAULT = null;
+    static TimeDuration firstTimeoutMin(RaftProperties properties) {
+      final TimeDuration fallbackFirstTimeoutMin = Rpc.timeoutMin(properties);
+      return getTimeDuration(properties.getTimeDuration(fallbackFirstTimeoutMin.getUnit()),
+          FIRST_TIMEOUT_MIN_KEY, fallbackFirstTimeoutMin, getDefaultLog());
+    }
+    static void setFirstTimeoutMin(RaftProperties properties, TimeDuration firstMinDuration) {
+      setTimeDuration(properties::setTimeDuration, FIRST_TIMEOUT_MIN_KEY, firstMinDuration);
+    }
+
+    String FIRST_TIMEOUT_MAX_KEY = PREFIX + ".first.timeout.max";
+    TimeDuration FIRST_TIMEOUT_MAX_DEFAULT = null;
+    static TimeDuration firstTimeoutMax(RaftProperties properties) {
+      final TimeDuration fallbackFirstTimeoutMax = Rpc.timeoutMax(properties);
+      return getTimeDuration(properties.getTimeDuration(fallbackFirstTimeoutMax.getUnit()),
+          FIRST_TIMEOUT_MAX_KEY, fallbackFirstTimeoutMax, getDefaultLog());
+    }
+    static void setFirstTimeoutMax(RaftProperties properties, TimeDuration firstMaxDuration) {
+      setTimeDuration(properties::setTimeDuration, FIRST_TIMEOUT_MAX_KEY, firstMaxDuration);
+    }
+
     String REQUEST_TIMEOUT_KEY = PREFIX + ".request.timeout";
     TimeDuration REQUEST_TIMEOUT_DEFAULT = TimeDuration.valueOf(3000, TimeUnit.MILLISECONDS);
     static TimeDuration requestTimeout(RaftProperties properties) {

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -650,7 +650,8 @@ public interface RaftServerConfigKeys {
     static TimeDuration firstElectionTimeoutMax(RaftProperties properties) {
       final TimeDuration fallbackFirstElectionTimeoutMax = Rpc.timeoutMax(properties, null);
       return getTimeDuration(properties.getTimeDuration(fallbackFirstElectionTimeoutMax.getUnit()),
-          FIRST_ELECTION_TIMEOUT_MAX_KEY, fallbackFirstElectionTimeoutMax, getDefaultLog());
+          FIRST_ELECTION_TIMEOUT_MAX_KEY, TIMEOUT_MAX_DEFAULT,
+          Rpc.TIMEOUT_MAX_KEY, fallbackFirstElectionTimeoutMax, getDefaultLog());
     }
     static void setFirstElectionTimeoutMax(RaftProperties properties, TimeDuration firstMaxDuration) {
       setTimeDuration(properties::setTimeDuration, FIRST_ELECTION_TIMEOUT_MAX_KEY, firstMaxDuration);

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -650,7 +650,7 @@ public interface RaftServerConfigKeys {
     static TimeDuration firstElectionTimeoutMax(RaftProperties properties) {
       final TimeDuration fallbackFirstElectionTimeoutMax = Rpc.timeoutMax(properties, null);
       return getTimeDuration(properties.getTimeDuration(fallbackFirstElectionTimeoutMax.getUnit()),
-          FIRST_ELECTION_TIMEOUT_MAX_KEY, TIMEOUT_MAX_DEFAULT,
+          FIRST_ELECTION_TIMEOUT_MAX_KEY, FIRST_ELECTION_TIMEOUT_MAX_DEFAULT,
           Rpc.TIMEOUT_MAX_KEY, fallbackFirstElectionTimeoutMax, getDefaultLog());
     }
     static void setFirstElectionTimeoutMax(RaftProperties properties, TimeDuration firstMaxDuration) {

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -628,7 +628,7 @@ public interface RaftServerConfigKeys {
 
     /** separate first timeout so that the startup unavailable time can be reduced */
     String FIRST_TIMEOUT_MIN_KEY = PREFIX + ".first.timeout.min";
-    TimeDuration FIRST_TIMEOUT_MIN_DEFAULT = null;
+    TimeDuration FIRST_TIMEOUT_MIN_DEFAULT = TimeDuration.valueOf(150, TimeUnit.MILLISECONDS);
     static TimeDuration firstTimeoutMin(RaftProperties properties) {
       final TimeDuration fallbackFirstTimeoutMin = Rpc.timeoutMin(properties);
       return getTimeDuration(properties.getTimeDuration(fallbackFirstTimeoutMin.getUnit()),
@@ -639,7 +639,7 @@ public interface RaftServerConfigKeys {
     }
 
     String FIRST_TIMEOUT_MAX_KEY = PREFIX + ".first.timeout.max";
-    TimeDuration FIRST_TIMEOUT_MAX_DEFAULT = null;
+    TimeDuration FIRST_TIMEOUT_MAX_DEFAULT = TimeDuration.valueOf(300, TimeUnit.MILLISECONDS);
     static TimeDuration firstTimeoutMax(RaftProperties properties) {
       final TimeDuration fallbackFirstTimeoutMax = Rpc.timeoutMax(properties);
       return getTimeDuration(properties.getTimeDuration(fallbackFirstTimeoutMax.getUnit()),

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -257,8 +257,8 @@ class RaftServerImpl implements RaftServer.Division,
 
   private TimeDuration getFirstRandomElectionTimeout() {
     final RaftProperties properties = proxy.getProperties();
-    final int min = RaftServerConfigKeys.Rpc.firstTimeoutMin(properties).toIntExact(TimeUnit.MILLISECONDS);
-    final int max = RaftServerConfigKeys.Rpc.firstTimeoutMax(properties).toIntExact(TimeUnit.MILLISECONDS);
+    final int min = RaftServerConfigKeys.Rpc.firstElectionTimeoutMin(properties).toIntExact(TimeUnit.MILLISECONDS);
+    final int max = RaftServerConfigKeys.Rpc.firstElectionTimeoutMax(properties).toIntExact(TimeUnit.MILLISECONDS);
     final int mills = min + ThreadLocalRandom.current().nextInt(max - min + 1);
     return TimeDuration.valueOf(mills, TimeUnit.MILLISECONDS);
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -187,7 +187,7 @@ class RaftServerImpl implements RaftServer.Division,
   private final ExecutorService serverExecutor;
   private final ExecutorService clientExecutor;
 
-  private final AtomicBoolean firstElectionTimeout = new AtomicBoolean(true);
+  private final AtomicBoolean firstElectionSinceStartup = new AtomicBoolean(true);
 
   RaftServerImpl(RaftGroup group, StateMachine stateMachine, RaftServerProxy proxy) throws IOException {
     final RaftPeerId id = proxy.getId();
@@ -247,7 +247,7 @@ class RaftServerImpl implements RaftServer.Division,
   }
 
   TimeDuration getRandomElectionTimeout() {
-    if (firstElectionTimeout.compareAndSet(true, false)) {
+    if (firstElectionSinceStartup.get()) {
       return getFirstRandomElectionTimeout();
     }
     final int min = properties().minRpcTimeoutMs();
@@ -1737,5 +1737,9 @@ class RaftServerImpl implements RaftServer.Division,
       return proxy.getGroupIds().stream().map(RaftGroupId::toString)
           .collect(Collectors.toList());
     }
+  }
+
+  public void onGroupLeaderElected() {
+    this.firstElectionSinceStartup.set(false);
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1739,7 +1739,7 @@ class RaftServerImpl implements RaftServer.Division,
     }
   }
 
-  public void onGroupLeaderElected() {
+  void onGroupLeaderElected() {
     this.firstElectionSinceStartup.set(false);
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -315,6 +315,7 @@ class ServerState implements Closeable {
       leaderId = newLeaderId;
       if (leaderId != null) {
         server.finishTransferLeadership();
+        server.onGroupLeaderElected();
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
ElectionTimeout cannot be set too small, which will lead to frequent leader change when full GC occurs. However, longer ElectionTimeout will cause longer unavailable times during start up, which is annoying.
In this PR I propose to separate first election timeout and normal election timeout. This can enable Raft Group elect a leader quickly during start up while avoid frequent leader change during normal operations.
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1638

## How was this patch tested?
unit tests
