### PR TITLE
RATIS-1758. Add linearizable read in Counter example

### DIFF
--- a/ratis-examples/README.md
+++ b/ratis-examples/README.md
@@ -134,10 +134,10 @@ result which should be the value of the counter.
 You can find more detail by reading these classes javaDocs.
 
 ### Run Counter Server and Client
-run the client and servers by these commands from ratis-examples directory:
-for server: `java -cp target/*.jar org.apache.ratis.examples.counter.server.CounterServer {serverIndex}`
-replace {serverIndex} with 1, 2, or 3
-for client: `java -cp target/*.jar org.apache.ratis.examples.counter.client.CounterClient`
+run the client and servers by these commands from ratis directory:
+for server: `java -cp ./ratis-examples/target/*.jar org.apache.ratis.examples.counter.server.CounterServer {serverIndex}`
+replace {serverIndex} with 0, 1, or 2
+for client: `java -cp ./ratis-examples/target/*.jar org.apache.ratis.examples.counter.client.CounterClient`
 
 ## Pre-Setup Vagrant Pseudo Cluster
 Note: This option is only available to Example 1 and 2

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/counter/server/CounterStateMachine.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/counter/server/CounterStateMachine.java
@@ -34,6 +34,7 @@ import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.MD5FileUtil;
+import org.apache.ratis.util.TimeDuration;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -79,6 +80,12 @@ public class CounterStateMachine extends BaseStateMachine {
   private final SimpleStateMachineStorage storage = new SimpleStateMachineStorage();
   private final AtomicInteger counter = new AtomicInteger(0);
 
+  private final TimeDuration simulatedSlowness;
+
+  CounterStateMachine(TimeDuration simulatedSlowness) {
+    this.simulatedSlowness = simulatedSlowness;
+  }
+
   /** @return the current state. */
   private synchronized CounterState getState() {
     return new CounterState(getLastAppliedTermIndex(), counter.get());
@@ -90,6 +97,14 @@ public class CounterStateMachine extends BaseStateMachine {
   }
 
   private synchronized int incrementCounter(TermIndex termIndex) {
+    try {
+      if (!simulatedSlowness.equals(TimeDuration.ZERO)) {
+        simulatedSlowness.sleep();
+      }
+    } catch (InterruptedException e) {
+      LOG.warn("{}: get interrupted in simulated slowness sleep before apply transaction", this);
+      Thread.currentThread().interrupt();
+    }
     updateLastAppliedTermIndex(termIndex);
     return counter.incrementAndGet();
   }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/counter/server/CounterStateMachine.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/counter/server/CounterStateMachine.java
@@ -85,6 +85,9 @@ public class CounterStateMachine extends BaseStateMachine {
   CounterStateMachine(TimeDuration simulatedSlowness) {
     this.simulatedSlowness = simulatedSlowness;
   }
+  CounterStateMachine() {
+    this.simulatedSlowness = TimeDuration.ZERO;
+  }
 
   /** @return the current state. */
   private synchronized CounterState getState() {

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/debug/server/Server.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/debug/server/Server.java
@@ -21,6 +21,7 @@ package org.apache.ratis.examples.debug.server;
 import org.apache.ratis.examples.common.Constants;
 import org.apache.ratis.examples.counter.server.CounterServer;
 import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.util.TimeDuration;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,7 +46,7 @@ public final class Server {
         .findFirst().orElseThrow(() -> new IllegalArgumentException("Peer not found: " + args[0]));
 
     final File storageDir = new File(Constants.PATH, currentPeer.getId().toString());
-    final CounterServer counterServer = new CounterServer(currentPeer, storageDir);
+    final CounterServer counterServer = new CounterServer(currentPeer, storageDir, TimeDuration.ZERO);
     counterServer.start();
   }
 }

--- a/ratis-examples/src/main/resources/conf.properties
+++ b/ratis-examples/src/main/resources/conf.properties
@@ -16,3 +16,5 @@
 
 raft.server.address.list=127.0.0.1:10024,127.0.0.1:10124,127.0.0.1:11124
 # raft.server.root.storage.path
+# raft.server.priority.list=1,0,0
+# raft.server.simulated-slowness.list=0,1s,0


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add linearizable read usage in Counter example.
Also fixed some problems in ratis-examples/README

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1758

## How was this patch tested?

manual test.
![WX20221208-170241](https://user-images.githubusercontent.com/48054931/206407663-415baba0-ade7-45bf-8010-5496afd1f9a3.png)

