### PR TITLE
RATIS-1651. Fix NP_NULL_PARAM_DEREF in GrpcServerProtocolService

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -17,7 +17,6 @@
  */
 package org.apache.ratis.grpc.server;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.grpc.GrpcUtil;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
@@ -106,7 +105,6 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
     }
 
     @Override
-    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     public void onNext(REQUEST request) {
       if (!replyInOrder(request)) {
         try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

I removed SuppressedWarning annotation. No additional changes are needed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1651

## How was this patch tested?

unit tests, local findbugs run