### PR TITLE
RATIS-1733. Typo: fix misleading params names in `RaftServerConfigKeys`

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
@@ -324,12 +324,9 @@ public interface ClientProtoUtils {
         b.setNotReplicatedException(nreBuilder);
       }
 
-      final LeaderNotReadyException lnre = reply.getLeaderNotReadyException();
-      if (lnre != null) {
-        LeaderNotReadyExceptionProto.Builder lnreBuilder = LeaderNotReadyExceptionProto.newBuilder()
-            .setServerId(ProtoUtils.toRaftGroupMemberIdProtoBuilder(lnre.getServerId()));
-        b.setLeaderNotReadyException(lnreBuilder);
-      }
+      Optional.ofNullable(reply.getLeaderNotReadyException())
+          .map(e -> LeaderNotReadyExceptionProto.newBuilder().setServerId(e.getRaftGroupMemberIdProto()))
+          .ifPresent(b::setLeaderNotReadyException);
 
       Optional.ofNullable(reply.getStateMachineException())
           .map(ClientProtoUtils::toStateMachineExceptionProtoBuilder)

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/LeaderNotReadyException.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/LeaderNotReadyException.java
@@ -17,7 +17,9 @@
  */
 package org.apache.ratis.protocol.exceptions;
 
+import org.apache.ratis.proto.RaftProtos.RaftGroupMemberIdProto;
 import org.apache.ratis.protocol.RaftGroupMemberId;
+import org.apache.ratis.util.ProtoUtils;
 
 /**
  * This exception is sent from the server to a client. The server has just
@@ -26,14 +28,18 @@ import org.apache.ratis.protocol.RaftGroupMemberId;
  * it cannot determine whether a request is just a retry.
  */
 public class LeaderNotReadyException extends ServerNotReadyException {
-  private final RaftGroupMemberId serverId;
+  private final RaftGroupMemberIdProto serverId;
 
   public LeaderNotReadyException(RaftGroupMemberId id) {
     super(id + " is in LEADER state but not ready yet.");
-    this.serverId = id;
+    this.serverId = ProtoUtils.toRaftGroupMemberIdProtoBuilder(id).build();
   }
 
   public RaftGroupMemberId getServerId() {
+    return ProtoUtils.toRaftGroupMemberId(serverId);
+  }
+
+  public RaftGroupMemberIdProto getRaftGroupMemberIdProto() {
     return serverId;
   }
 }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -114,8 +114,8 @@ public interface RaftServerConfigKeys {
       return getInt(properties::getInt, PROXY_SIZE_KEY, PROXY_SIZE_DEFAULT, getDefaultLog(),
           requireMin(0), requireMax(65536));
     }
