### PR TITLE
RATIS-1707. Fix corner case when getPrevious in LogAppenderBase

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1322,15 +1322,18 @@ class RaftServerImpl implements RaftServer.Division,
       List<LogEntryProto> entries) {
     if (entries != null && !entries.isEmpty()) {
       final long index0 = entries.get(0).getIndex();
-
-      if (previous == null || previous.getTerm() == 0) {
-        Preconditions.assertTrue(index0 == 0,
-            "Unexpected Index: previous is null but entries[%s].getIndex()=%s",
-            0, index0);
-      } else {
-        Preconditions.assertTrue(previous.getIndex() == index0 - 1,
-            "Unexpected Index: previous is %s but entries[%s].getIndex()=%s",
-            previous, 0, index0);
+      // Check if next entry's index is 1 greater than the snapshotIndex. If yes, then
+      // we do not have to check for the existence of previous.
+      if (index0 != state.getSnapshotIndex() + 1) {
+        if (previous == null || previous.getTerm() == 0) {
+          Preconditions.assertTrue(index0 == 0,
+              "Unexpected Index: previous is null but entries[%s].getIndex()=%s",
+              0, index0);
+        } else {
+          Preconditions.assertTrue(previous.getIndex() == index0 - 1,
+              "Unexpected Index: previous is %s but entries[%s].getIndex()=%s",
+              previous, 0, index0);
+        }
       }
 
       for (int i = 0; i < entries.size(); i++) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
@@ -158,11 +158,6 @@ public abstract class LogAppenderBase implements LogAppender {
       }
     }
 
-    final long raftLogLastPurgedIndex = getRaftLog().getStartIndex() - 1;
-    if (raftLogLastPurgedIndex == previousIndex) {
-      return TermIndex.valueOf(server.getInfo().getCurrentTerm(), raftLogLastPurgedIndex);
-    }
-
     return null;
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
@@ -158,6 +158,11 @@ public abstract class LogAppenderBase implements LogAppender {
       }
     }
 
+    final long raftLogLastPurgedIndex = getRaftLog().getStartIndex() - 1;
+    if (raftLogLastPurgedIndex == previousIndex) {
+      return TermIndex.valueOf(server.getInfo().getCurrentTerm(), raftLogLastPurgedIndex);
+    }
+
     return null;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the cluster, we found that there are many exceptions on Failed appendEntries.

Unexpected Index: previous is null but entries[0].getIndex()=3402406. So the follower cannot append an entry due to some limit.

The scenario:

Follower B restarted, leader A sent the entry and B can not find the previous log entry. A sent the notifyInstallSnapshot request to B, and B found its next index is larger than the leader's firstAvailableLogIndex(the index to install snapshot). A updated B's index according to the reply and sent the entries to B.  A will find the previous entry TermIndex through ``getPrevious(long nextIndex)``, if nextIndex of raft log of B is exactly the same as startIndex of leader A (B needs the entries since A's firstAvailableLogIndex), A has purged its raft log and will check the snapshot Index through server.getStateMachine().getLatestSnapshot() whether it equals to nextIndex - 1, if not then returns null. 

The reason:
The problem is due to the uncertainty of the purging raft log. If A has also been stopped, and thus triggered the takeSnapshot, the raft log may not be purged up to the snapshot index. The latest snapshot index from SM is not equal to the raft log's first available index, which leads to this corner case.

We could add a case check for this when getPrevious.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1707

## How was this patch tested?
/
