### PR TITLE
RATIS-1727. Typo: change GrpcConfigKey 'useCached' to useSeparate

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
@@ -240,8 +240,8 @@ public interface GrpcConfigKeys {
       return getBoolean(properties::getBoolean, HEARTBEAT_CHANNEL_KEY,
               HEARTBEAT_CHANNEL_DEFAULT, getDefaultLog());
     }
-    static void setHeartbeatChannel(RaftProperties properties, boolean useCached) {
-      setBoolean(properties::setBoolean, HEARTBEAT_CHANNEL_KEY, useCached);
+    static void setHeartbeatChannel(RaftProperties properties, boolean useSeparate) {
+      setBoolean(properties::setBoolean, HEARTBEAT_CHANNEL_KEY, useSeparate);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

After upgrading to Ratis 2.4.0, I found the param name for heartbeatChannel is confusing. 
It should be `useSeparate` instead of `useCached`

Jira issue: https://issues.apache.org/jira/browse/RATIS-1727