### PR TITLE
RATIS-1725. Update github actions for node16

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache for maven dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
@@ -37,7 +37,7 @@ jobs:
       - name: Run a full build
         run: ./dev-support/checks/build.sh -Prelease assembly:single
       - name: Store source tarball for compilation
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ratis-src
           path: ratis-assembly/target/apache-ratis-*-src.tar.gz
@@ -55,14 +55,14 @@ jobs:
       fail-fast: false
     steps:
       - name: Download source tarball
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ratis-src
       - name: Untar sources
         run: |
           tar --strip-components 1 -xzvf apache-ratis-*-src.tar.gz
       - name: Cache for maven dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
@@ -82,9 +82,9 @@ jobs:
     name: rat
     runs-on: ubuntu-20.04
     steps:
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v3
         - name: Cache for maven dependencies
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: ~/.m2/repository
             key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
@@ -92,7 +92,7 @@ jobs:
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
         - run: ./dev-support/checks/rat.sh
-        - uses: actions/upload-artifact@master
+        - uses: actions/upload-artifact@v3
           if: always()
           with:
             name: rat
@@ -104,9 +104,9 @@ jobs:
     name: author
     runs-on: ubuntu-20.04
     steps:
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v3
         - run: ./dev-support/checks/author.sh
-        - uses: actions/upload-artifact@master
+        - uses: actions/upload-artifact@v3
           if: always()
           with:
             name: author
@@ -127,9 +127,9 @@ jobs:
           run: |
             echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
         # REMOVE CODE ABOVE WHEN ISSUE IS ADDRESSED!
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v3
         - name: Cache for maven dependencies
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: ~/.m2/repository
             key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
@@ -140,7 +140,7 @@ jobs:
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: ${{ !cancelled() }}
-        - uses: actions/upload-artifact@master
+        - uses: actions/upload-artifact@v3
           if: ${{ !cancelled() }}
           with:
             name: unit-${{ matrix.profile }}
@@ -152,9 +152,9 @@ jobs:
     name: checkstyle
     runs-on: ubuntu-20.04
     steps:
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v3
         - name: Cache for maven dependencies
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: ~/.m2/repository
             key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
@@ -162,7 +162,7 @@ jobs:
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
         - run: ./dev-support/checks/checkstyle.sh
-        - uses: actions/upload-artifact@master
+        - uses: actions/upload-artifact@v3
           if: always()
           with:
             name: checkstyle
@@ -178,9 +178,9 @@ jobs:
           uses: actions/setup-java@v1
           with:
             java-version: 8
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v3
         - name: Cache for maven dependencies
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: ~/.m2/repository
             key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
@@ -188,7 +188,7 @@ jobs:
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
         - run: ./dev-support/checks/findbugs.sh
-        - uses: actions/upload-artifact@master
+        - uses: actions/upload-artifact@v3
           if: always()
           with:
             name: findbugs
@@ -201,9 +201,9 @@ jobs:
     runs-on: ubuntu-20.04
     if: (github.repository == 'apache/ratis' || github.repository == 'apache/incubator-ratis') && github.event_name != 'pull_request'
     steps:
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v3
         - name: Cache for maven dependencies
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
             path: ~/.m2/repository
             key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -31,8 +31,9 @@ jobs:
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Run a full build
         run: ./dev-support/checks/build.sh -Prelease assembly:single
@@ -70,8 +71,9 @@ jobs:
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Run a full build
         run: ./dev-support/checks/build.sh
@@ -175,8 +177,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
         - name: Setup java
-          uses: actions/setup-java@v1
+          uses: actions/setup-java@v3
           with:
+            distribution: 'temurin'
             java-version: 8
         - uses: actions/checkout@v3
         - name: Cache for maven dependencies
@@ -211,8 +214,9 @@ jobs:
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
         - name: Setup java 11
-          uses: actions/setup-java@v1
+          uses: actions/setup-java@v3
           with:
+            distribution: 'temurin'
             java-version: 11
         - run: ./dev-support/checks/sonar.sh
           env:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Github Actions action versions to ones that use node16, as node12 is being deprecated: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

https://issues.apache.org/jira/browse/RATIS-1725

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/incubator-ratis/actions/runs/3252239569