### PR TITLE
RATIS-1716. Separate ReadException and ReadIndexException for client retry

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientReply.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientReply.java
@@ -26,6 +26,7 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.exceptions.NotReplicatedException;
 import org.apache.ratis.protocol.exceptions.RaftException;
 import org.apache.ratis.protocol.exceptions.ReadException;
+import org.apache.ratis.protocol.exceptions.ReadIndexException;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.protocol.exceptions.TransferLeadershipException;
 import org.apache.ratis.util.JavaUtils;
@@ -170,7 +171,8 @@ public class RaftClientReply extends RaftClientMessage {
           AlreadyClosedException.class,
           NotLeaderException.class, NotReplicatedException.class,
           LeaderNotReadyException.class, StateMachineException.class, DataStreamException.class,
-          LeaderSteppingDownException.class, TransferLeadershipException.class, ReadException.class),
+          LeaderSteppingDownException.class, TransferLeadershipException.class, ReadException.class,
+          ReadIndexException.class),
           () -> "Unexpected exception class: " + this);
     }
   }
@@ -248,6 +250,10 @@ public class RaftClientReply extends RaftClientMessage {
 
   public ReadException getReadException() {
     return JavaUtils.cast(exception, ReadException.class);
+  }
+
+  public ReadIndexException getReadIndexException() {
+    return JavaUtils.cast(exception, ReadIndexException.class);
   }
 
   /** @return the exception, if there is any; otherwise, return null. */

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/ReadIndexException.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/ReadIndexException.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.protocol.exceptions;
+
+
+/**
+ * This indicates a retryable read exception
+ */
+public class ReadIndexException extends RaftException {
+
+  public ReadIndexException(String message) {
+    super(message);
+  }
+  public ReadIndexException(Throwable throwable) {
+    super(throwable);
+  }
+}

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/ReadIndexException.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/ReadIndexException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -26,7 +26,7 @@ public class ReadIndexException extends RaftException {
   public ReadIndexException(String message) {
     super(message);
   }
-  public ReadIndexException(Throwable throwable) {
-    super(throwable);
+  public ReadIndexException(String message, Throwable throwable) {
+    super(message, throwable);
   }
 }

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -409,6 +409,7 @@ message RaftClientReplyProto {
     ThrowableProto leaderSteppingDownException = 9;
     ThrowableProto transferLeadershipException = 10;
     ThrowableProto readException = 11;
+    ThrowableProto readIndexException = 12;
   }
 
   uint64 logIndex = 14; // When the request is a write request and the reply is success, the log index of the transaction

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -1090,6 +1090,7 @@ class LeaderStateImpl implements LeaderState {
     // leader has not committed any entries in this term, reject
     if (server.getRaftLog().getTermIndex(readIndex).getTerm() != server.getState().getCurrentTerm()) {
       return JavaUtils.completeExceptionally(new ReadIndexException(
+          "Failed to getReadIndex " + readIndex + " since the term is not yet committed.",
           new LeaderNotReadyException(server.getMemberId())));
     }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -38,6 +38,7 @@ import org.apache.ratis.protocol.TransferLeadershipRequest;
 import org.apache.ratis.protocol.exceptions.LeaderNotReadyException;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.exceptions.NotReplicatedException;
+import org.apache.ratis.protocol.exceptions.ReadIndexException;
 import org.apache.ratis.protocol.exceptions.ReconfigurationTimeoutException;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.impl.ReadIndexHeartbeats.AppendEntriesListener;
@@ -1088,7 +1089,8 @@ class LeaderStateImpl implements LeaderState {
 
     // leader has not committed any entries in this term, reject
     if (server.getRaftLog().getTermIndex(readIndex).getTerm() != server.getState().getCurrentTerm()) {
-      return JavaUtils.completeExceptionally(new LeaderNotReadyException(server.getMemberId()));
+      return JavaUtils.completeExceptionally(new ReadIndexException(
+          new LeaderNotReadyException(server.getMemberId())));
     }
 
     final MemoizedSupplier<AppendEntriesListener> supplier = MemoizedSupplier.valueOf(

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -25,6 +25,7 @@ import org.apache.ratis.proto.RaftProtos.*;
 import org.apache.ratis.proto.RaftProtos.RaftClientRequestProto.TypeCase;
 import org.apache.ratis.protocol.*;
 import org.apache.ratis.protocol.exceptions.ReadException;
+import org.apache.ratis.protocol.exceptions.ReadIndexException;
 import org.apache.ratis.protocol.exceptions.SetConfigurationException;
 import org.apache.ratis.protocol.exceptions.GroupMismatchException;
 import org.apache.ratis.protocol.exceptions.LeaderNotReadyException;
@@ -947,7 +948,7 @@ class RaftServerImpl implements RaftServer.Division,
           if (reply.getServerReply().getSuccess()) {
             return reply.getReadIndex();
           } else {
-            throw new CompletionException(new ReadException(getId() +
+            throw new CompletionException(new ReadIndexException(getId() +
                 ": Failed to get read index from the leader: " + reply));
           }
         });
@@ -974,6 +975,8 @@ class RaftServerImpl implements RaftServer.Division,
       return newExceptionReply(request, (StateMachineException) e);
     } else if (e instanceof ReadException) {
       return newExceptionReply(request, (ReadException) e);
+    } else if (e instanceof ReadIndexException) {
+      return newExceptionReply(request, (ReadIndexException) e);
     } else {
       throw new CompletionException(e);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In Linearizable Read Only requests, there are two category of exceptions:
1. LeaderNotReady / NotLeader, client should retry on these exceptions.
2. TimeoutIOException, client should accept that this read request fails.

In This PR, I propose to separate ReadException to ReadException(fail) and ReadIndexException(retry-able).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1716

## How was this patch tested?
1. Passed original unit tests.
2. Add new unit test suite for client retry on ReadIndexException.
