### PR TITLE
RATIS-1711. Fix a bug in LogProtoUtils.isStateMachineDataEmpty

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/LogProtoUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/LogProtoUtils.java
@@ -151,7 +151,7 @@ public final class LogProtoUtils {
     return getStateMachineEntry(entry)
         .map(StateMachineEntryProto::getStateMachineData)
         .map(ByteString::isEmpty)
-        .orElse(false);
+        .orElse(true);
   }
 
   private static Optional<StateMachineEntryProto> getStateMachineEntry(LogEntryProto entry) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -288,7 +288,7 @@ public class SegmentedRaftLog extends RaftLogBase {
     if (entry == null) {
       throw new RaftLogIOException("Log entry not found: index = " + index);
     }
-    if (!LogProtoUtils.isStateMachineDataEmpty(entry)) {
+    if (LogProtoUtils.isStateMachineDataEmpty(entry)) {
       return newEntryWithData(entry, null);
     }
 


### PR DESCRIPTION
see [https://issues.apache.org/jira/browse/RATIS-1711](https://issues.apache.org/jira/browse/RATIS-1711)