### PR TITLE
RATIS-1643. Add heartbeat broadcast mechanism for leader readIndex

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -382,6 +382,7 @@ public class GrpcLogAppender extends LogAppenderBase {
         default:
           throw new IllegalStateException("Unexpected reply result: " + reply.getResult());
       }
+      getLeaderState().onAppendEntriesReply(getFollower(), reply);
       notifyLogAppender();
     }
 

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LeaderState.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LeaderState.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.leader;
 
+import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -61,5 +62,8 @@ public interface LeaderState {
 
   /** Check if a follower is bootstrapping. */
   boolean isFollowerBootstrapping(FollowerInfo follower);
+
+  /** Received an {@link AppendEntriesReplyProto} */
+  void onAppendEntriesReply(FollowerInfo follower, AppendEntriesReplyProto reply);
 
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.server.impl;
 
 import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
 import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
@@ -39,6 +40,7 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.exceptions.NotReplicatedException;
 import org.apache.ratis.protocol.exceptions.ReconfigurationTimeoutException;
 import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.server.impl.ReadRequests.AppendEntriesListener;
 import org.apache.ratis.server.leader.FollowerInfo;
 import org.apache.ratis.server.leader.LeaderState;
 import org.apache.ratis.server.leader.LogAppender;
@@ -53,6 +55,7 @@ import org.apache.ratis.util.CodeInjectionForTesting;
 import org.apache.ratis.util.CollectionUtils;
 import org.apache.ratis.util.Daemon;
 import org.apache.ratis.util.JavaUtils;
+import org.apache.ratis.util.MemoizedSupplier;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.Timestamp;
@@ -803,6 +806,39 @@ class LeaderStateImpl implements LeaderState {
     }
   }
 
+  private boolean hasMajority(Predicate<RaftPeerId> isAcked) {
+    final RaftPeerId selfId = server.getId();
+    final RaftConfigurationImpl conf = server.getRaftConf();
+
+    final List<RaftPeerId> followers = voterLists.get(0);
+    final boolean includeSelf = conf.containsInConf(selfId);
+    final boolean newConf = hasMajority(isAcked, followers, includeSelf);
+
+    if (!conf.isTransitional()) {
+      return newConf;
+    } else {
+      final List<RaftPeerId> oldFollowers = voterLists.get(1);
+      final boolean includeSelfInOldConf = conf.containsInOldConf(selfId);
+      final boolean oldConf = hasMajority(isAcked, oldFollowers, includeSelfInOldConf);
+      return newConf && oldConf;
+    }
+  }
+
+  private boolean hasMajority(Predicate<RaftPeerId> isAcked, List<RaftPeerId> followers, boolean includeSelf) {
+    if (followers.isEmpty() && !includeSelf) {
+      return true;
+    }
+
+    int count = includeSelf ? 1 : 0;
+    for (RaftPeerId follower: followers) {
+      if (isAcked.test(follower)) {
+        count++;
+      }
+    }
+    final int size = includeSelf ? followers.size() + 1 : followers.size();
+    return count > size / 2;
+  }
+
   private void updateCommit(LogEntryHeader[] entriesToCommit) {
     final long newCommitIndex = raftLog.getLastCommittedIndex();
     logMetadata(newCommitIndex);
@@ -1026,6 +1062,56 @@ class LeaderStateImpl implements LeaderState {
     // step down as follower
     stepDown(currentTerm, StepDownReason.LOST_MAJORITY_HEARTBEATS);
     return false;
+  }
+
+  /**
+   * Obtain the current readIndex for read only requests. See Raft paper section 6.4.
+   * 1. Leader makes sure at least one log from current term is committed.
+   * 2. Leader record last committed index as readIndex.
+   * 3. Leader broadcast heartbeats to followers and waits for acknowledgements.
+   * 4. If majority respond success, returns readIndex.
+   * @return current readIndex.
+   */
+  CompletableFuture<Long> getReadIndex() {
+    final long readIndex = server.getRaftLog().getLastCommittedIndex();
+
+    // if group contains only one member, fast path
+    if (server.getRaftConf().getCurrentPeers().size() == 1) {
+      return CompletableFuture.completedFuture(readIndex);
+    }
+
+    // leader has not committed any entries in this term, reject
+    if (server.getRaftLog().getTermIndex(readIndex).getTerm() != server.getState().getCurrentTerm()) {
+      return JavaUtils.completeExceptionally(new LeaderNotReadyException(server.getMemberId()));
+    }
+
+    final MemoizedSupplier<AppendEntriesListener> supplier = MemoizedSupplier.valueOf(
+        () -> new AppendEntriesListener(readIndex));
+    final AppendEntriesListener listener = server.getState().getReadRequests().addAppendEntriesListener(
+        readIndex, key -> supplier.get());
+
+    // the readIndex is already acknowledged before
+    if (listener == null) {
+      return CompletableFuture.completedFuture(readIndex);
+    }
+
+    if (supplier.isInitialized()) {
+      senders.forEach(sender -> {
+        listener.init(sender);
+        try {
+          sender.triggerHeartbeat();
+        } catch (IOException e) {
+          LOG.warn("{}: {} cannot trigger heartbeat due to {}", this, sender, e);
+        }
+      });
+    }
+
+    return listener.getFuture();
+  }
+
+  @Override
+  public void onAppendEntriesReply(FollowerInfo follower, RaftProtos.AppendEntriesReplyProto reply) {
+    server.getState().getReadRequests().onAppendEntriesReply(reply, this::hasMajority);
   }
 
   void replyPendingRequest(long logIndex, RaftClientReply reply) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -72,6 +72,8 @@ class ServerState {
   private volatile Timestamp lastNoLeaderTime;
   private final TimeDuration noLeaderTimeout;
 
+  private final ReadRequests readRequests;
+
   /**
    * Latest term server has seen.
    * Initialized to 0 on first boot, increases monotonically.
@@ -128,6 +130,8 @@ class ServerState {
     this.log = JavaUtils.memoize(() -> initRaftLog(getSnapshotIndexFromStateMachine, prop));
     this.stateMachineUpdater = JavaUtils.memoize(() -> new StateMachineUpdater(
         stateMachine, server, this, getLog().getSnapshotIndex(), prop));
+
+    this.readRequests = new ReadRequests();
   }
 
   void initialize(StateMachine stateMachine) throws IOException {
@@ -483,5 +487,9 @@ class ServerState {
       return true;
     }
     return getLog().contains(ti);
+  }
+
+  ReadRequests getReadRequests() {
+    return readRequests;
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
@@ -193,6 +193,7 @@ class LogAppenderDefault extends LogAppenderBase {
           break;
         default: throw new IllegalArgumentException("Unable to process result " + reply.getResult());
       }
+      getLeaderState().onAppendEntriesReply(getFollower(), reply);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add the heartbeat broadcast mechanism in LeaderState. 
When a leader is requested for current readIndex, it should first confirm its authority by broadcasting heartbeats and receiving majority acknowledgements. If the leadership is confirmed, the readIndex can be safely returned.
In this PR I propose to add the broadcast mechanism and use it to implement readIndex request.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1643

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
this patch should be tested when Read request using ReadIndex Option is implemented.
