### PR TITLE
RATIS-1748. Cache getMetricName to reduce garbage

### DIFF
--- a/ratis-metrics-default/src/main/java/org/apache/ratis/metrics/impl/RatisMetricRegistryImpl.java
+++ b/ratis-metrics-default/src/main/java/org/apache/ratis/metrics/impl/RatisMetricRegistryImpl.java
@@ -34,6 +34,7 @@ import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesti
 import java.util.Map;
 import java.util.Objects;
 import java.util.SortedMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 /**
@@ -51,6 +52,7 @@ public class RatisMetricRegistryImpl implements RatisMetricRegistry {
 
   private final MetricRegistryInfo info;
   private final String namePrefix;
+  private final Map<String, String> metricNameCache = new ConcurrentHashMap<>();
 
   private JmxReporter jmxReporter;
   private ConsoleReporter consoleReporter;
@@ -113,7 +115,7 @@ public class RatisMetricRegistryImpl implements RatisMetricRegistry {
   }
 
   private String getMetricName(String shortName) {
-    return MetricRegistry.name(namePrefix, shortName);
+    return metricNameCache.computeIfAbsent(shortName, key -> MetricRegistry.name(namePrefix, shortName));
   }
 
   private <T extends Metric> T register(String name, T metric) throws IllegalArgumentException {

--- a/ratis-metrics-dropwizard3/src/main/java/org/apache/ratis/metrics/dropwizard3/Dm3RatisMetricRegistryImpl.java
+++ b/ratis-metrics-dropwizard3/src/main/java/org/apache/ratis/metrics/dropwizard3/Dm3RatisMetricRegistryImpl.java
@@ -29,11 +29,13 @@ import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
 import com.codahale.metrics.JmxReporter;
+
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 import java.util.Map;
 import java.util.Objects;
 import java.util.SortedMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 /**
@@ -51,6 +53,7 @@ public class Dm3RatisMetricRegistryImpl implements RatisMetricRegistry {
 
   private final MetricRegistryInfo info;
   private final String namePrefix;
+  private final Map<String, String> metricNameCache = new ConcurrentHashMap<>();
 
   private JmxReporter jmxReporter;
   private ConsoleReporter consoleReporter;
@@ -113,7 +116,7 @@ public class Dm3RatisMetricRegistryImpl implements RatisMetricRegistry {
   }
 
   private String getMetricName(String shortName) {
-    return MetricRegistry.name(namePrefix, shortName);
+    return metricNameCache.computeIfAbsent(shortName, key -> MetricRegistry.name(namePrefix, shortName));
   }
 
   private <T extends Metric> T register(String name, T metric) throws IllegalArgumentException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

- reduce unnecessary object allocations to reduce memory and garbage collection pressure

## What is the link to the Apache JIRA

- https://issues.apache.org/jira/browse/RATIS-1748

## How was this patch tested?

Existing tests cover this