### PR TITLE
RATIS-1687. Make SetConfigurationRequest backwards compatible

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/SetConfigurationRequest.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/SetConfigurationRequest.java
@@ -149,9 +149,34 @@ public class SetConfigurationRequest extends RaftClientRequest {
   private final Arguments arguments;
 
   public SetConfigurationRequest(ClientId clientId, RaftPeerId serverId,
+      RaftGroupId groupId, long callId, List<RaftPeer> peers) {
+    this(clientId, serverId, groupId, callId,
+        Arguments.newBuilder()
+            .setServersInNewConf(peers)
+            .build());
+  }
+
+  public SetConfigurationRequest(ClientId clientId, RaftPeerId serverId,
+      RaftGroupId groupId, long callId, List<RaftPeer> peers, List<RaftPeer> listeners) {
+    this(clientId, serverId, groupId, callId,
+        Arguments.newBuilder()
+            .setServersInNewConf(peers)
+            .setListenersInNewConf(listeners)
+            .build());
+  }
+
+  public SetConfigurationRequest(ClientId clientId, RaftPeerId serverId,
       RaftGroupId groupId, long callId, Arguments arguments) {
     super(clientId, serverId, groupId, callId, true, writeRequestType());
     this.arguments = arguments;
+  }
+
+  public List<RaftPeer> getPeersInNewConf() {
+    return arguments.serversInNewConf;
+  }
+
+  public List<RaftPeer> getListenersInNewConf() {
+    return arguments.listenersInNewConf;
   }
 
   public Arguments getArguments() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes made to SetConfigurationRequest for RATIS-1593 and RATIS-1594 are not backwards compatible.  Downstream component (e.g. Ozone) needs code change to be able to construct a SetConfigurationRequest after upgrade.  I think we should support the old interface for 2.4.0.

https://issues.apache.org/jira/browse/RATIS-1687

## How was this patch tested?

Built Ratis, compiled Ozone with it.

Regular CI:
https://github.com/adoroszlai/incubator-ratis/actions/runs/2929301261