### PR TITLE
RATIS-1680. TestLeaderInstallSnapshot creates untracked files

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
@@ -20,6 +20,7 @@ package org.apache.ratis;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
@@ -28,6 +29,7 @@ import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.server.storage.FileInfo;
+import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.SnapshotInfo;
 import org.apache.ratis.statemachine.StateMachine;
@@ -106,12 +108,22 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
     }
 
     private static class StateMachineWithMultiNestedSnapshotFile extends SimpleStateMachine4Testing {
-        // contains two snapshot files
-        // sm/snapshot/1.bin
-        // sm/snapshot/sub/2.bin
-        final File snapshotRoot = new File(getSMdir(), "snapshot");
-        final File file1 = new File(snapshotRoot, "1.bin");
-        final File file2 = new File(new File(snapshotRoot, "sub"), "2.bin");
+
+        File snapshotRoot;
+        File file1;
+        File file2;
+
+        @Override
+        public synchronized void initialize(RaftServer server, RaftGroupId groupId, RaftStorage raftStorage) throws IOException {
+            super.initialize(server, groupId, raftStorage);
+
+            // contains two snapshot files
+            // sm/snapshot/1.bin
+            // sm/snapshot/sub/2.bin
+            snapshotRoot = new File(getSMdir(), "snapshot");
+            file1 = new File(snapshotRoot, "1.bin");
+            file2 = new File(new File(snapshotRoot, "sub"), "2.bin");
+        }
 
         @Override
         public synchronized void pause() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestLeaderInstallSnapshot` leaves untracked files in `ratis-test/snapshot` directory.

```
$ mvn clean test -DfailIfNoTests=false -Dtest=TestLeaderInstallSnapshot
...
$ git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	ratis-test/snapshot/

nothing added to commit but untracked files present (use "git add" to track)

$ find ratis-test/snapshot | sort
ratis-test/snapshot
ratis-test/snapshot/1.bin
ratis-test/snapshot/sub
ratis-test/snapshot/sub/2.bin
```

The root cause is that `getSMdir()` returns `null` until storage is initialized.

https://issues.apache.org/jira/browse/RATIS-1680

## How was this patch tested?

```
$ mvn clean test -DfailIfNoTests=false -Dtest=TestLeaderInstallSnapshot
...
$ git status
On branch RATIS-1680

nothing to commit, working tree clean
```

Regular CI:
https://github.com/adoroszlai/incubator-ratis/actions/runs/2882163120