### PR TITLE
RATIS-1701. Add new Server RPC: readIndex

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/api/BlockingApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/BlockingApi.java
@@ -49,6 +49,14 @@ public interface BlockingApi {
   RaftClientReply sendReadOnly(Message message) throws IOException;
 
   /**
+   * Send the given readonly message to the given server (not the raft service)
+   * @param message The request message.
+   * @param server The target server
+   * @return the reply.
+   */
+  RaftClientReply sendReadOnly(Message message, RaftPeerId server) throws IOException;
+
+  /**
    * Send the given stale-read message to the given server (not the raft service).
    * If the server commit index is larger than or equal to the given min-index, the request will be processed.
    * Otherwise, the server throws a {@link org.apache.ratis.protocol.exceptions.StaleReadException}.

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/BlockingImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/BlockingImpl.java
@@ -65,6 +65,11 @@ class BlockingImpl implements BlockingApi {
   }
 
   @Override
+  public RaftClientReply sendReadOnly(Message message, RaftPeerId server) throws IOException {
+    return send(RaftClientRequest.readRequestType(), message, server);
+  }
+
+  @Override
   public RaftClientReply sendStaleRead(Message message, long minIndex, RaftPeerId server)
       throws IOException {
     return send(RaftClientRequest.staleReadRequestType(minIndex), message, server);

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
@@ -29,6 +29,7 @@ import org.apache.ratis.protocol.exceptions.LeaderSteppingDownException;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.exceptions.NotReplicatedException;
 import org.apache.ratis.protocol.exceptions.RaftException;
+import org.apache.ratis.protocol.exceptions.ReadException;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.protocol.exceptions.TransferLeadershipException;
 import org.apache.ratis.rpc.CallId;
@@ -47,6 +48,7 @@ import static org.apache.ratis.proto.RaftProtos.RaftClientReplyProto.ExceptionDe
 import static org.apache.ratis.proto.RaftProtos.RaftClientReplyProto.ExceptionDetailsCase.LEADERSTEPPINGDOWNEXCEPTION;
 import static org.apache.ratis.proto.RaftProtos.RaftClientReplyProto.ExceptionDetailsCase.NOTLEADEREXCEPTION;
 import static org.apache.ratis.proto.RaftProtos.RaftClientReplyProto.ExceptionDetailsCase.NOTREPLICATEDEXCEPTION;
+import static org.apache.ratis.proto.RaftProtos.RaftClientReplyProto.ExceptionDetailsCase.READEXCEPTION;
 import static org.apache.ratis.proto.RaftProtos.RaftClientReplyProto.ExceptionDetailsCase.STATEMACHINEEXCEPTION;
 import static org.apache.ratis.proto.RaftProtos.RaftClientReplyProto.ExceptionDetailsCase.TRANSFERLEADERSHIPEXCEPTION;
 
@@ -303,6 +305,10 @@ public interface ClientProtoUtils {
           .map(ProtoUtils::toThrowableProto)
           .ifPresent(b::setTransferLeadershipException);
 
+      Optional.ofNullable(reply.getReadException())
+          .map(ProtoUtils::toThrowableProto)
+          .ifPresent(b::setReadException);
+
       final RaftClientReplyProto serialized = b.build();
       final RaftException e = reply.getException();
       if (e != null) {
@@ -392,6 +398,8 @@ public interface ClientProtoUtils {
       e = ProtoUtils.toThrowable(replyProto.getLeaderSteppingDownException(), LeaderSteppingDownException.class);
     } else if (replyProto.getExceptionDetailsCase().equals(TRANSFERLEADERSHIPEXCEPTION)) {
       e = ProtoUtils.toThrowable(replyProto.getTransferLeadershipException(), TransferLeadershipException.class);
+    } else if (replyProto.getExceptionDetailsCase().equals(READEXCEPTION)) {
+      e = ProtoUtils.toThrowable(replyProto.getReadException(), ReadException.class);
     } else {
       e = null;
     }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientReply.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientReply.java
@@ -25,6 +25,7 @@ import org.apache.ratis.protocol.exceptions.LeaderSteppingDownException;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.exceptions.NotReplicatedException;
 import org.apache.ratis.protocol.exceptions.RaftException;
+import org.apache.ratis.protocol.exceptions.ReadException;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.protocol.exceptions.TransferLeadershipException;
 import org.apache.ratis.util.JavaUtils;
@@ -169,7 +170,7 @@ public class RaftClientReply extends RaftClientMessage {
           AlreadyClosedException.class,
           NotLeaderException.class, NotReplicatedException.class,
           LeaderNotReadyException.class, StateMachineException.class, DataStreamException.class,
-          LeaderSteppingDownException.class, TransferLeadershipException.class),
+          LeaderSteppingDownException.class, TransferLeadershipException.class, ReadException.class),
           () -> "Unexpected exception class: " + this);
     }
   }
@@ -243,6 +244,10 @@ public class RaftClientReply extends RaftClientMessage {
 
   public TransferLeadershipException getTransferLeadershipException() {
     return JavaUtils.cast(exception, TransferLeadershipException.class);
+  }
+
+  public ReadException getReadException() {
+    return JavaUtils.cast(exception, ReadException.class);
   }
 
   /** @return the exception, if there is any; otherwise, return null. */

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/ReadException.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/ReadException.java
@@ -21,6 +21,10 @@ package org.apache.ratis.protocol.exceptions;
  * This exception indicates the failure of a read request.
  */
 public class ReadException extends RaftException {
+  public ReadException(String message) {
+    super(message);
+  }
+
   public ReadException(Throwable cause) {
     super(cause);
   }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -130,6 +130,11 @@ public class GrpcServerProtocolClient implements Closeable {
     return r;
   }
 
+  void readIndex(ReadIndexRequestProto request, StreamObserver<ReadIndexReplyProto> s) {
+    asyncStub.withDeadlineAfter(requestTimeoutDuration.getDuration(), requestTimeoutDuration.getUnit())
+        .readIndex(request, s);
+  }
+
   StreamObserver<AppendEntriesRequestProto> appendEntries(
       StreamObserver<AppendEntriesReplyProto> responseHandler, boolean isHeartbeat) {
     if (isHeartbeat && useSeparateHBChannel) {

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -198,6 +198,20 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
   }
 
   @Override
+  public void readIndex(ReadIndexRequestProto request, StreamObserver<ReadIndexReplyProto> responseObserver) {
+    try {
+      server.readIndexAsync(request).thenAccept(reply -> {
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
+      });
+    } catch (Throwable e) {
+      GrpcUtil.warn(LOG,
+          () -> getId() + ": Failed readIndex " + ProtoUtils.toString(request.getServerRequest()), e);
+      responseObserver.onError(GrpcUtil.wrapException(e));
+    }
+  }
+
+  @Override
   public StreamObserver<AppendEntriesRequestProto> appendEntries(
       StreamObserver<AppendEntriesReplyProto> responseObserver) {
     return new ServerRequestStreamObserver<AppendEntriesRequestProto, AppendEntriesReplyProto>(

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
@@ -27,10 +27,12 @@ import org.apache.ratis.rpc.SupportedRpcType;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.RaftServerRpcWithProxy;
+import org.apache.ratis.server.protocol.RaftServerAsynchronousProtocol;
 import org.apache.ratis.thirdparty.io.grpc.ServerInterceptors;
 import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;
 import org.apache.ratis.thirdparty.io.grpc.netty.NettyServerBuilder;
 import org.apache.ratis.thirdparty.io.grpc.Server;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.thirdparty.io.netty.channel.ChannelOption;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.ClientAuth;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
@@ -44,6 +46,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
@@ -55,6 +58,41 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
   static final Logger LOG = LoggerFactory.getLogger(GrpcService.class);
   public static final String GRPC_SEND_SERVER_REQUEST =
       JavaUtils.getClassSimpleName(GrpcService.class) + ".sendRequest";
+
+  class AsyncService implements RaftServerAsynchronousProtocol {
+
+    @Override
+    public CompletableFuture<AppendEntriesReplyProto> appendEntriesAsync(AppendEntriesRequestProto request)
+        throws IOException {
+      throw new UnsupportedOperationException("This method is not supported");
+    }
+
+    @Override
+    public CompletableFuture<ReadIndexReplyProto> readIndexAsync(ReadIndexRequestProto request) throws IOException {
+      CodeInjectionForTesting.execute(GRPC_SEND_SERVER_REQUEST, getId(), null, request);
+
+      final CompletableFuture<ReadIndexReplyProto> f = new CompletableFuture<>();
+      final StreamObserver<ReadIndexReplyProto> s = new StreamObserver<ReadIndexReplyProto>() {
+        @Override
+        public void onNext(ReadIndexReplyProto reply) {
+          f.complete(reply);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+          f.completeExceptionally(throwable);
+        }
+
+        @Override
+        public void onCompleted() {
+        }
+      };
+
+      final RaftPeerId target = RaftPeerId.valueOf(request.getServerRequest().getReplyId());
+      getProxies().getProxy(target).readIndex(request, s);
+      return f;
+    }
+  }
 
   public static final class Builder {
     private RaftServer server;
@@ -107,6 +145,8 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
   private final Supplier<InetSocketAddress> addressSupplier;
   private final Supplier<InetSocketAddress> clientServerAddressSupplier;
   private final Supplier<InetSocketAddress> adminServerAddressSupplier;
+
+  private final AsyncService asyncService = new AsyncService();
 
   private final ExecutorService executor;
   private final GrpcClientProtocolService clientProtocolService;
@@ -310,6 +350,11 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
   @Override
   public InetSocketAddress getAdminServerAddress() {
     return adminServerAddressSupplier.get();
+  }
+
+  @Override
+  public RaftServerAsynchronousProtocol async() {
+    return asyncService;
   }
 
   @Override

--- a/ratis-proto/src/main/proto/Grpc.proto
+++ b/ratis-proto/src/main/proto/Grpc.proto
@@ -45,6 +45,9 @@ service RaftServerProtocolService {
 
   rpc installSnapshot(stream ratis.common.InstallSnapshotRequestProto)
       returns(stream ratis.common.InstallSnapshotReplyProto) {}
+
+  rpc readIndex(ratis.common.ReadIndexRequestProto)
+      returns(stream ratis.common.ReadIndexReplyProto) {}
 }
 
 service AdminProtocolService {

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -239,6 +239,15 @@ message InstallSnapshotReplyProto {
   }
 }
 
+message ReadIndexRequestProto {
+  RaftRpcRequestProto serverRequest = 1;
+}
+
+message ReadIndexReplyProto {
+  RaftRpcReplyProto serverReply = 1;
+  uint64 readIndex = 2;
+}
+
 message ClientMessageEntryProto {
   bytes content = 1;
 }
@@ -399,6 +408,7 @@ message RaftClientReplyProto {
     ThrowableProto dataStreamException = 8;
     ThrowableProto leaderSteppingDownException = 9;
     ThrowableProto transferLeadershipException = 10;
+    ThrowableProto readException = 11;
   }
 
   uint64 logIndex = 14; // When the request is a write request and the reply is success, the log index of the transaction

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -182,7 +182,11 @@ public interface RaftServerConfigKeys {
     String OPTION_KEY = ".option";
     Option OPTION_DEFAULT = Option.DEFAULT;
     static Option option(RaftProperties properties) {
-      return get(properties::getEnum, OPTION_KEY, OPTION_DEFAULT, getDefaultLog());
+      Option option =  get(properties::getEnum, OPTION_KEY, OPTION_DEFAULT, getDefaultLog());
+      if (option != Option.DEFAULT && option != Option.LINEARIZABLE) {
+        throw new IllegalArgumentException("Unexpected read option: " + option);
+      }
+      return option;
     }
     static void setOption(RaftProperties properties, Option option) {
       set(properties::setEnum, OPTION_KEY, option);

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerRpc.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerRpc.java
@@ -57,7 +57,7 @@ public interface RaftServerRpc extends RaftServerProtocol, RpcType.Get, RaftPeer
   }
 
   default RaftServerAsynchronousProtocol async() {
-    throw new UnsupportedOperationException(JavaUtils.getClassSimpleName(RaftServerAsynchronousProtocol.class) +
-        "is not yet supported");
+    throw new UnsupportedOperationException(getClass().getName()
+        + " does not support " + JavaUtils.getClassSimpleName(RaftServerAsynchronousProtocol.class));
   }
 }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerRpc.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerRpc.java
@@ -21,7 +21,9 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.rpc.RpcType;
+import org.apache.ratis.server.protocol.RaftServerAsynchronousProtocol;
 import org.apache.ratis.server.protocol.RaftServerProtocol;
+import org.apache.ratis.util.JavaUtils;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -52,5 +54,10 @@ public interface RaftServerRpc extends RaftServerProtocol, RpcType.Get, RaftPeer
 
   /** The server role changes from leader to a non-leader role. */
   default void notifyNotLeader(RaftGroupId groupId) {
+  }
+
+  default RaftServerAsynchronousProtocol async() {
+    throw new UnsupportedOperationException(JavaUtils.getClassSimpleName(RaftServerAsynchronousProtocol.class) +
+        "is not yet supported");
   }
 }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/RaftServerAsynchronousProtocol.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/RaftServerAsynchronousProtocol.java
@@ -18,6 +18,8 @@
 
 package org.apache.ratis.server.protocol;
 
+import org.apache.ratis.proto.RaftProtos.ReadIndexRequestProto;
+import org.apache.ratis.proto.RaftProtos.ReadIndexReplyProto;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
 
@@ -27,5 +29,8 @@ import java.util.concurrent.CompletableFuture;
 public interface RaftServerAsynchronousProtocol {
 
   CompletableFuture<AppendEntriesReplyProto> appendEntriesAsync(AppendEntriesRequestProto request)
+      throws IOException;
+
+  CompletableFuture<ReadIndexReplyProto> readIndexAsync(ReadIndexRequestProto request)
       throws IOException;
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -824,6 +824,8 @@ class RaftServerImpl implements RaftServer.Division,
 
     if (request.is(TypeCase.STALEREAD)) {
       replyFuture = staleReadAsync(request);
+    } else if (request.is(TypeCase.READ)) {
+      replyFuture = readAsync(request);
     } else {
       // first check the server's leader state
       CompletableFuture<RaftClientReply> reply = checkLeaderState(request, null,
@@ -845,11 +847,7 @@ class RaftServerImpl implements RaftServer.Division,
         }
       }
 
-      if (type.is(TypeCase.READ)) {
-        // TODO: We might not be the leader anymore by the time this completes.
-        // See the RAFT paper section 8 (last part)
-        replyFuture = readAsync(request);
-      } else if (type.is(TypeCase.WATCH)) {
+      if (type.is(TypeCase.WATCH)) {
         replyFuture = watchAsync(request);
       } else if (type.is(TypeCase.MESSAGESTREAM)) {
         replyFuture = streamAsync(request);
@@ -914,6 +912,16 @@ class RaftServerImpl implements RaftServer.Division,
     return getState().getReadRequests();
   }
 
+  private CompletableFuture<ReadIndexReplyProto> sendReadIndexAsync() {
+    final ReadIndexRequestProto request = ServerProtoUtils.toReadIndexRequestProto(
+        getMemberId(),  getInfo().getLeaderId());
+    try {
+      return getServerRpc().async().readIndexAsync(request);
+    } catch (IOException e) {
+      return JavaUtils.completeExceptionally(e);
+    }
+  }
+
   private CompletableFuture<RaftClientReply> readAsync(RaftClientRequest request) {
     if (readOption == RaftServerConfigKeys.Read.Option.LINEARIZABLE) {
       /*
@@ -923,11 +931,22 @@ class RaftServerImpl implements RaftServer.Division,
         3. Finally, query the statemachine and return the result.
        */
       final LeaderStateImpl leader = role.getLeaderState().orElse(null);
-      // TODO support follower linearizable read
-      if (leader == null) {
-        return JavaUtils.completeExceptionally(generateNotLeaderException());
+
+      final CompletableFuture<Long> replyFuture;
+      if (leader != null) {
+        replyFuture = leader.getReadIndex();
+      } else {
+        replyFuture = sendReadIndexAsync().thenApply(reply -> {
+          if (reply.getServerReply().getSuccess()) {
+            return reply.getReadIndex();
+          } else {
+            throw new CompletionException(new ReadException(getId() +
+                ": Failed to get read index from the leader: " + reply));
+          }
+        });
       }
-      return leader.getReadIndex()
+
+      return replyFuture
           .thenCompose(readIndex -> getReadRequests().waitToAdvance(readIndex))
           .thenCompose(readIndex -> queryStateMachine(request))
           .exceptionally(e -> readException2Reply(request, e));
@@ -1352,6 +1371,24 @@ class RaftServerImpl implements RaftServer.Division,
       LOG.error("{}: Failed appendEntriesAsync {}", getMemberId(), r, t);
       throw t;
     }
+  }
+
+  @Override
+  public CompletableFuture<ReadIndexReplyProto> readIndexAsync(ReadIndexRequestProto request) throws IOException {
+    assertLifeCycleState(LifeCycle.States.RUNNING);
+
+    final RaftPeerId peerId = RaftPeerId.valueOf(request.getServerRequest().getRequestorId());
+
+    final LeaderStateImpl leader = role.getLeaderState().orElse(null);
+    if (leader == null) {
+      return CompletableFuture.completedFuture(
+          ServerProtoUtils.toReadIndexReplyProto(peerId, getMemberId(), false, INVALID_LOG_INDEX));
+    }
+
+    return leader.getReadIndex()
+        .thenApply(index -> ServerProtoUtils.toReadIndexReplyProto(peerId, getMemberId(), true, index))
+        .exceptionally(throwable ->
+            ServerProtoUtils.toReadIndexReplyProto(peerId, getMemberId(), false, INVALID_LOG_INDEX));
   }
 
   static void logAppendEntries(boolean isHeartbeat, Supplier<String> message) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -951,7 +951,11 @@ class RaftServerImpl implements RaftServer.Division,
           .thenCompose(readIndex -> queryStateMachine(request))
           .exceptionally(e -> readException2Reply(request, e));
     } else if (readOption == RaftServerConfigKeys.Read.Option.DEFAULT) {
-      return queryStateMachine(request);
+       CompletableFuture<RaftClientReply> reply = checkLeaderState(request, null, false);
+       if (reply != null) {
+         return reply;
+       }
+       return queryStateMachine(request);
     } else {
       throw new IllegalStateException("Unexpected read option: " + readOption);
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -21,6 +21,8 @@ import org.apache.ratis.RaftConfigKeys;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.datastream.SupportedDataStreamType;
+import org.apache.ratis.proto.RaftProtos.ReadIndexRequestProto;
+import org.apache.ratis.proto.RaftProtos.ReadIndexReplyProto;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
@@ -624,6 +626,13 @@ class RaftServerProxy implements RaftServer {
     final RaftGroupId groupId = ProtoUtils.toRaftGroupId(request.getServerRequest().getRaftGroupId());
     return getImplFuture(groupId)
         .thenCompose(impl -> impl.executeSubmitServerRequestAsync(() -> impl.appendEntriesAsync(request)));
+  }
+
+  @Override
+  public CompletableFuture<ReadIndexReplyProto> readIndexAsync(ReadIndexRequestProto request) throws IOException {
+    final RaftGroupId groupId = ProtoUtils.toRaftGroupId(request.getServerRequest().getRaftGroupId());
+    return getImplFuture(groupId)
+        .thenCompose(impl -> impl.executeSubmitServerRequestAsync(() -> impl.readIndexAsync(request)));
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
@@ -109,6 +109,21 @@ final class ServerProtoUtils {
     return builder.build();
   }
 
+  static ReadIndexRequestProto toReadIndexRequestProto(
+      RaftGroupMemberId requestorId, RaftPeerId replyId) {
+    return ReadIndexRequestProto.newBuilder()
+        .setServerRequest(ClientProtoUtils.toRaftRpcRequestProtoBuilder(requestorId, replyId))
+        .build();
+  }
+
+  static ReadIndexReplyProto toReadIndexReplyProto(
+      RaftPeerId requestorId, RaftGroupMemberId replyId, boolean success, long index) {
+    return ReadIndexReplyProto.newBuilder()
+        .setServerReply(toRaftRpcReplyProtoBuilder(requestorId, replyId, success))
+        .setReadIndex(index)
+        .build();
+  }
+
   @SuppressWarnings("parameternumber")
   static AppendEntriesReplyProto toAppendEntriesReplyProto(
       RaftPeerId requestorId, RaftGroupMemberId replyId, long term,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a new server RPC type: readIndex. This RPC is sent from follower to leader for asking current readIndex. 
When a follower receives a linearizable read request, it should first obtain readIndex through this RPC, and then wait forstatemachine to advance and read.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1701

