### PR TITLE
RATIS-1717. Perf: Use global serialize buf to avoid temp buf

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
@@ -63,9 +63,12 @@ class BufferedWriteChannel implements Closeable {
   }
 
   void write(byte[] b) throws IOException {
+    write(b, b.length);
+  }
+  void write(byte[] b, int len) throws IOException {
     int offset = 0;
-    while (offset < b.length) {
-      int toPut = Math.min(b.length - offset, writeBuffer.remaining());
+    while (offset < len) {
+      int toPut = Math.min(len - offset, writeBuffer.remaining());
       writeBuffer.put(b, offset, toPut);
       offset += toPut;
       if (writeBuffer.remaining() == 0) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -149,6 +149,7 @@ class SegmentedRaftLogWorker {
   private final StateMachine stateMachine;
   private final SegmentedRaftLogMetrics raftLogMetrics;
   private final ByteBuffer writeBuffer;
+  private final Supplier<byte[]> sharedBuffer;
 
   /**
    * The number of entries that have been written into the SegmentedRaftLogOutputStream but
@@ -207,6 +208,9 @@ class SegmentedRaftLogWorker {
 
     final int bufferSize = RaftServerConfigKeys.Log.writeBufferSize(properties).getSizeInt();
     this.writeBuffer = ByteBuffer.allocateDirect(bufferSize);
+    final int logEntryLimit = RaftServerConfigKeys.Log.Appender.bufferByteLimit(properties).getSizeInt();
+    // 4 bytes (serialized size) + logEntryLimit + 4 bytes (checksum)
+    this.sharedBuffer = MemoizedSupplier.valueOf(() -> new byte[logEntryLimit + 8]);
     this.unsafeFlush = RaftServerConfigKeys.Log.unsafeFlushEnabled(properties);
     this.asyncFlush = RaftServerConfigKeys.Log.asyncFlushEnabled(properties);
     if (asyncFlush && unsafeFlush) {
@@ -729,6 +733,6 @@ class SegmentedRaftLogWorker {
   private void allocateSegmentedRaftLogOutputStream(File file, boolean append) throws IOException {
     Preconditions.assertTrue(out == null && writeBuffer.position() == 0);
     out = new SegmentedRaftLogOutputStream(file, append, segmentMaxSize,
-            preallocatedSize, writeBuffer);
+            preallocatedSize, writeBuffer, sharedBuffer);
   }
 }


### PR DESCRIPTION
## Motivation
Serializing a log entry to RaftLog currently requires two data copies, one from entry to temp heap array, one from heap array to direct byteBuffer. The original motivation is to reduce the former copy and directly serialize log entry to direct byteBuffer. This beneficial in the following two aspects:
1. Avoid temp heap array and reduce young GC pressure.
2. Save CPU cycles on copying data and reduce latency.

However, the checksum operation on Log Entry prevents us from eliminating the extra copy. Performing checksum on direct memory involves copying data back to heap (Oops🥵), one byte at a time. To make matters worse, Unsafe operations involves lots of safety overheads like boundary checking, make the performance even slower (3x times) than original two-copy method. Therefore, we better leave the current two-copy method unchanged.

Still, we can allocate a global `serializeBuf` and avoid allocating a temp heap array every write operation. 

## What changes were proposed in this pull request?
Allocate a global serialize buffer (as large as BufferByteLimit) and use this buffer to hold serialization results.

According to benchmark simulation results(Using Apache IoTDB workloads), this patch can reduce the byte array allocation in the write path and reduce total young GC frequency by roughly 20% .

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1717

## How was this patch tested?
1. unit tests
2. manual tests and benchmark tests.
