### PR TITLE
RATIS-1673. Verify duplicate peerid when init raft group

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftGroup.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftGroup.java
@@ -61,13 +61,9 @@ public final class RaftGroup {
     if (peers == null || !peers.iterator().hasNext()) {
       this.peers = Collections.emptyMap();
     } else {
+      Preconditions.assertUnique(peers);
       final Map<RaftPeerId, RaftPeer> map = new HashMap<>();
-      peers.forEach(p -> {
-        Preconditions.assertTrue(!map.containsKey(p.getId()),
-            () -> "PeerId " + p.getId() + " has already appeared in this group.");
-        map.put(p.getId(), p);
-      });
-
+      peers.forEach(p -> map.put(p.getId(), p));
       this.peers = Collections.unmodifiableMap(map);
     }
   }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftGroup.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftGroup.java
@@ -62,7 +62,12 @@ public final class RaftGroup {
       this.peers = Collections.emptyMap();
     } else {
       final Map<RaftPeerId, RaftPeer> map = new HashMap<>();
-      peers.forEach(p -> map.put(p.getId(), p));
+      peers.forEach(p -> {
+        Preconditions.assertTrue(!map.containsKey(p.getId()),
+            () -> "PeerId " + p.getId() + " has already appeared in this group.");
+        map.put(p.getId(), p);
+      });
+
       this.peers = Collections.unmodifiableMap(map);
     }
   }

--- a/ratis-test/src/test/java/org/apache/ratis/protocol/TestRaftGroup.java
+++ b/ratis-test/src/test/java/org/apache/ratis/protocol/TestRaftGroup.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.protocol;
+
+import org.apache.ratis.BaseTest;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+public class TestRaftGroup extends BaseTest {
+  @Override
+  public int getGlobalTimeoutSeconds() {
+    return 1;
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testDuplicatePeerId() throws Exception {
+    UUID groupId = UUID.fromString("02511d47-d67c-49a3-9011-abb3109a44c1");
+
+    List<RaftPeer> peers = new LinkedList<>();
+    peers.add(RaftPeer.newBuilder().setId("n0").build());
+    peers.add(RaftPeer.newBuilder().setId("n0").build());
+    RaftGroup.valueOf(RaftGroupId.valueOf(groupId), peers);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

When run ratis example, the script still runs normally while the peerids are same.
```
BIN=ratis-examples/src/main/bin
PEERS=n0:127.0.0.1:6000,n0:127.0.0.1:6001,n0:127.0.0.1:6002
```

After patch
```
[dcadmin@dcadmin-work ratis]$     PEERS=n0:127.0.0.1:6000,n0:127.0.0.1:6001,n0:127.0.0.1:6002
[dcadmin@dcadmin-work ratis]$ ID=n0; ${BIN}/server.sh arithmetic server --id ${ID} --storage /tmp/ratis/test/${ID} --peers ${PEERS}
Found /work/projects/opensource/raft/ratis/ratis-examples/target/ratis-examples-3.0.0-SNAPSHOT.jar
Exception in thread "main" java.lang.IllegalStateException: PeerId n0 has already appeared in this group.
        at org.apache.ratis.util.Preconditions.assertTrue(Preconditions.java:72)
        at org.apache.ratis.protocol.RaftGroup.lambda$new$2(RaftGroup.java:66)
        at java.util.Arrays$ArrayList.forEach(Arrays.java:3880)
        at org.apache.ratis.protocol.RaftGroup.<init>(RaftGroup.java:65)
        at org.apache.ratis.protocol.RaftGroup.valueOf(RaftGroup.java:38)
        at org.apache.ratis.examples.arithmetic.cli.Server.run(Server.java:77)
        at org.apache.ratis.examples.common.Runner.main(Runner.java:63)
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1673

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
