### PR TITLE
RATIS-1698. Add unit-test of listener related to leaderElection

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
@@ -157,6 +157,10 @@ class PeerConfiguration {
     return num > size() / 2;
   }
 
+  long getMajorityCount() {
+    return size() / 2 + 1;
+  }
+
   boolean majorityRejectVotes(Collection<RaftPeerId> rejected) {
     int num = size();
     for (RaftPeerId other : rejected) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
@@ -157,7 +157,7 @@ class PeerConfiguration {
     return num > size() / 2;
   }
 
-  long getMajorityCount() {
+  int getMajorityCount() {
     return size() / 2 + 1;
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
@@ -231,6 +231,10 @@ final class RaftConfigurationImpl implements RaftConfiguration {
         (oldConf == null || oldConf.hasMajority(others, selfId));
   }
 
+  long getMajorityCount() {
+    return conf.getMajorityCount();
+  }
+
   /** @return true if the rejects are in the majority(maybe half is enough in some cases). */
   boolean majorityRejectVotes(Collection<RaftPeerId> rejects) {
     return conf.majorityRejectVotes(rejects) ||

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
@@ -231,7 +231,7 @@ final class RaftConfigurationImpl implements RaftConfiguration {
         (oldConf == null || oldConf.hasMajority(others, selfId));
   }
 
-  long getMajorityCount() {
+  int getMajorityCount() {
     return conf.getMajorityCount();
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -129,6 +129,48 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
   }
 
   @Test
+  public void testLeaderNotCountListenerForMajority() throws Exception {
+    runWithNewCluster(3, 2, this::runTestLeaderNotCountListenerForMajority);
+  }
+
+  void runTestLeaderNotCountListenerForMajority(CLUSTER cluster) throws Exception {
+    final RaftServer.Division leader = waitForLeader(cluster);
+    Assert.assertEquals(2, ((RaftConfigurationImpl)cluster.getLeader().getRaftConf()).getMajorityCount());
+    try (RaftClient client = cluster.createClient(leader.getId())) {
+      client.io().send(new RaftTestUtil.SimpleMessage("message"));
+      List<RaftPeer> listeners = cluster.getListeners()
+          .stream().map(RaftServer.Division::getPeer).collect(Collectors.toList());
+      Assert.assertEquals(2, listeners.size());
+      RaftClientReply reply = client.admin().setConfiguration(cluster.getPeers());
+      Assert.assertTrue(reply.isSuccess());
+      Collection<RaftPeer> peer = leader.getRaftConf().getAllPeers(RaftProtos.RaftPeerRole.LISTENER);
+      Assert.assertEquals(0, peer.size());
+    }
+    Assert.assertEquals(3, ((RaftConfigurationImpl)cluster.getLeader().getRaftConf()).getMajorityCount());
+  }
+
+  @Test
+  public void testListenerNotStartLeaderElection() throws Exception {
+    runWithNewCluster(3, 2, this::runTestListenerNotStartLeaderElection);
+  }
+
+  void runTestListenerNotStartLeaderElection(CLUSTER cluster) throws Exception {
+    final RaftServer.Division leader = waitForLeader(cluster);
+    final TimeDuration maxTimeout = RaftServerConfigKeys.Rpc.timeoutMax(getProperties());
+
+    final RaftServer.Division listener = cluster.getListeners().get(0);
+    final RaftPeerId listenerId = listener.getId();
+    try {
+      isolate(cluster, listenerId);
+      maxTimeout.sleep();
+      maxTimeout.sleep();
+      Assert.assertEquals(RaftProtos.RaftPeerRole.LISTENER, listener.getInfo().getCurrentRole());
+    } finally {
+      deIsolate(cluster, leader.getId());
+    }
+  }
+
+  @Test
   public void testTransferLeader() throws Exception {
     try(final MiniRaftCluster cluster = newCluster(3)) {
       cluster.start();

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -166,7 +166,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
       maxTimeout.sleep();
       Assert.assertEquals(RaftProtos.RaftPeerRole.LISTENER, listener.getInfo().getCurrentRole());
     } finally {
-      deIsolate(cluster, leader.getId());
+      deIsolate(cluster, listener.getId());
     }
   }
 


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/RATIS-1698
