### PR TITLE
RATIS-1754. Set leader to null when stepping down

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -534,6 +534,7 @@ class RaftServerImpl implements RaftServer.Division,
       setRole(RaftPeerRole.FOLLOWER, reason);
       if (old == RaftPeerRole.LEADER) {
         role.shutdownLeaderState(false);
+        state.setLeader(null, reason);
       } else if (old == RaftPeerRole.CANDIDATE) {
         role.shutdownLeaderElection();
       } else if (old == RaftPeerRole.FOLLOWER) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
ServerState.getLeaderId() still returns itself when a leader just steps down. This PR proposes to update leader to null when stepping down.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1754
