### PR TITLE
RATIS-1340: Ratis scripts' discovery of Bash source path is incompatible with CDPATH.

### DIFF
--- a/ratis-examples/src/main/bin/client.sh
+++ b/ratis-examples/src/main/bin/client.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 
 USAGE="client.sh <example> <command>"
 

--- a/ratis-examples/src/main/bin/common.sh
+++ b/ratis-examples/src/main/bin/common.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 
 LIB_DIR=${SCRIPT_DIR}/../lib
 

--- a/ratis-examples/src/main/bin/server.sh
+++ b/ratis-examples/src/main/bin/server.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 source $DIR/common.sh
 
 java ${LOGGER_OPTS} -jar $ARTIFACT "$@"

--- a/ratis-examples/src/main/bin/start-all.sh
+++ b/ratis-examples/src/main/bin/start-all.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 
 USAGE="start-all.sh <example> <subcommand>"
 

--- a/ratis-experiments/scripts/flatbuf-compile.sh
+++ b/ratis-experiments/scripts/flatbuf-compile.sh
@@ -16,7 +16,7 @@
 
 set -eu
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 DOCDIR="$DIR/.."
 
 if [ "$(which flatc)" ]; then


### PR DESCRIPTION
…ble with CDPATH.

## What changes were proposed in this pull request?

Several Bash scripts in Ratis use this common idiom to discover the current source path and then build relative paths from it:

```
DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
```
This mostly works well, but it isn't compatible with interactive shells using the `CDPATH` environment variable to provide a custom search path for resolving the directory referenced by `cd`.  (See [bash man page](https://linux.die.net/man/1/bash) discussion of `CDPATH` and how the resolved directory is "written to the standard output.")

The standard solution is to redirect stdout of `cd` to `/dev/null`:

```
DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
```

Some Ratis scripts already do this, but not all.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1340

## How was this patch tested?

Manual testing invoking the scripts.