### PR TITLE
RATIS-1691. Potential deadlock in server shutdown

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -415,14 +415,14 @@ class RaftServerProxy implements RaftServer {
       } catch (IOException ignored) {
         LOG.warn(getId() + ": Failed to close " + SupportedDataStreamType.NETTY + " server", ignored);
       }
+
+      try {
+        ConcurrentUtils.shutdownAndWait(executor);
+      } catch (Exception ignored) {
+        LOG.warn(getId() + ": Failed to shutdown executor", ignored);
+      }
     });
     pauseMonitor.stop();
-
-    try {
-      ConcurrentUtils.shutdownAndWait(executor);
-    } catch (Exception ignored) {
-      LOG.warn(getId() + ": Failed to shutdown executor", ignored);
-    }
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move shutdown of `RaftServerProxy#executor` inside the block which is executed after lifecycle check.  This prevents subsequent callers (notably `StateMachineUpdater`) from blocking until the executor is shutdown.

https://issues.apache.org/jira/browse/RATIS-1691

## How was this patch tested?

Ran all Ratis unit tests locally.

Ran Ozone integration tests with 2.4.0-rc0 + RATIS-1687 + this change.  Most tests passed (most importantly HA tests that timed out previously).

Regular CI:
https://github.com/adoroszlai/incubator-ratis/actions/runs/2935727046