### PR TITLE
RATIS-1690. Disable fail-fast for unit check

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -120,7 +120,7 @@ jobs:
           - grpc
           - server
           - misc
-      fail-fast: ${{ github.event_name == 'pull_request' }}
+      fail-fast: false
     steps:
         # TEMPORARY WHILE GITHUB FIXES https://github.com/actions/virtual-environments/issues/3185
         - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file


### PR DESCRIPTION
## What changes were proposed in this pull request?

RATIS-1313 added matrix build with fail-fast behavior, which RATIS-1341 restricted to PRs only.  Due to a Github improvement committers can now choose to re-run only failed tasks.  Thus cancelling parallel runs no longer provides the most cost-effective way to get a clean run.

https://issues.apache.org/jira/browse/RATIS-1690

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/incubator-ratis/actions/runs/2933403333