### PR TITLE
RATIS-1652. Fix NP_NULL_PARAM_DEREF in DataStreamManagement

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -18,7 +18,6 @@
 
 package org.apache.ratis.netty.server;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.client.DataStreamOutputRpc;
 import org.apache.ratis.client.impl.ClientProtoUtils;
 import org.apache.ratis.conf.RaftProperties;
@@ -125,7 +124,6 @@ public class DataStreamManagement {
     private final LocalStream local;
     private final Set<RemoteStream> remotes;
     private final RaftServer server;
-    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     private final AtomicReference<CompletableFuture<Void>> previous
         = new AtomicReference<>(CompletableFuture.completedFuture(null));
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

removed SuppressedWarning annotation. No additional changed are needed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1652

## How was this patch tested?

unit tests, local findbugs run
