### PR TITLE
RATIS-1695 Improve error observability and state mgmt in RaftServer

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/Daemon.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/Daemon.java
@@ -17,14 +17,36 @@
  */
 package org.apache.ratis.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicReference;
+
 public class Daemon extends Thread {
   {
     setDaemon(true);
   }
+  // TODO(jiacheng): Ideally, use the logger from the thread class itself
+  static final Logger LOG = LoggerFactory.getLogger(Daemon.class);
+
+  /** If the thread meets an uncaught exception, this field will be set. */
+  private final AtomicReference<Throwable> throwable = new AtomicReference<>(null);
+  protected Stated statedServer;
 
   /** Construct a daemon thread. */
+  // TODO(jiacheng): Consolidate all constructors
   public Daemon() {
     super();
+    setUncaughtExceptionHandler((thread, t) -> {
+      onError(t);
+    });
+  }
+
+  public Daemon(String name, Stated server) {
+    this();
+    this.setName(name);
+    this.statedServer = server;
   }
 
   /** Construct a daemon thread with the given runnable. */
@@ -36,5 +58,34 @@ public class Daemon extends Thread {
   public Daemon(Runnable runnable, String name) {
     super(runnable);
     this.setName(name);
+  }
+
+  public Daemon(Runnable runnable, String name, Stated server) {
+    this(runnable, name);
+    this.statedServer = server;
+  }
+
+  /**
+   * Handles the uncaught error on thread crashing.
+   *
+   * @param t the crashing error
+   */
+  public void onError(Throwable t) {
+    throwable.set(t);
+    if (statedServer != null) {
+      LOG.error("Daemon thread {} exiting due to an uncaught exception, marking RaftServer {} state to ERROR",
+              getName(), statedServer, t);
+      statedServer.setError(t);
+      // TODO(jiacheng): Transition the server state to ERROR
+    }
+
+    // TODO(jiacheng): should i set the lifecycle to close and exit? or it is possible to recover?
+    //  Do a RaftServer state transition in a heartbeat thread
+    // TODO(jiacheng): what if this thread is created in a threadpool?
+  }
+
+  @Nullable
+  public Throwable getError() {
+    return throwable.get();
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/util/Stated.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/Stated.java
@@ -1,0 +1,10 @@
+package org.apache.ratis.util;
+
+import javax.annotation.Nullable;
+
+public interface Stated {
+  void setError(Throwable t);
+
+  @Nullable
+  Throwable getError();
+}

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/DivisionInfo.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/DivisionInfo.java
@@ -22,11 +22,12 @@ import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.proto.RaftProtos.RoleInfoProto;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.util.LifeCycle;
+import org.apache.ratis.util.Stated;
 
 /**
  * Information of a raft server division.
  */
-public interface DivisionInfo {
+public interface DivisionInfo extends Stated {
   /** @return the current role of this server division. */
   RaftPeerRole getCurrentRole();
 
@@ -58,6 +59,7 @@ public interface DivisionInfo {
    */
   RaftPeerId getLeaderId();
 
+  // TODO(jiacheng): How is this lifecycle mapped to RaftServer lifecycle? See RaftServerProxy
   /** @return the life cycle state of this server division. */
   LifeCycle.State getLifeCycleState();
 

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
@@ -34,6 +34,7 @@ import org.apache.ratis.thirdparty.com.google.common.collect.Iterables;
 import org.apache.ratis.util.IOUtils;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.ReflectionUtils;
+import org.apache.ratis.util.Stated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,11 +50,11 @@ import java.util.Optional;
 public interface RaftServer extends Closeable, RpcType.Get,
     RaftServerProtocol, RaftServerAsynchronousProtocol,
     RaftClientProtocol, RaftClientAsynchronousProtocol,
-    AdminProtocol, AdminAsynchronousProtocol {
+    AdminProtocol, AdminAsynchronousProtocol, Stated {
   Logger LOG = LoggerFactory.getLogger(RaftServer.class);
 
   /** A division of a {@link RaftServer} for a particular {@link RaftGroup}. */
-  interface Division extends Closeable {
+  interface Division extends Closeable, Stated {
     Logger LOG = LoggerFactory.getLogger(Division.class);
 
     /** @return the {@link DivisionProperties} for this division. */

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
@@ -65,6 +65,7 @@ class FollowerState extends Daemon {
   private final AtomicInteger outstandingOp = new AtomicInteger();
 
   FollowerState(RaftServerImpl server, Object reason) {
+    // implicitly calling super() here
     this.name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
     this.setName(this.name);
     this.server = server;

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -621,7 +621,7 @@ class LeaderStateImpl implements LeaderState {
    */
   private class EventProcessor extends Daemon {
     public EventProcessor(String name) {
-      setName(name);
+      super(name, server);
     }
     @Override
     public void run() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -69,6 +69,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.*;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -97,7 +98,7 @@ import org.apache.ratis.util.function.CheckedSupplier;
 
 class RaftServerImpl implements RaftServer.Division,
     RaftServerProtocol, RaftServerAsynchronousProtocol,
-    RaftClientProtocol, RaftClientAsynchronousProtocol{
+    RaftClientProtocol, RaftClientAsynchronousProtocol, Stated {
   private static final String CLASS_NAME = JavaUtils.getClassSimpleName(RaftServerImpl.class);
   static final String REQUEST_VOTE = CLASS_NAME + ".requestVote";
   static final String APPEND_ENTRIES = CLASS_NAME + ".appendEntries";

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -374,6 +374,7 @@ class RaftServerProxy implements RaftServer {
 
   @Override
   public LifeCycle.State getLifeCycleState() {
+    // TODO(jiacheng): How do i expose the exception from here?
     return lifeCycle.getCurrentState();
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
@@ -110,7 +110,7 @@ class StateMachineUpdater implements Runnable {
     };
     this.purgeUptoSnapshotIndex = RaftServerConfigKeys.Log.purgeUptoSnapshotIndex(properties);
 
-    updater = new Daemon(this);
+    updater = new Daemon(this, name, server);
     this.awaitForSignal = new AwaitForSignal(name);
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
@@ -69,7 +69,7 @@ public abstract class LogAppenderBase implements LogAppender {
     final SizeInBytes bufferByteLimit = RaftServerConfigKeys.Log.Appender.bufferByteLimit(properties);
     final int bufferElementLimit = RaftServerConfigKeys.Log.Appender.bufferElementLimit(properties);
     this.buffer = new DataQueue<>(this, bufferByteLimit, bufferElementLimit, EntryWithData::getSerializedSize);
-    this.daemon = new LogAppenderDaemon(this);
+    this.daemon = new LogAppenderDaemon(this, server);
     this.eventAwaitForSignal = new AwaitForSignal(name);
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDaemon.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDaemon.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.leader;
 
+import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.util.Daemon;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.LifeCycle;
@@ -25,6 +26,7 @@ import java.io.InterruptedIOException;
 import java.util.function.UnaryOperator;
 
 import org.apache.ratis.util.LifeCycle.State;
+import org.apache.ratis.util.Stated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,11 +46,11 @@ class LogAppenderDaemon {
 
   private final LogAppender logAppender;
 
-  LogAppenderDaemon(LogAppender logAppender) {
+  LogAppenderDaemon(LogAppender logAppender, Stated server) {
     this.logAppender = logAppender;
     this.name = logAppender + "-" + JavaUtils.getClassSimpleName(getClass());
     this.lifeCycle = new LifeCycle(name);
-    this.daemon = new Daemon(this::run, name);
+    this.daemon = new Daemon(this::run, name, server);
   }
 
   public boolean isWorking() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Updates the RaftServer API so external user can retrieve the internal exception in Ratis
2. Adds UncaughtExceptionHandler to most critical `Daemon` threads so uncaught exceptions can propagated to the RaftServer level

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1695

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
