### PR TITLE
RATIS-1719. Bump the copyright year to 2022 in NOTICE file.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Ratis
-Copyright 2017-2021 The Apache Software Foundation
+Copyright 2017-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/ratis-assembly/src/main/resources/NOTICE
+++ b/ratis-assembly/src/main/resources/NOTICE
@@ -1,5 +1,5 @@
 Apache Ratis
-Copyright 2017-2021 The Apache Software Foundation
+Copyright 2017-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1719