### PR TITLE
RATIS-1689. Remove the use of the thirdparty Gauge.

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/GrpcServerMetrics.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/GrpcServerMetrics.java
@@ -17,13 +17,13 @@
  */
 package org.apache.ratis.grpc.metrics;
 
-import org.apache.ratis.thirdparty.com.codahale.metrics.Gauge;
 import org.apache.ratis.metrics.MetricRegistryInfo;
 import org.apache.ratis.metrics.RatisMetricRegistry;
 import org.apache.ratis.metrics.RatisMetrics;
-import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 import org.apache.ratis.thirdparty.com.codahale.metrics.Timer;
+
+import java.util.function.Supplier;
 
 public class GrpcServerMetrics extends RatisMetrics {
   private static final String RATIS_GRPC_METRICS_APP_NAME = "ratis_grpc";
@@ -89,8 +89,7 @@ public class GrpcServerMetrics extends RatisMetrics {
         follower)).inc();
   }
 
-  public void addPendingRequestsCount(String follower,
-      Gauge pendinglogQueueSize) {
+  public void addPendingRequestsCount(String follower, Supplier<Integer> pendinglogQueueSize) {
     registry.gauge(String.format(RATIS_GRPC_METRICS_LOG_APPENDER_PENDING_COUNT, follower), () -> pendinglogQueueSize);
   }
 
@@ -100,10 +99,5 @@ public class GrpcServerMetrics extends RatisMetrics {
 
   public static String getHeartbeatSuffix(boolean heartbeat) {
     return heartbeat ? "_heartbeat" : "";
-  }
-
-  @VisibleForTesting
-  public RatisMetricRegistry getRegistry() {
-    return registry;
   }
 }

--- a/ratis-metrics/src/main/java/org/apache/ratis/metrics/MetricRegistryInfo.java
+++ b/ratis-metrics/src/main/java/org/apache/ratis/metrics/MetricRegistryInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,10 +18,9 @@
 
 package org.apache.ratis.metrics;
 
+import org.apache.ratis.thirdparty.com.codahale.metrics.MetricRegistry;
 
 import java.util.Objects;
-
-import org.apache.ratis.thirdparty.com.codahale.metrics.*;
 
 /**
  *

--- a/ratis-metrics/src/main/java/org/apache/ratis/metrics/MetricsReporting.java
+++ b/ratis-metrics/src/main/java/org/apache/ratis/metrics/MetricsReporting.java
@@ -17,14 +17,14 @@
  */
 package org.apache.ratis.metrics;
 
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-
-import org.apache.ratis.thirdparty.com.codahale.metrics.*;
+import org.apache.ratis.thirdparty.com.codahale.metrics.ConsoleReporter;
 import org.apache.ratis.thirdparty.com.codahale.metrics.jmx.JmxReporter;
 import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 public final class MetricsReporting {
   public static final Logger LOG = LoggerFactory.getLogger(MetricsReporting.class);

--- a/ratis-metrics/src/main/java/org/apache/ratis/metrics/RatisMetricRegistry.java
+++ b/ratis-metrics/src/main/java/org/apache/ratis/metrics/RatisMetricRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,11 +17,18 @@
  */
 package org.apache.ratis.metrics;
 
-import java.util.SortedMap;
-
-import org.apache.ratis.thirdparty.com.codahale.metrics.*;
+import org.apache.ratis.thirdparty.com.codahale.metrics.ConsoleReporter;
+import org.apache.ratis.thirdparty.com.codahale.metrics.Counter;
+import org.apache.ratis.thirdparty.com.codahale.metrics.Histogram;
+import org.apache.ratis.thirdparty.com.codahale.metrics.Meter;
+import org.apache.ratis.thirdparty.com.codahale.metrics.Metric;
+import org.apache.ratis.thirdparty.com.codahale.metrics.MetricRegistry;
+import org.apache.ratis.thirdparty.com.codahale.metrics.MetricSet;
+import org.apache.ratis.thirdparty.com.codahale.metrics.Timer;
 import org.apache.ratis.thirdparty.com.codahale.metrics.jmx.JmxReporter;
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
+
+import java.util.function.Supplier;
 
 public interface RatisMetricRegistry {
   Timer timer(String name);
@@ -30,11 +37,9 @@ public interface RatisMetricRegistry {
 
   boolean remove(String name);
 
-  Gauge gauge(String name, MetricRegistry.MetricSupplier<Gauge> supplier);
+  <T> void gauge(String name, Supplier<Supplier<T>> gaugeSupplier);
 
   Timer timer(String name, MetricRegistry.MetricSupplier<Timer> supplier);
-
-  SortedMap<String, Gauge> getGauges(MetricFilter filter);
 
   Counter counter(String name, MetricRegistry.MetricSupplier<Counter> supplier);
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineMetrics.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineMetrics.java
@@ -56,10 +56,8 @@ public final class StateMachineMetrics extends RatisMetrics {
   private StateMachineMetrics(String serverId, LongSupplier getApplied,
       LongSupplier getApplyCompleted) {
     registry = getMetricRegistryForStateMachine(serverId);
-    registry.gauge(STATEMACHINE_APPLIED_INDEX_GAUGE,
-        () -> () -> getApplied.getAsLong());
-    registry.gauge(STATEMACHINE_APPLY_COMPLETED_GAUGE,
-        () -> () -> getApplyCompleted.getAsLong());
+    registry.gauge(STATEMACHINE_APPLIED_INDEX_GAUGE, () -> getApplied::getAsLong);
+    registry.gauge(STATEMACHINE_APPLY_COMPLETED_GAUGE, () -> getApplyCompleted::getAsLong);
   }
 
   private RatisMetricRegistry getMetricRegistryForStateMachine(String serverId) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/metrics/RaftLogMetricsBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/metrics/RaftLogMetricsBase.java
@@ -18,12 +18,12 @@
 
 package org.apache.ratis.server.metrics;
 
-import org.apache.ratis.thirdparty.com.codahale.metrics.*;
 import org.apache.ratis.metrics.MetricRegistryInfo;
 import org.apache.ratis.metrics.RatisMetricRegistry;
 import org.apache.ratis.metrics.RatisMetrics;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.server.raftlog.LogEntryHeader;
+import org.apache.ratis.thirdparty.com.codahale.metrics.Timer;
 
 public class RaftLogMetricsBase extends RatisMetrics implements RaftLogMetrics {
   public static final String RATIS_LOG_WORKER_METRICS_DESC = "Metrics for Log Worker";

--- a/ratis-server/src/main/java/org/apache/ratis/server/metrics/RaftServerMetricsImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/metrics/RaftServerMetricsImpl.java
@@ -22,12 +22,10 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.SortedMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.ratis.thirdparty.com.codahale.metrics.Counter;
-import org.apache.ratis.thirdparty.com.codahale.metrics.Gauge;
 import org.apache.ratis.thirdparty.com.codahale.metrics.Timer;
 
 import org.apache.ratis.metrics.MetricRegistryInfo;
@@ -40,7 +38,6 @@ import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.metrics.RatisMetrics;
 import org.apache.ratis.server.RetryCache;
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
-import org.apache.ratis.util.Preconditions;
 
 /**
  * Metric Registry for Raft Group Server. One instance per leader/follower.
@@ -88,7 +85,7 @@ public final class RaftServerMetricsImpl extends RatisMetrics implements RaftSer
   /** id -> key */
   private static final Map<RaftPeerId, String> PEER_COMMIT_INDEX_GAUGE_KEYS = new ConcurrentHashMap<>();
 
-  private static String getPeerCommitIndexGaugeKey(RaftPeerId serverId) {
+  static String getPeerCommitIndexGaugeKey(RaftPeerId serverId) {
     return PEER_COMMIT_INDEX_GAUGE_KEYS.computeIfAbsent(serverId,
         key -> String.format(LEADER_METRIC_PEER_COMMIT_INDEX, key));
   }
@@ -152,26 +149,9 @@ public final class RaftServerMetricsImpl extends RatisMetrics implements RaftSer
         .orElse(0L));
   }
 
-  /**
-   * Get the commit index gauge for the given peer of the server
-   * @return Metric Gauge holding the value of commit index of the peer
-   */
   @VisibleForTesting
-  public static Gauge getPeerCommitIndexGauge(RaftGroupMemberId serverId, RaftPeerId peerId) {
-
-    final RaftServerMetricsImpl serverMetrics = METRICS.get(serverId);
-    if (serverMetrics == null) {
-      return null;
-    }
-
-    final String followerCommitIndexKey = getPeerCommitIndexGaugeKey(peerId);
-
-    SortedMap<String, Gauge> map =
-        serverMetrics.registry.getGauges((s, metric) ->
-            s.contains(followerCommitIndexKey));
-
-    Preconditions.assertTrue(map.size() <= 1);
-    return map.get(map.firstKey());
+  static RaftServerMetricsImpl getImpl(RaftGroupMemberId serverId) {
+    return METRICS.get(serverId);
   }
 
   /**
@@ -213,7 +193,7 @@ public final class RaftServerMetricsImpl extends RatisMetrics implements RaftSer
     registry.counter(REQUEST_QUEUE_LIMIT_HIT_COUNTER).inc();
   }
 
-  public void addNumPendingRequestsGauge(Gauge queueSize) {
+  public void addNumPendingRequestsGauge(Supplier<Integer> queueSize) {
     registry.gauge(REQUEST_QUEUE_SIZE, () -> queueSize);
   }
 
@@ -221,7 +201,7 @@ public final class RaftServerMetricsImpl extends RatisMetrics implements RaftSer
     return registry.remove(REQUEST_QUEUE_SIZE);
   }
 
-  public void addNumPendingRequestsMegaByteSize(Gauge megabyteSize) {
+  public void addNumPendingRequestsMegaByteSize(Supplier<Integer> megabyteSize) {
     registry.gauge(REQUEST_MEGA_BYTE_SIZE, () -> megabyteSize);
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/metrics/SegmentedRaftLogMetrics.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/metrics/SegmentedRaftLogMetrics.java
@@ -18,12 +18,10 @@
 
 package org.apache.ratis.server.metrics;
 
-import org.apache.ratis.thirdparty.com.codahale.metrics.*;
 import org.apache.ratis.protocol.RaftGroupMemberId;
-import org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogCache;
-import org.apache.ratis.util.DataQueue;
+import org.apache.ratis.thirdparty.com.codahale.metrics.Timer;
 
-import java.util.Queue;
+import java.util.function.Supplier;
 
 public class SegmentedRaftLogMetrics extends RaftLogMetricsBase {
   //////////////////////////////
@@ -82,34 +80,28 @@ public class SegmentedRaftLogMetrics extends RaftLogMetricsBase {
     super(serverId);
   }
 
-  public void addDataQueueSizeGauge(DataQueue queue) {
-    registry.gauge(RAFT_LOG_DATA_QUEUE_SIZE, () -> queue::getNumElements);
+  public void addDataQueueSizeGauge(Supplier<Integer> numElements) {
+    registry.gauge(RAFT_LOG_DATA_QUEUE_SIZE, () -> numElements);
   }
 
-  public void addClosedSegmentsNum(SegmentedRaftLogCache cache) {
-    registry.gauge(RAFT_LOG_CACHE_CLOSED_SEGMENTS_NUM, () -> () -> {
-      return cache.getCachedSegmentNum();
-    });
+  public void addClosedSegmentsNum(Supplier<Long> cachedSegmentNum) {
+    registry.gauge(RAFT_LOG_CACHE_CLOSED_SEGMENTS_NUM, () -> cachedSegmentNum);
   }
 
-  public void addClosedSegmentsSizeInBytes(SegmentedRaftLogCache cache) {
-    registry.gauge(RAFT_LOG_CACHE_CLOSED_SEGMENTS_SIZE_IN_BYTES, () -> () -> {
-      return cache.getClosedSegmentsSizeInBytes();
-    });
+  public void addClosedSegmentsSizeInBytes(Supplier<Long> closedSegmentsSizeInBytes) {
+    registry.gauge(RAFT_LOG_CACHE_CLOSED_SEGMENTS_SIZE_IN_BYTES, () -> closedSegmentsSizeInBytes);
   }
 
-  public void addOpenSegmentSizeInBytes(SegmentedRaftLogCache cache) {
-    registry.gauge(RAFT_LOG_CACHE_OPEN_SEGMENT_SIZE_IN_BYTES, () -> () -> {
-      return cache.getOpenSegmentSizeInBytes();
-    });
+  public void addOpenSegmentSizeInBytes(Supplier<Long> openSegmentSizeInBytes) {
+    registry.gauge(RAFT_LOG_CACHE_OPEN_SEGMENT_SIZE_IN_BYTES, () -> openSegmentSizeInBytes);
   }
 
-  public void addLogWorkerQueueSizeGauge(Queue queue) {
-    registry.gauge(RAFT_LOG_WORKER_QUEUE_SIZE, () -> () -> queue.size());
+  public void addLogWorkerQueueSizeGauge(Supplier<Integer> queueSize) {
+    registry.gauge(RAFT_LOG_WORKER_QUEUE_SIZE, () -> queueSize);
   }
 
-  public void addFlushBatchSizeGauge(MetricRegistry.MetricSupplier<Gauge> supplier) {
-    registry.gauge(RAFT_LOG_SYNC_BATCH_SIZE, supplier);
+  public void addFlushBatchSizeGauge(Supplier<Integer> flushBatchSize) {
+    registry.gauge(RAFT_LOG_SYNC_BATCH_SIZE, () -> flushBatchSize);
   }
 
   private Timer getTimer(String timerName) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -371,9 +371,9 @@ public class SegmentedRaftLogCache {
     this.closedSegments = new LogSegmentList(name);
     this.storage = storage;
     this.raftLogMetrics = raftLogMetrics;
-    this.raftLogMetrics.addClosedSegmentsNum(this);
-    this.raftLogMetrics.addClosedSegmentsSizeInBytes(this);
-    this.raftLogMetrics.addOpenSegmentSizeInBytes(this);
+    this.raftLogMetrics.addClosedSegmentsNum(this::getCachedSegmentNum);
+    this.raftLogMetrics.addClosedSegmentsSizeInBytes(this::getClosedSegmentsSizeInBytes);
+    this.raftLogMetrics.addOpenSegmentSizeInBytes(this::getOpenSegmentSizeInBytes);
     this.maxCachedSegments = RaftServerConfigKeys.Log.segmentCacheNumMax(properties);
     this.maxSegmentCacheSize = RaftServerConfigKeys.Log.segmentCacheSizeMax(properties).getSize();
   }
@@ -391,15 +391,15 @@ public class SegmentedRaftLogCache {
     }
   }
 
-  public long getCachedSegmentNum() {
+  long getCachedSegmentNum() {
     return closedSegments.countCached();
   }
 
-  public long getClosedSegmentsSizeInBytes() {
+  long getClosedSegmentsSizeInBytes() {
     return closedSegments.getTotalFileSize();
   }
 
-  public long getOpenSegmentSizeInBytes() {
+  long getOpenSegmentSizeInBytes() {
     return openSegment == null ? 0 : openSegment.getTotalFileSize();
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/LogAppenderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/LogAppenderTests.java
@@ -24,7 +24,7 @@ import org.apache.log4j.Level;
 import org.apache.ratis.RaftTestUtil.SimpleMessage;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.conf.RaftProperties;
-import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.metrics.impl.RatisMetricRegistryImpl;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto.LogEntryBodyCase;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -141,8 +141,8 @@ public abstract class LogAppenderTests<CLUSTER extends MiniRaftCluster>
       throw e;
     }
 
-    final RatisMetricRegistry ratisMetricRegistry
-        = ((RaftServerMetricsImpl)leaderServer.getRaftServerMetrics()).getRegistry();
+    final RatisMetricRegistryImpl ratisMetricRegistry = (RatisMetricRegistryImpl)
+        ((RaftServerMetricsImpl)leaderServer.getRaftServerMetrics()).getRegistry();
 
     // Get all last_heartbeat_elapsed_time metric gauges. Should be equal to number of followers.
     SortedMap<String, Gauge> heartbeatElapsedTimeGauges = ratisMetricRegistry.getGauges((s, metric) ->
@@ -160,7 +160,8 @@ public abstract class LogAppenderTests<CLUSTER extends MiniRaftCluster>
       // Try to get Heartbeat metrics for follower.
       final RaftServerMetricsImpl followerMetrics = (RaftServerMetricsImpl) followerServer.getRaftServerMetrics();
       // Metric should not exist. It only exists in leader.
-      assertTrue(followerMetrics.getRegistry().getGauges((s, m) -> s.contains("lastHeartbeatElapsedTime")).isEmpty());
+      final RatisMetricRegistryImpl followerMetricRegistry = (RatisMetricRegistryImpl)followerMetrics.getRegistry();
+      assertTrue(followerMetricRegistry.getGauges((s, m) -> s.contains("lastHeartbeatElapsedTime")).isEmpty());
       for (boolean heartbeat : new boolean[] { true, false }) {
         assertTrue(followerMetrics.getFollowerAppendEntryTimer(heartbeat).getMeanRate() > 0.0d);
         assertTrue(followerMetrics.getFollowerAppendEntryTimer(heartbeat).getCount() > 0L);

--- a/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java
@@ -36,7 +36,7 @@ import org.apache.ratis.server.impl.BlockRequestHandlingInjection;
 import org.apache.ratis.server.impl.MiniRaftCluster;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.server.impl.RetryCacheTestUtil;
-import org.apache.ratis.server.metrics.RaftServerMetricsImpl;
+import org.apache.ratis.server.metrics.ServerMetricsTestUtils;
 import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.JavaUtils;
@@ -51,7 +51,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CompletableFuture;
@@ -489,14 +488,14 @@ public abstract class RaftBasicTests<CLUSTER extends MiniRaftCluster>
     final List<RaftServer.Division> followers = cluster.getFollowers();
     final RaftGroupMemberId leader = cluster.getLeader().getMemberId();
 
-    Gauge leaderCommitGauge = RaftServerMetricsImpl.getPeerCommitIndexGauge(leader, leader.getPeerId());
+    Gauge leaderCommitGauge = ServerMetricsTestUtils.getPeerCommitIndexGauge(leader, leader.getPeerId());
 
     for (RaftServer.Division f : followers) {
       final RaftGroupMemberId follower = f.getMemberId();
-      Gauge followerCommitGauge = RaftServerMetricsImpl.getPeerCommitIndexGauge(leader, follower.getPeerId());
+      Gauge followerCommitGauge = ServerMetricsTestUtils.getPeerCommitIndexGauge(leader, follower.getPeerId());
       Assert.assertTrue((Long)leaderCommitGauge.getValue() >=
           (Long)followerCommitGauge.getValue());
-      Gauge followerMetric = RaftServerMetricsImpl.getPeerCommitIndexGauge(follower, follower.getPeerId());
+      Gauge followerMetric = ServerMetricsTestUtils.getPeerCommitIndexGauge(follower, follower.getPeerId());
       System.out.println(followerCommitGauge.getValue());
       System.out.println(followerMetric.getValue());
       Assert.assertTrue((Long)followerCommitGauge.getValue()  <= (Long)followerMetric.getValue());
@@ -511,12 +510,7 @@ public abstract class RaftBasicTests<CLUSTER extends MiniRaftCluster>
 
     Optional<RatisMetricRegistry> metricRegistry = MetricRegistries.global().get(info);
     Assert.assertTrue(metricRegistry.isPresent());
-    RatisMetricRegistry ratisStateMachineMetricRegistry = metricRegistry.get();
 
-    SortedMap<String, Gauge> gaugeMap =
-        ratisStateMachineMetricRegistry.getGauges((s, metric) ->
-            s.contains(gaugeName));
-
-    return gaugeMap.get(gaugeMap.firstKey());
+    return ServerMetricsTestUtils.getGaugeWithName(gaugeName, metricRegistry::get);
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -22,7 +22,7 @@ import org.apache.ratis.BaseTest;
 import org.apache.ratis.RaftTestUtil;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.conf.RaftProperties;
-import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.metrics.impl.RatisMetricRegistryImpl;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftGroupId;
@@ -407,8 +407,8 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
     cluster.start();
     final RaftServer.Division leaderServer = waitForLeader(cluster);
 
-    final RatisMetricRegistry ratisMetricRegistry = LeaderElectionMetrics.getMetricRegistryForLeaderElection(
-        leaderServer.getMemberId());
+    final RatisMetricRegistryImpl ratisMetricRegistry = (RatisMetricRegistryImpl)
+        LeaderElectionMetrics.getMetricRegistryForLeaderElection(leaderServer.getMemberId());
 
     // Verify each metric individually.
     long numLeaderElections = ratisMetricRegistry.counter(LEADER_ELECTION_COUNT_METRIC).getCount();

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/TestLogAppenderMetrics.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/TestLogAppenderMetrics.java
@@ -21,7 +21,7 @@ import static org.apache.ratis.server.metrics.LogAppenderMetrics.FOLLOWER_MATCH_
 import static org.apache.ratis.server.metrics.LogAppenderMetrics.FOLLOWER_NEXT_INDEX;
 import static org.apache.ratis.server.metrics.LogAppenderMetrics.FOLLOWER_RPC_RESP_TIME;
 
-import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.metrics.impl.RatisMetricRegistryImpl;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -35,7 +35,7 @@ import org.apache.ratis.thirdparty.com.codahale.metrics.Gauge;
 
 public class TestLogAppenderMetrics {
 
-  private RatisMetricRegistry ratisMetricRegistry;
+  private RatisMetricRegistryImpl ratisMetricRegistry;
   private RaftPeerId raftPeerId;
   private MyFollowerInfo followerInfo;
 
@@ -46,7 +46,7 @@ public class TestLogAppenderMetrics {
     RaftGroupMemberId raftGroupMemberId = RaftGroupMemberId.valueOf(raftPeerId, raftGroupId);
     followerInfo = new MyFollowerInfo(100L);
     LogAppenderMetrics logAppenderMetrics = new LogAppenderMetrics(raftGroupMemberId);
-    ratisMetricRegistry = logAppenderMetrics.getRegistry();
+    ratisMetricRegistry = (RatisMetricRegistryImpl) logAppenderMetrics.getRegistry();
     logAppenderMetrics.addFollowerGauges(raftPeerId, followerInfo::getNextIndex, followerInfo::getMatchIndex,
         followerInfo::getLastRpcTime);
   }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/TestRetryCacheMetrics.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/TestRetryCacheMetrics.java
@@ -21,8 +21,8 @@ package org.apache.ratis.server.impl;
 import static org.apache.ratis.server.metrics.RaftServerMetricsImpl.*;
 import static org.junit.Assert.assertEquals;
 
+import org.apache.ratis.metrics.impl.RatisMetricRegistryImpl;
 import org.apache.ratis.thirdparty.com.codahale.metrics.Gauge;
-import org.apache.ratis.metrics.RatisMetricRegistry;
 import org.apache.ratis.protocol.ClientInvocationId;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.RaftGroupId;
@@ -40,7 +40,7 @@ import java.util.Map;
  * Test for metrics of retry cache.
  */
 public class TestRetryCacheMetrics {
-    private static RatisMetricRegistry ratisMetricRegistry;
+    private static RatisMetricRegistryImpl ratisMetricRegistry;
     private static RetryCacheImpl retryCache;
 
     @BeforeClass
@@ -53,7 +53,7 @@ public class TestRetryCacheMetrics {
 
       final RaftServerMetricsImpl raftServerMetrics = RaftServerMetricsImpl.computeIfAbsentRaftServerMetrics(
           raftGroupMemberId, () -> null, retryCache::getStatistics);
-      ratisMetricRegistry = raftServerMetrics.getRegistry();
+      ratisMetricRegistry = (RatisMetricRegistryImpl) raftServerMetrics.getRegistry();
     }
     
     @After

--- a/ratis-server/src/test/java/org/apache/ratis/server/metrics/ServerMetricsTestUtils.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/metrics/ServerMetricsTestUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server.metrics;
+
+import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.metrics.impl.RatisMetricRegistryImpl;
+import org.apache.ratis.protocol.RaftGroupMemberId;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.thirdparty.com.codahale.metrics.Gauge;
+import org.apache.ratis.util.Preconditions;
+
+import java.util.SortedMap;
+import java.util.function.Supplier;
+
+public interface ServerMetricsTestUtils {
+  static Gauge getGaugeWithName(String gaugeName, Supplier<RatisMetricRegistry> metrics) {
+    final SortedMap<String, Gauge> gaugeMap = ((RatisMetricRegistryImpl)metrics.get()).getGauges(
+        (s, metric) -> s.contains(gaugeName));
+    return gaugeMap.get(gaugeMap.firstKey());
+  }
+
+  /**
+   * Get the commit index gauge for the given peer of the server
+   * @return Metric Gauge holding the value of commit index of the peer
+   */
+  static Gauge getPeerCommitIndexGauge(RaftGroupMemberId serverId, RaftPeerId peerId) {
+    final RaftServerMetricsImpl serverMetrics = RaftServerMetricsImpl.getImpl(serverId);
+    if (serverMetrics == null) {
+      return null;
+    }
+
+    final String followerCommitIndexKey = RaftServerMetricsImpl.getPeerCommitIndexGaugeKey(peerId);
+
+    final SortedMap<String, Gauge> map = ((RatisMetricRegistryImpl)serverMetrics.getRegistry())
+        .getGauges((s, metric) -> s.contains(followerCommitIndexKey));
+
+    Preconditions.assertTrue(map.size() <= 1);
+    return map.get(map.firstKey());
+  }
+}

--- a/ratis-server/src/test/java/org/apache/ratis/server/metrics/TestLeaderElectionMetrics.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/metrics/TestLeaderElectionMetrics.java
@@ -23,9 +23,9 @@ import static org.apache.ratis.server.metrics.LeaderElectionMetrics.LEADER_ELECT
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.ratis.metrics.impl.RatisMetricRegistryImpl;
 import org.apache.ratis.thirdparty.com.codahale.metrics.Gauge;
 import org.apache.ratis.BaseTest;
-import org.apache.ratis.metrics.RatisMetricRegistry;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -40,7 +40,7 @@ import java.util.SortedMap;
 public class TestLeaderElectionMetrics extends BaseTest {
 
   private static LeaderElectionMetrics leaderElectionMetrics;
-  private static RatisMetricRegistry ratisMetricRegistry;
+  private static RatisMetricRegistryImpl ratisMetricRegistry;
 
   @BeforeClass
   public static void setUp() {
@@ -48,7 +48,7 @@ public class TestLeaderElectionMetrics extends BaseTest {
     RaftPeerId raftPeerId = RaftPeerId.valueOf("TestId");
     RaftGroupMemberId raftGroupMemberId = RaftGroupMemberId.valueOf(raftPeerId, raftGroupId);
     leaderElectionMetrics = LeaderElectionMetrics.getLeaderElectionMetrics(raftGroupMemberId, () -> 1000L);
-    ratisMetricRegistry = leaderElectionMetrics.getRegistry();
+    ratisMetricRegistry = (RatisMetricRegistryImpl) leaderElectionMetrics.getRegistry();
   }
 
   @Test

--- a/ratis-test/src/test/java/org/apache/ratis/TestRaftServerSlownessDetection.java
+++ b/ratis-test/src/test/java/org/apache/ratis/TestRaftServerSlownessDetection.java
@@ -19,12 +19,11 @@ package org.apache.ratis;
 
 import org.apache.log4j.Level;
 import org.apache.ratis.conf.RaftProperties;
-import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.metrics.impl.RatisMetricRegistryImpl;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.impl.MiniRaftCluster;
-import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.server.metrics.RaftServerMetricsImpl;
 import org.apache.ratis.server.simulation.MiniRaftClusterWithSimulatedRpc;
 import org.apache.ratis.proto.RaftProtos;
@@ -91,8 +90,8 @@ public class TestRaftServerSlownessDetection extends BaseTest {
         .slownessTimeout(cluster.getProperties()).toIntExact(TimeUnit.MILLISECONDS);
     RaftServer.Division failedFollower = cluster.getFollowers().get(0);
 
-    final RatisMetricRegistry ratisMetricRegistry
-        = ((RaftServerMetricsImpl)leaderServer.getRaftServerMetrics()).getRegistry();
+    final RatisMetricRegistryImpl ratisMetricRegistry
+        = (RatisMetricRegistryImpl) ((RaftServerMetricsImpl)leaderServer.getRaftServerMetrics()).getRegistry();
     SortedMap<String, Gauge> heartbeatElapsedTimeGauges =
         ratisMetricRegistry.getGauges((s, metric) ->
             s.contains("lastHeartbeatElapsedTime"));

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftServerWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftServerWithGrpc.java
@@ -22,12 +22,10 @@ import static org.apache.ratis.server.metrics.RaftServerMetricsImpl.RAFT_CLIENT_
 import static org.apache.ratis.server.metrics.RaftServerMetricsImpl.RAFT_CLIENT_WATCH_REQUEST;
 import static org.apache.ratis.server.metrics.RaftServerMetricsImpl.RAFT_CLIENT_WRITE_REQUEST;
 import static org.apache.ratis.server.metrics.RaftServerMetricsImpl.REQUEST_QUEUE_LIMIT_HIT_COUNTER;
-import static org.apache.ratis.server.metrics.RaftServerMetricsImpl.REQUEST_MEGA_BYTE_SIZE;
 import static org.apache.ratis.server.metrics.RaftServerMetricsImpl.REQUEST_BYTE_SIZE_LIMIT_HIT_COUNTER;
 import static org.apache.ratis.server.metrics.RaftServerMetricsImpl.RESOURCE_LIMIT_HIT_COUNTER;
 
 import org.apache.ratis.server.storage.RaftStorage;
-import org.apache.ratis.thirdparty.com.codahale.metrics.Gauge;
 import org.apache.log4j.Level;
 import org.apache.ratis.BaseTest;
 import org.apache.ratis.protocol.RaftGroup;
@@ -250,12 +248,6 @@ public class TestRaftServerWithGrpc extends BaseTest implements MiniRaftClusterW
       RaftClient client = cluster.createClient(cluster.getLeader().getId(), RetryPolicies.noRetry());
       clients.add(client);
       client.async().send(new SimpleMessage("2nd Message"));
-
-
-      final SortedMap<String, Gauge> gaugeMap = getRaftServerMetrics(cluster.getLeader())
-          .getRegistry().getGauges((s, metric) -> s.contains(
-              REQUEST_MEGA_BYTE_SIZE));
-
 
       for (int i = 0; i < 10; i++) {
         client = cluster.createClient(cluster.getLeader().getId(), RetryPolicies.noRetry());

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLogCache.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLogCache.java
@@ -25,7 +25,7 @@ import java.util.stream.IntStream;
 
 import org.apache.ratis.RaftTestUtil.SimpleOperation;
 import org.apache.ratis.conf.RaftProperties;
-import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.metrics.impl.RatisMetricRegistryImpl;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.server.metrics.SegmentedRaftLogMetrics;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -44,12 +44,12 @@ public class TestSegmentedRaftLogCache {
 
   private SegmentedRaftLogCache cache;
   private SegmentedRaftLogMetrics raftLogMetrics;
-  private RatisMetricRegistry ratisMetricRegistry;
+  private RatisMetricRegistryImpl ratisMetricRegistry;
 
   @Before
   public void setup() {
     raftLogMetrics = new SegmentedRaftLogMetrics(RaftServerTestUtil.TEST_MEMBER_ID);
-    ratisMetricRegistry = raftLogMetrics.getRegistry();
+    ratisMetricRegistry = (RatisMetricRegistryImpl) raftLogMetrics.getRegistry();
     cache = new SegmentedRaftLogCache(null, null, prop, raftLogMetrics);
   }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1689

This is a retry of #724 .