### PR TITLE
RATIS-1736. Fix ratis-shell can't work in branch-2

### DIFF
--- a/ratis-shell/pom.xml
+++ b/ratis-shell/pom.xml
@@ -34,6 +34,11 @@
       <groupId>org.apache.ratis</groupId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <artifactId>ratis-metrics</artifactId>
+      <groupId>org.apache.ratis</groupId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/RATIS-1736
