### PR TITLE
RATIS-1682. Fix ratis make_rc.sh prepare-bin phase

### DIFF
--- a/dev-support/make_rc.sh
+++ b/dev-support/make_rc.sh
@@ -117,6 +117,7 @@ prepare-bin() {
   mkdir -p "$WORKINGDIR"
   cd "$WORKINGDIR"
   tar zvxf "$projectdir/ratis-assembly/target/apache-ratis-${RATISVERSION}-src.tar.gz"
+  mv "apache-ratis-${RATISVERSION}-src" "apache-ratis-${RATISVERSION}"
   cd "apache-ratis-${RATISVERSION}"
 
   mvnFun clean install assembly:single -DskipTests=true  -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}"


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/RATIS-1682
