### PR TITLE
RATIS-1706. Move heartbeat listeners to LeaderState

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -40,7 +40,7 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.exceptions.NotReplicatedException;
 import org.apache.ratis.protocol.exceptions.ReconfigurationTimeoutException;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.ReadRequests.AppendEntriesListener;
+import org.apache.ratis.server.impl.ReadIndexHeartbeats.AppendEntriesListener;
 import org.apache.ratis.server.leader.FollowerInfo;
 import org.apache.ratis.server.leader.LeaderState;
 import org.apache.ratis.server.leader.LogAppender;
@@ -260,6 +260,8 @@ class LeaderStateImpl implements LeaderState {
   private final long followerMaxGapThreshold;
   private final PendingStepDown pendingStepDown;
 
+  private final ReadIndexHeartbeats readIndexHeartbeats;
+
   LeaderStateImpl(RaftServerImpl server) {
     this.name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
     this.server = server;
@@ -279,6 +281,7 @@ class LeaderStateImpl implements LeaderState {
     this.watchRequests = new WatchRequests(server.getMemberId(), properties);
     this.messageStreamRequests = new MessageStreamRequests(server.getMemberId());
     this.pendingStepDown = new PendingStepDown(this);
+    this.readIndexHeartbeats = new ReadIndexHeartbeats();
     long maxPendingRequests = RaftServerConfigKeys.Write.elementLimit(properties);
     double followerGapRatioMax = RaftServerConfigKeys.Write.followerGapRatioMax(properties);
 
@@ -337,6 +340,7 @@ class LeaderStateImpl implements LeaderState {
       LOG.warn("{}: Caught exception in sendNotLeaderResponses", this, e);
     }
     messageStreamRequests.clear();
+    readIndexHeartbeats.clear();
     server.getServerRpc().notifyNotLeader(server.getMemberId().getGroupId());
     logAppenderMetrics.unregister();
     raftServerMetrics.unregister();
@@ -1087,7 +1091,7 @@ class LeaderStateImpl implements LeaderState {
 
     final MemoizedSupplier<AppendEntriesListener> supplier = MemoizedSupplier.valueOf(
         () -> new AppendEntriesListener(readIndex));
-    final AppendEntriesListener listener = server.getReadRequests().addAppendEntriesListener(
+    final AppendEntriesListener listener = readIndexHeartbeats.addAppendEntriesListener(
         readIndex, key -> supplier.get());
 
     // the readIndex is already acknowledged before
@@ -1110,7 +1114,7 @@ class LeaderStateImpl implements LeaderState {
 
   @Override
   public void onAppendEntriesReply(LogAppender appender, RaftProtos.AppendEntriesReplyProto reply) {
-    server.getReadRequests().onAppendEntriesReply(appender, reply, this::hasMajority);
+    readIndexHeartbeats.onAppendEntriesReply(appender, reply, this::hasMajority);
   }
 
   void replyPendingRequest(long logIndex, RaftClientReply reply) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadIndexHeartbeats.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadIndexHeartbeats.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server.impl;
+
+import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.leader.LogAppender;
+import org.apache.ratis.server.raftlog.RaftLog;
+import org.apache.ratis.server.raftlog.RaftLogIndex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class ReadIndexHeartbeats {
+  private static final Logger LOG = LoggerFactory.getLogger(ReadIndexHeartbeats.class);
+
+  /** The acknowledgement from a {@link LogAppender} of a heartbeat for a particular call id. */
+  static class HeartbeatAck {
+    private final LogAppender appender;
+    private final long minCallId;
+    private volatile boolean acknowledged = false;
+
+    HeartbeatAck(LogAppender appender) {
+      this.appender = appender;
+      this.minCallId = appender.getCallId();
+    }
+
+    /** Is the heartbeat (for a particular call id) acknowledged? */
+    boolean isAcknowledged() {
+      return acknowledged;
+    }
+
+    /**
+     * @return true if the acknowledged state is changed from false to true;
+     *         otherwise, the acknowledged state remains unchanged, return false.
+     */
+    boolean receive(AppendEntriesReplyProto reply) {
+      if (acknowledged) {
+        return false;
+      }
+      synchronized (this) {
+        if (!acknowledged && isValid(reply)) {
+          acknowledged = true;
+          return true;
+        }
+        return false;
+      }
+    }
+
+    private boolean isValid(AppendEntriesReplyProto reply) {
+      if (reply == null || !reply.getServerReply().getSuccess()) {
+        return false;
+      }
+      // valid only if the reply has a later call id than the min.
+      return appender.getCallIdComparator().compare(reply.getServerReply().getCallId(), minCallId) >= 0;
+    }
+  }
+
+  static class AppendEntriesListener {
+    private final long commitIndex;
+    private final CompletableFuture<Long> future = new CompletableFuture<>();
+    private final ConcurrentHashMap<RaftPeerId, HeartbeatAck> replies = new ConcurrentHashMap<>();
+
+    AppendEntriesListener(long commitIndex) {
+      this.commitIndex = commitIndex;
+    }
+
+    CompletableFuture<Long> getFuture() {
+      return future;
+    }
+
+    boolean receive(LogAppender logAppender, AppendEntriesReplyProto proto,
+                    Predicate<Predicate<RaftPeerId>> hasMajority) {
+      if (isCompletedNormally()) {
+        return true;
+      }
+
+      final HeartbeatAck reply = replies.computeIfAbsent(
+          logAppender.getFollowerId(), key -> new HeartbeatAck(logAppender));
+      if (reply.receive(proto)) {
+        if (hasMajority.test(id -> replies.get(id).isAcknowledged())) {
+          future.complete(commitIndex);
+          return true;
+        }
+      }
+
+      return isCompletedNormally();
+    }
+
+    boolean isCompletedNormally() {
+      return future.isDone() && !future.isCancelled() && !future.isCompletedExceptionally();
+    }
+  }
+
+  class AppendEntriesListeners {
+    private final NavigableMap<Long, AppendEntriesListener> sorted = new TreeMap<>();
+
+    synchronized AppendEntriesListener add(long commitIndex, Function<Long, AppendEntriesListener> constructor) {
+      return sorted.computeIfAbsent(commitIndex, constructor);
+    }
+
+    synchronized void onAppendEntriesReply(LogAppender appender, AppendEntriesReplyProto reply,
+                                           Predicate<Predicate<RaftPeerId>> hasMajority) {
+      final long callId = reply.getServerReply().getCallId();
+
+      Iterator<Map.Entry<Long, AppendEntriesListener>> iterator = sorted.entrySet().iterator();
+      while (iterator.hasNext()) {
+        Map.Entry<Long, AppendEntriesListener> entry = iterator.next();
+        if (entry.getKey() > callId) {
+          return;
+        }
+
+        final AppendEntriesListener listener = entry.getValue();
+        if (listener == null) {
+          continue;
+        }
+
+        if (listener.receive(appender, reply, hasMajority)) {
+          ackedCommitIndex.updateToMax(listener.commitIndex, s -> LOG.debug("{}: {}", this, s));
+          iterator.remove();
+        }
+      }
+    }
+  }
+
+  private final AppendEntriesListeners appendEntriesListeners = new AppendEntriesListeners();
+  private final RaftLogIndex ackedCommitIndex = new RaftLogIndex("ackedCommitIndex", RaftLog.INVALID_LOG_INDEX);
+
+  AppendEntriesListener addAppendEntriesListener(long commitIndex,
+                                                              Function<Long, AppendEntriesListener> constructor) {
+    if (commitIndex <= ackedCommitIndex.get()) {
+      return null;
+    }
+    return appendEntriesListeners.add(commitIndex, constructor);
+  }
+
+  void onAppendEntriesReply(LogAppender appender, AppendEntriesReplyProto reply,
+                            Predicate<Predicate<RaftPeerId>> hasMajority) {
+    appendEntriesListeners.onAppendEntriesReply(appender, reply, hasMajority);
+  }
+
+  void clear() {
+    appendEntriesListeners.sorted.clear();
+  }
+}

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadRequests.java
@@ -18,14 +18,9 @@
 package org.apache.ratis.server.impl;
 
 import org.apache.ratis.conf.RaftProperties;
-import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
-import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.ReadException;
 import org.apache.ratis.protocol.exceptions.TimeoutIOException;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.leader.LogAppender;
-import org.apache.ratis.server.raftlog.RaftLog;
-import org.apache.ratis.server.raftlog.RaftLogIndex;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.util.MemoizedSupplier;
 import org.apache.ratis.util.TimeDuration;
@@ -33,130 +28,15 @@ import org.apache.ratis.util.TimeoutExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Iterator;
-import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 /** For supporting linearizable read. */
 class ReadRequests {
   private static final Logger LOG = LoggerFactory.getLogger(ReadRequests.class);
-
-  /** The acknowledgement from a {@link LogAppender} of a heartbeat for a particular call id. */
-  static class HeartbeatAck {
-    private final LogAppender appender;
-    private final long minCallId;
-    private volatile boolean acknowledged = false;
-
-    HeartbeatAck(LogAppender appender) {
-      this.appender = appender;
-      this.minCallId = appender.getCallId();
-    }
-
-    /** Is the heartbeat (for a particular call id) acknowledged? */
-    boolean isAcknowledged() {
-      return acknowledged;
-    }
-
-    /**
-     * @return true if the acknowledged state is changed from false to true;
-     *         otherwise, the acknowledged state remains unchanged, return false.
-     */
-    boolean receive(AppendEntriesReplyProto reply) {
-      if (acknowledged) {
-        return false;
-      }
-      synchronized (this) {
-        if (!acknowledged && isValid(reply)) {
-          acknowledged = true;
-          return true;
-        }
-        return false;
-      }
-    }
-
-    private boolean isValid(AppendEntriesReplyProto reply) {
-      if (reply == null || !reply.getServerReply().getSuccess()) {
-        return false;
-      }
-      // valid only if the reply has a later call id than the min.
-      return appender.getCallIdComparator().compare(reply.getServerReply().getCallId(), minCallId) >= 0;
-    }
-  }
-
-  static class AppendEntriesListener {
-    private final long commitIndex;
-    private final CompletableFuture<Long> future = new CompletableFuture<>();
-    private final ConcurrentHashMap<RaftPeerId, HeartbeatAck> replies = new ConcurrentHashMap<>();
-
-    AppendEntriesListener(long commitIndex) {
-      this.commitIndex = commitIndex;
-    }
-
-    CompletableFuture<Long> getFuture() {
-      return future;
-    }
-
-    boolean receive(LogAppender logAppender, AppendEntriesReplyProto proto,
-                    Predicate<Predicate<RaftPeerId>> hasMajority) {
-      if (isCompletedNormally()) {
-        return true;
-      }
-
-      final HeartbeatAck reply = replies.computeIfAbsent(
-          logAppender.getFollowerId(), key -> new HeartbeatAck(logAppender));
-      if (reply.receive(proto)) {
-        if (hasMajority.test(id -> replies.get(id).isAcknowledged())) {
-          future.complete(commitIndex);
-          return true;
-        }
-      }
-
-      return isCompletedNormally();
-    }
-
-    boolean isCompletedNormally() {
-      return future.isDone() && !future.isCancelled() && !future.isCompletedExceptionally();
-    }
-  }
-
-  class AppendEntriesListeners {
-    private final NavigableMap<Long, AppendEntriesListener> sorted = new TreeMap<>();
-
-    synchronized AppendEntriesListener add(long commitIndex, Function<Long, AppendEntriesListener> constructor) {
-      return sorted.computeIfAbsent(commitIndex, constructor);
-    }
-
-    synchronized void onAppendEntriesReply(LogAppender appender, AppendEntriesReplyProto reply,
-                                           Predicate<Predicate<RaftPeerId>> hasMajority) {
-      final long callId = reply.getServerReply().getCallId();
-
-      Iterator<Map.Entry<Long, AppendEntriesListener>> iterator = sorted.entrySet().iterator();
-      while (iterator.hasNext()) {
-        Map.Entry<Long, AppendEntriesListener> entry = iterator.next();
-        if (entry.getKey() > callId) {
-          return;
-        }
-
-        final AppendEntriesListener listener = entry.getValue();
-        if (listener == null) {
-          continue;
-        }
-
-        if (listener.receive(appender, reply, hasMajority)) {
-          ackedCommitIndex.updateToMax(listener.commitIndex, s -> LOG.debug("{}: {}", ReadRequests.this, s));
-          iterator.remove();
-        }
-      }
-    }
-  }
 
   static class ReadIndexQueue {
     private final TimeoutExecutor scheduler = TimeoutExecutor.getInstance();
@@ -199,27 +79,12 @@ class ReadRequests {
     }
   }
 
-  private final AppendEntriesListeners appendEntriesListeners = new AppendEntriesListeners();
-  private final RaftLogIndex ackedCommitIndex = new RaftLogIndex("ackedCommitIndex", RaftLog.INVALID_LOG_INDEX);
   private final ReadIndexQueue readIndexQueue;
   private final StateMachine stateMachine;
 
   ReadRequests(RaftProperties properties, StateMachine stateMachine) {
     this.readIndexQueue = new ReadIndexQueue(RaftServerConfigKeys.Read.timeout(properties));
     this.stateMachine = stateMachine;
-  }
-
-  AppendEntriesListener addAppendEntriesListener(long commitIndex,
-                                                 Function<Long, AppendEntriesListener> constructor) {
-    if (commitIndex <= ackedCommitIndex.get()) {
-      return null;
-    }
-    return appendEntriesListeners.add(commitIndex, constructor);
-  }
-
-  void onAppendEntriesReply(LogAppender appender, AppendEntriesReplyProto reply,
-                            Predicate<Predicate<RaftPeerId>> hasMajority) {
-    appendEntriesListeners.onAppendEntriesReply(appender, reply, hasMajority);
   }
 
   Consumer<Long> getAppliedIndexConsumer() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, `HeartbeatsListeners` in `ReadRequests` has the same lifecycle as `ServerState`. it should belong to Leader LifeCycle and be renewed every time a new Leader is elected. We should move related fields to `LeaderStateImpl`.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1706

## How was this patch tested?

It passed the existing unit tests in ReadOnlyTests
