### PR TITLE
RATIS-1674. In GrpcLogAppender, disable retry and add minWait.

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A new log appender implementation using grpc bi-directional stream API.
@@ -72,6 +73,9 @@ public class GrpcLogAppender extends LogAppenderBase {
   private final TimeDuration requestTimeoutDuration;
   private final TimeoutExecutor scheduler = TimeoutExecutor.getInstance();
 
+  private final long waitTimeMinMs;
+  private final AtomicReference<Timestamp> lastAppendEntries;
+
   private volatile StreamObservers appendLogRequestObserver;
   private final boolean useSeparateHBChannel;
 
@@ -90,6 +94,10 @@ public class GrpcLogAppender extends LogAppenderBase {
     this.requestTimeoutDuration = RaftServerConfigKeys.Rpc.requestTimeout(properties);
     this.installSnapshotEnabled = RaftServerConfigKeys.Log.Appender.installSnapshotEnabled(properties);
     this.useSeparateHBChannel = GrpcConfigKeys.Server.heartbeatChannel(properties);
+
+    final TimeDuration waitTimeMin = RaftServerConfigKeys.Log.Appender.waitTimeMin(properties);
+    this.waitTimeMinMs = waitTimeMin.toLong(TimeUnit.MILLISECONDS);
+    this.lastAppendEntries = new AtomicReference<>(Timestamp.currentTime().addTime(waitTimeMin.negate()));
 
     grpcServerMetrics = new GrpcServerMetrics(server.getMemberId().toString());
     grpcServerMetrics.addPendingRequestsCount(getFollowerId().toString(), pendingRequests::logRequestsSize);
@@ -172,9 +180,10 @@ public class GrpcLogAppender extends LogAppenderBase {
       // For normal nodes, new entries should be sent ASAP
       // however for slow followers (especially when the follower is down),
       // keep sending without any wait time only ends up in high CPU load
-      return 0L;
+      final long min = waitTimeMinMs - lastAppendEntries.get().elapsedTimeMs();
+      return Math.max(0L, min);
     }
-    return Math.min(10L, getHeartbeatWaitTimeMs());
+    return Math.min(waitTimeMinMs, getHeartbeatWaitTimeMs());
   }
 
   private boolean isSlowFollower() {
@@ -284,6 +293,7 @@ public class GrpcLogAppender extends LogAppenderBase {
         .map(observer -> {
           request.startRequestTimer();
           observer.onNext(proto);
+          lastAppendEntries.set(Timestamp.currentTime());
           return true;
         }).isPresent();
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -102,6 +102,7 @@ public class GrpcServerProtocolClient implements Closeable {
     } else {
       channelBuilder.negotiationType(NegotiationType.PLAINTEXT);
     }
+    channelBuilder.disableRetry();
     return channelBuilder.flowControlWindow(flowControlWindow).build();
   }
 

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -543,6 +543,16 @@ public interface RaftServerConfigKeys {
       static void setInstallSnapshotEnabled(RaftProperties properties, boolean shouldInstallSnapshot) {
         setBoolean(properties::setBoolean, INSTALL_SNAPSHOT_ENABLED_KEY, shouldInstallSnapshot);
       }
+
+      String WAIT_TIME_MIN_KEY = PREFIX + ".wait-time.min";
+      TimeDuration WAIT_TIME_MIN_DEFAULT = TimeDuration.valueOf(10, TimeUnit.MILLISECONDS);
+      static TimeDuration waitTimeMin(RaftProperties properties) {
+        return getTimeDuration(properties.getTimeDuration(WAIT_TIME_MIN_DEFAULT.getUnit()),
+            WAIT_TIME_MIN_KEY, WAIT_TIME_MIN_DEFAULT, getDefaultLog());
+      }
+      static void setWaitTimeMin(RaftProperties properties, TimeDuration minDuration) {
+        setTimeDuration(properties::setTimeDuration, WAIT_TIME_MIN_KEY, minDuration);
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Add minWait for GrpcLogAppender. When cluster contains a slow follower, 0 waiting time ends up high cpu load and lots of Inconsistent AppendEntries. 
2. Disable retry for Server RPC channel. There's leak in gRPC retry mechanism that could lead to OutOfDirectMemoryError when appendEntries timeout and retried on a slow follower. see https://github.com/grpc/grpc-java/issues/9563.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/projects/RATIS/issues/RATIS-1674

## How was this patch tested?
unit tests
manual tests
