### PR TITLE
RATIS-1752. Clean md5 file created by old ratis version.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/FileUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/FileUtils.java
@@ -143,13 +143,29 @@ public interface FileUtils {
     deleteFully(source);
   }
 
-  /** The same as passing f.toPath() to {@link #delete(Path)}. */
+  /**
+   * The same as passing f.toPath() to {@link #deletePathQuietly(Path)}.
+   *
+   * @param f file to delete
+   * @return true if the file is successfully deleted false otherwise
+   */
   static boolean deleteFileQuietly(File f) {
+    return deletePathQuietly(f.toPath());
+  }
+
+  /**
+   * Delete the given path quietly.
+   * Only print a debug message in case that there is an exception,
+   *
+   * @param p path to delete
+   * @return true if the path is successfully deleted false otherwise
+   */
+  static boolean deletePathQuietly(Path p) {
     try {
-      delete(f.toPath());
+      delete(p);
       return true;
     } catch (Exception ex) {
-      LOG.debug("File delete was not successful {}", f.getAbsoluteFile(), ex);
+      LOG.debug("Failed to delete " + p.toAbsolutePath(), ex);
       return false;
     }
   }

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/SimpleStateMachineStorage.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/SimpleStateMachineStorage.java
@@ -124,20 +124,20 @@ public class SimpleStateMachineStorage implements StateMachineStorage {
           .map(FileInfo::getPath)
           .forEach(snapshotPath -> {
             LOG.info("Deleting old snapshot at {}", snapshotPath.toAbsolutePath());
-            final boolean deleted = FileUtils.deletePathQuietly(snapshotPath);
-            if (deleted) {
-              final File md5file = MD5FileUtil.getDigestFileForFile(snapshotPath.toFile());
-              FileUtils.deleteFileQuietly(md5file);
-            }
+            FileUtils.deletePathQuietly(snapshotPath);
           });
       // clean up the md5 files if the corresponding snapshot file does not exist
       try (DirectoryStream<Path> stream = Files.newDirectoryStream(stateMachineDir.toPath(),
           SNAPSHOT_MD5_FILTER)) {
         for (Path md5path : stream) {
-          final String md5file = md5path.getFileName().toString();
-          final File snapshotFile = new File(md5path.getParent().toFile(),
-              md5file.substring(0, md5file.length() - MD5_SUFFIX.length()));
-          if (!snapshotFile.exists()){
+          Path md5FileNamePath = md5path.getFileName();
+          if (md5FileNamePath == null) {
+            continue;
+          }
+          final String md5FileName = md5FileNamePath.toString();
+          final File snapshotFile = new File(stateMachineDir,
+              md5FileName.substring(0, md5FileName.length() - MD5_SUFFIX.length()));
+          if (!snapshotFile.exists()) {
             FileUtils.deletePathQuietly(md5path);
           }
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Clean md5 file created by old ratis version

## What is the link to the Apache JIRA

[RATIS-1752](https://issues.apache.org/jira/browse/RATIS-1752)

## How was this patch tested?

Check if old MD5 file can be deleted correctly.
