### PR TITLE
RATIS-1721. example-bin.xml and shell-bin.xml use incorrect LICENSE.

### DIFF
--- a/ratis-assembly/pom.xml
+++ b/ratis-assembly/pom.xml
@@ -148,9 +148,9 @@
             </goals>
             <configuration>
               <descriptors>
-                <descriptor>src/main/assembly/bin.xml</descriptor>
                 <descriptor>src/main/assembly/examples-bin.xml</descriptor>
                 <descriptor>src/main/assembly/shell-bin.xml</descriptor>
+                <descriptor>src/main/assembly/bin.xml</descriptor>
                 <descriptor>src/main/assembly/bin-pkg.xml</descriptor>
               </descriptors>
               <finalName>apache-ratis-${project.version}-bin</finalName>

--- a/ratis-assembly/src/main/assembly/bin.xml
+++ b/ratis-assembly/src/main/assembly/bin.xml
@@ -54,14 +54,6 @@
   </moduleSets>
   <fileSets>
     <fileSet>
-      <directory>${project.basedir}/..</directory>
-      <outputDirectory>.</outputDirectory>
-      <includes>
-        <include>DISCLAIMER</include>
-      </includes>
-      <fileMode>0644</fileMode>
-    </fileSet>
-    <fileSet>
       <directory>${project.basedir}/src/main/resources</directory>
       <outputDirectory>.</outputDirectory>
       <includes>

--- a/ratis-assembly/src/main/assembly/examples-bin.xml
+++ b/ratis-assembly/src/main/assembly/examples-bin.xml
@@ -35,17 +35,10 @@
   </dependencySets>
   <fileSets>
     <fileSet>
-      <directory>${project.basedir}/..</directory>
+      <directory>${project.basedir}/src/main/resources</directory>
       <outputDirectory>.</outputDirectory>
       <includes>
-        <include>DISCLAIMER</include>
-      </includes>
-      <fileMode>0644</fileMode>
-    </fileSet>
-    <fileSet>
-      <directory>${project.build.directory}/maven-shared-archive-resources/META-INF/</directory>
-      <outputDirectory>.</outputDirectory>
-      <includes>
+        <include>README.md</include>
         <include>LICENSE</include>
         <include>NOTICE</include>
       </includes>

--- a/ratis-assembly/src/main/assembly/shell-bin.xml
+++ b/ratis-assembly/src/main/assembly/shell-bin.xml
@@ -32,17 +32,10 @@
       <outputDirectory>jars</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>${project.basedir}/..</directory>
+      <directory>${project.basedir}/src/main/resources</directory>
       <outputDirectory>.</outputDirectory>
       <includes>
-        <include>DISCLAIMER</include>
-      </includes>
-      <fileMode>0644</fileMode>
-    </fileSet>
-    <fileSet>
-      <directory>${project.build.directory}/maven-shared-archive-resources/META-INF/</directory>
-      <outputDirectory>.</outputDirectory>
-      <includes>
+        <include>README.md</include>
         <include>LICENSE</include>
         <include>NOTICE</include>
       </includes>

--- a/ratis-assembly/src/main/assembly/src.xml
+++ b/ratis-assembly/src/main/assembly/src.xml
@@ -96,7 +96,6 @@
       <outputDirectory>.</outputDirectory>
       <includes>
         <include>BUILDING.md</include>
-        <include>DISCLAIMER</include>
         <include>LICENSE</include>
         <include>NOTICE</include>
         <include>README.md</include>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1721