### PR TITLE
RATIS-1761. If LeaderStateImpl is not running, it should not restart a LogAppender.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/OpenCloseState.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/OpenCloseState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -60,7 +60,7 @@ public class OpenCloseState {
     final Throwable t = state.get();
     if (!(t instanceof OpenTrace)) {
       final String s = name + " is expected to be opened but it is " + toString(t);
-      throw new IllegalArgumentException(s, t);
+      throw new IllegalStateException(s, t);
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -395,6 +395,7 @@ class LeaderStateImpl implements LeaderState {
 
   void stop() {
     if (!isStopped.compareAndSet(false, true)) {
+      LOG.info("{} is already stopped", this);
       return;
     }
     // do not interrupt event processor since it may be in the middle of logSync
@@ -610,6 +611,7 @@ class LeaderStateImpl implements LeaderState {
   @Override
   public void restart(LogAppender sender) {
     if (!isRunning()) {
+      LOG.warn("Failed to restart {}: {} is not running", sender, this);
       return;
     }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -78,6 +78,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
 import java.util.function.Predicate;
@@ -164,7 +165,7 @@ class LeaderStateImpl implements LeaderState {
       } catch (InterruptedException ie) {
         Thread.currentThread().interrupt();
         String s = this + ": poll() is interrupted";
-        if (!running) {
+        if (isStopped.get()) {
           LOG.info(s + " gracefully");
           return null;
         } else {
@@ -318,7 +319,7 @@ class LeaderStateImpl implements LeaderState {
   private final PendingRequests pendingRequests;
   private final WatchRequests watchRequests;
   private final MessageStreamRequests messageStreamRequests;
-  private volatile boolean running = true;
+  private final AtomicBoolean isStopped = new AtomicBoolean();
 
   private final int stagingCatchupGap;
   private final long placeHolderIndex;
@@ -393,7 +394,9 @@ class LeaderStateImpl implements LeaderState {
   }
 
   void stop() {
-    this.running = false;
+    if (!isStopped.compareAndSet(false, true)) {
+      return;
+    }
     // do not interrupt event processor since it may be in the middle of logSync
     senders.forEach(LogAppender::stop);
     final NotLeaderException nle = server.generateNotLeaderException();
@@ -440,7 +443,8 @@ class LeaderStateImpl implements LeaderState {
    */
   PendingRequest startSetConfiguration(SetConfigurationRequest request, List<RaftPeer> peersInNewConf) {
     LOG.info("{}: startSetConfiguration {}", this, request);
-    Preconditions.assertTrue(running && !inStagingState());
+    Preconditions.assertTrue(isRunning(), () -> this + " is not running.");
+    Preconditions.assertTrue(!inStagingState(), () -> this + " is already in staging state " + stagingState);
 
     final List<RaftPeer> listenersInNewConf = request.getArguments().getPeersInNewConf(RaftPeerRole.LISTENER);
     final Collection<RaftPeer> peersToBootStrap = server.getRaftConf().filterNotContainedInConf(peersInNewConf);
@@ -595,8 +599,20 @@ class LeaderStateImpl implements LeaderState {
     senders.removeAll(toStop);
   }
 
+  boolean isRunning() {
+    if (isStopped.get()) {
+      return false;
+    }
+    final LeaderStateImpl current = server.getRole().getLeaderState().orElse(null);
+    return this == current;
+  }
+
   @Override
   public void restart(LogAppender sender) {
+    if (!isRunning()) {
+      return;
+    }
+
     final FollowerInfo info = sender.getFollower();
     LOG.info("{}: Restarting {} for {}", this, JavaUtils.getClassSimpleName(sender.getClass()), info.getName());
     sender.stop();
@@ -633,7 +649,7 @@ class LeaderStateImpl implements LeaderState {
       LOG.warn(s, e);
       // the failure should happen while changing the state to follower
       // thus the in-memory state should have been updated
-      if (running) {
+      if (!isStopped.get()) {
         throw new IllegalStateException(s + " and running == true", e);
       }
     }
@@ -669,7 +685,7 @@ class LeaderStateImpl implements LeaderState {
 
   private void prepare() {
     synchronized (server) {
-      if (running) {
+      if (isRunning()) {
         final ServerState state = server.getState();
         if (state.getRaftConf().isTransitional() && state.isConfCommitted()) {
           // the configuration is in transitional state, and has been committed
@@ -694,10 +710,10 @@ class LeaderStateImpl implements LeaderState {
       // apply an empty message; check if necessary to replicate (new) conf
       prepare();
 
-      while (running) {
+      while (isRunning()) {
         final StateUpdateEvent event = eventQueue.poll();
         synchronized(server) {
-          if (running) {
+          if (isRunning()) {
             if (event != null) {
               event.execute();
             } else if (inStagingState()) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
@@ -127,6 +127,7 @@ public abstract class LogAppenderBase implements LogAppender {
 
   void restart() {
     if (!server.getInfo().isAlive()) {
+      LOG.warn("Failed to restart {}: server {} is not alive", this, server.getMemberId());
       return;
     }
     getLeaderState().restart(this);

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
@@ -125,6 +125,13 @@ public abstract class LogAppenderBase implements LogAppender {
     daemon.tryToClose();
   }
 
+  void restart() {
+    if (!server.getInfo().isAlive()) {
+      return;
+    }
+    getLeaderState().restart(this);
+  }
+
   @Override
   public final FollowerInfo getFollower() {
     return follower;

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDaemon.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDaemon.java
@@ -42,9 +42,9 @@ class LogAppenderDaemon {
   private final LifeCycle lifeCycle;
   private final Daemon daemon;
 
-  private final LogAppender logAppender;
+  private final LogAppenderBase logAppender;
 
-  LogAppenderDaemon(LogAppender logAppender) {
+  LogAppenderDaemon(LogAppenderBase logAppender) {
     this.logAppender = logAppender;
     this.name = logAppender + "-" + JavaUtils.getClassSimpleName(getClass());
     this.lifeCycle = new LifeCycle(name);
@@ -88,7 +88,7 @@ class LogAppenderDaemon {
       lifeCycle.transitionIfValid(EXCEPTION);
     } finally {
       if (lifeCycle.transitionAndGet(TRANSITION_FINALLY) == EXCEPTION) {
-        logAppender.getLeaderState().restart(logAppender);
+        logAppender.restart();
       }
     }
   }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1761