### PR TITLE
RATIS-1684. Upgrade Ratis Thirdparty to 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
     <shaded.protobuf.version>3.19.2</shaded.protobuf.version>
-    <shaded.grpc.version>1.44.0</shaded.grpc.version>
+    <shaded.grpc.version>1.48.1</shaded.grpc.version>
 
     <!-- Test properties -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>

--- a/pom.xml
+++ b/pom.xml
@@ -216,10 +216,6 @@
     <test.exclude.pattern>_</test.exclude.pattern>
     <!-- number of threads/forks to use when running tests in parallel, see parallel-tests profile -->
     <testsThreadCount>4</testsThreadCount>
-
-    <!--metrics-->
-    <shaded.dropwizard.version>4.2.9</shaded.dropwizard.version>
-    <shaded.dropwizard.ganglia.version>3.2.6</shaded.dropwizard.ganglia.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
     <maven.min.version>3.3.9</maven.min.version>
 
     <!-- Contains all shaded thirdparty dependencies -->
-    <ratis.thirdparty.version>1.0.1</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.2</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
     <shaded.protobuf.version>3.19.2</shaded.protobuf.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Ratis Thirdparty to 1.0.2, which has the following (non-test) changes:

RATIS-1600. Add protobuf-java-util
RATIS-1632. Upgrade gRPC to 1.48.1
RATIS-1664. Exclude org.slf4j.* in ratis-thirdparty-misc
RATIS-1679. Shade io.perfmark:perfmark-api in ratis-thirdparty


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1684

## How was this patch tested?
https://github.com/codings-dan/incubator-ratis/actions/runs/2910213305