-    static void setProxySize(RaftProperties properties, int port) {
-      setInt(properties::setInt, PROXY_SIZE_KEY, port);
+    static void setProxySize(RaftProperties properties, int size) {
+      setInt(properties::setInt, PROXY_SIZE_KEY, size);
     }
 
     String SERVER_CACHED_KEY = PREFIX + ".server.cached";
@@ -133,8 +133,8 @@ public interface RaftServerConfigKeys {
       return getInt(properties::getInt, SERVER_SIZE_KEY, SERVER_SIZE_DEFAULT, getDefaultLog(),
           requireMin(0), requireMax(65536));
     }
-    static void setServerSize(RaftProperties properties, int port) {
-      setInt(properties::setInt, SERVER_SIZE_KEY, port);
+    static void setServerSize(RaftProperties properties, int size) {
+      setInt(properties::setInt, SERVER_SIZE_KEY, size);
     }
 
     String CLIENT_CACHED_KEY = PREFIX + ".client.cached";
@@ -152,8 +152,8 @@ public interface RaftServerConfigKeys {
       return getInt(properties::getInt, CLIENT_SIZE_KEY, CLIENT_SIZE_DEFAULT, getDefaultLog(),
           requireMin(0), requireMax(65536));
     }
-    static void setClientSize(RaftProperties properties, int port) {
-      setInt(properties::setInt, CLIENT_SIZE_KEY, port);
+    static void setClientSize(RaftProperties properties, int size) {
+      setInt(properties::setInt, CLIENT_SIZE_KEY, size);
     }
   }
 
@@ -567,8 +567,8 @@ public interface RaftServerConfigKeys {
       return getBoolean(properties::getBoolean,
           AUTO_TRIGGER_ENABLED_KEY, AUTO_TRIGGER_ENABLED_DEFAULT, getDefaultLog());
     }
-    static void setAutoTriggerEnabled(RaftProperties properties, boolean autoTriggerThreshold) {
-      setBoolean(properties::setBoolean, AUTO_TRIGGER_ENABLED_KEY, autoTriggerThreshold);
+    static void setAutoTriggerEnabled(RaftProperties properties, boolean autoTriggerEnabled) {
+      setBoolean(properties::setBoolean, AUTO_TRIGGER_ENABLED_KEY, autoTriggerEnabled);
     }
 
     /** The log index gap between to two snapshot creations. */
@@ -628,8 +628,8 @@ public interface RaftServerConfigKeys {
           requireMin(0), requireMax(65536));
     }
 
-    static void setAsyncRequestThreadPoolSize(RaftProperties properties, int port) {
-      setInt(properties::setInt, ASYNC_REQUEST_THREAD_POOL_SIZE_KEY, port);
+    static void setAsyncRequestThreadPoolSize(RaftProperties properties, int size) {
+      setInt(properties::setInt, ASYNC_REQUEST_THREAD_POOL_SIZE_KEY, size);
     }
 
     String ASYNC_WRITE_THREAD_POOL_SIZE_KEY = PREFIX + ".async.write.thread.pool.size";
@@ -641,8 +641,8 @@ public interface RaftServerConfigKeys {
           requireMin(0), requireMax(65536));
     }
 
-    static void setAsyncWriteThreadPoolSize(RaftProperties properties, int port) {
-      setInt(properties::setInt, ASYNC_WRITE_THREAD_POOL_SIZE_KEY, port);
+    static void setAsyncWriteThreadPoolSize(RaftProperties properties, int size) {
+      setInt(properties::setInt, ASYNC_WRITE_THREAD_POOL_SIZE_KEY, size);
     }
 
     String CLIENT_POOL_SIZE_KEY = PREFIX + ".client.pool.size";
@@ -795,8 +795,8 @@ public interface RaftServerConfigKeys {
       return getTimeDuration(properties.getTimeDuration(LEADER_STEP_DOWN_WAIT_TIME_DEFAULT.getUnit()),
           LEADER_STEP_DOWN_WAIT_TIME_KEY, LEADER_STEP_DOWN_WAIT_TIME_DEFAULT, getDefaultLog());
     }
-    static void setLeaderStepDownWaitTime(RaftProperties properties, TimeDuration noLeaderTimeout) {
-      setTimeDuration(properties::setTimeDuration, LEADER_STEP_DOWN_WAIT_TIME_KEY, noLeaderTimeout);
+    static void setLeaderStepDownWaitTime(RaftProperties properties, TimeDuration leaderStepDownWaitTime) {
+      setTimeDuration(properties::setTimeDuration, LEADER_STEP_DOWN_WAIT_TIME_KEY, leaderStepDownWaitTime);
     }
 
     String PRE_VOTE_KEY = PREFIX + ".pre-vote";

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -921,6 +921,9 @@ class RaftServerImpl implements RaftServer.Division,
   }
 
   private CompletableFuture<ReadIndexReplyProto> sendReadIndexAsync() {
+    if (getInfo().getLeaderId() == null) {
+      JavaUtils.completeExceptionally(generateNotLeaderException());
+    }
     final ReadIndexRequestProto request = ServerProtoUtils.toReadIndexRequestProto(
         getMemberId(),  getInfo().getLeaderId());
     try {
@@ -944,7 +947,7 @@ class RaftServerImpl implements RaftServer.Division,
       if (leader != null) {
         replyFuture = leader.getReadIndex();
       } else {
-        replyFuture = sendReadIndexAsync().thenApply(reply -> {
+        replyFuture = sendReadIndexAsync().thenApply(reply   -> {
           if (reply.getServerReply().getSuccess()) {
             return reply.getReadIndex();
           } else {

--- a/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
@@ -224,7 +224,7 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
         .newBuilder()
         .setDefaultPolicy(RetryPolicies.noRetry())
         .setExceptionToPolicy(ReadIndexException.class,
-            RetryPolicies.retryForeverWithSleep(TimeDuration.valueOf(100, TimeUnit.MILLISECONDS)))
+            RetryPolicies.retryForeverWithSleep(TimeDuration.valueOf(500, TimeUnit.MILLISECONDS)))
         .build();
 
     RaftTestUtil.waitForLeader(cluster);


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1733