### PR TITLE
RATIS-1681. Use atomic_move to enhance robustness

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/FileUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/FileUtils.java
@@ -76,9 +76,15 @@ public interface FileUtils {
   }
 
   static void move(Path src, Path dst) throws IOException {
-    LogUtils.runAndLog(LOG,
+    try {
+      LogUtils.runAndLog(LOG,
         () -> Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE),
-        () -> "Files.move " + src + " to " + dst);
+        () -> "Atomic Files.move " + src + " to " + dst);
+    } catch (AtomicMoveNotSupportedException e) {
+      LogUtils.runAndLog(LOG,
+        () -> Files.move(src, dst),
+        () -> "Atomic move not supported. Fallback to Files.move " + src + " to " + dst);
+    }
   }
 
   /**

--- a/ratis-common/src/main/java/org/apache/ratis/util/FileUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/FileUtils.java
@@ -77,7 +77,7 @@ public interface FileUtils {
 
   static void move(Path src, Path dst) throws IOException {
     LogUtils.runAndLog(LOG,
-        () -> Files.move(src, dst),
+        () -> Files.move(src, dst, StandardCopyOption.ATOMIC_MOVE),
         () -> "Files.move " + src + " to " + dst);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use StandardCopyOption.ATOMIC_MOVE to enhance robustness.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1681

## How was this patch tested?
unit tests
