### PR TITLE
RATIS-1744. NullPointerException causes RaftClient retry failure.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -923,7 +923,7 @@ class RaftServerImpl implements RaftServer.Division,
   private CompletableFuture<ReadIndexReplyProto> sendReadIndexAsync() {
     final RaftPeerId leaderId = getInfo().getLeaderId();
     if (leaderId == null) {
-      return JavaUtils.completeExceptionally(generateNotLeaderException());
+      return JavaUtils.completeExceptionally(new ReadIndexException(getMemberId() + ": Leader is unknown."));
     }
     final ReadIndexRequestProto request = ServerProtoUtils.toReadIndexRequestProto(getMemberId(), leaderId);
     try {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -921,11 +921,11 @@ class RaftServerImpl implements RaftServer.Division,
   }
 
   private CompletableFuture<ReadIndexReplyProto> sendReadIndexAsync() {
-    if (getInfo().getLeaderId() == null) {
-      JavaUtils.completeExceptionally(generateNotLeaderException());
+    final RaftPeerId leaderId = getInfo().getLeaderId();
+    if (leaderId == null) {
+      return JavaUtils.completeExceptionally(generateNotLeaderException());
     }
-    final ReadIndexRequestProto request = ServerProtoUtils.toReadIndexRequestProto(
-        getMemberId(),  getInfo().getLeaderId());
+    final ReadIndexRequestProto request = ServerProtoUtils.toReadIndexRequestProto(getMemberId(), leaderId);
     try {
       return getServerRpc().async().readIndexAsync(request);
     } catch (IOException e) {


### PR DESCRIPTION
```java
//RaftServerImpl
  private CompletableFuture<ReadIndexReplyProto> sendReadIndexAsync() {
    if (getInfo().getLeaderId() == null) {
      JavaUtils.completeExceptionally(generateNotLeaderException());
    }
    final ReadIndexRequestProto request = ServerProtoUtils.toReadIndexRequestProto(
        getMemberId(),  getInfo().getLeaderId());
    try {
      return getServerRpc().async().readIndexAsync(request);
    } catch (IOException e) {
      return JavaUtils.completeExceptionally(e);
    }
  }
```
- The first `JavaUtils.completeExceptionally` was not returned
- When the first `getInfo().getLeaderId()` returns non-null, the second `getInfo().getLeaderId()` may return null.

Due to the bugs above, `ReadOnlyRequestTests.testLinearizableReadTimeout()` may fail with NPE; see https://github.com/apache/ratis/actions/runs/3581261971/jobs/6024132981#step:5:534

See https://issues.apache.org/jira/browse/RATIS-1744