### PR TITLE
RATIS-1756. Consistent usage of gapThreshold in getMajorityMin

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -808,7 +808,7 @@ class LeaderStateImpl implements LeaderState {
       }
 
       final long[] indicesInOldConf = getSorted(oldFollowers, includeSelfInOldConf, followerIndex, logIndex);
-      final MinMajorityMax oldConf = MinMajorityMax.valueOf(indicesInOldConf, followerMaxGapThreshold);
+      final MinMajorityMax oldConf = MinMajorityMax.valueOf(indicesInOldConf, gapThreshold);
       return Optional.of(newConf.combine(oldConf));
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Seems the usage of gapThreshold is not consistent in getMajorityMin.

This ticket is to fix the issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1756

## How was this patch tested?

no test.
