### PR TITLE
RATIS-1763. Purging logs in an ordered manner

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -318,8 +318,8 @@ public class SegmentedRaftLogCache {
           // to purge that.
           int startIndex = (overlappedSegment.getEndIndex() == index) ?
               segmentIndex : segmentIndex - 1;
-          for (int i = startIndex; i >= 0; i--) {
-            LogSegment segment = segments.remove(i);
+          for (int i = 0; i <= startIndex; i++) {
+            LogSegment segment = segments.remove(0); // must remove the first segment to avoid gaps.
             sizeInBytes -= segment.getTotalFileSize();
             list.add(SegmentFileInfo.newClosedSegmentFileInfo(segment));
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We encountered `IllegalStateException` indicating a LogSegment missing as follows:
```java
java.lang.IllegalStateException Found a gap between logs: the last log segment log-88826_88927 ended at 88927 but the next log segment log-89130_89071 started at 89130.
	at org.apache.ratis.util.Preconditions.assertTrue(Preconditions.java:72)
	at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogCache.validateAdding(SegmentedRaftLogCache.java:421)
	at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogCache.addSegment(SegmentedRaftLogCache.java:428)
	at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogCache.loadSegment(SegmentedRaftLogCache.java:381)
	at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLog.loadLogSegments(SegmentedRaftLog.java:241)
	at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLog.openImpl(SegmentedRaftLog.java:214)
	at org.apache.ratis.server.raftlog.RaftLogBase.open(RaftLogBase.java:251)
	at org.apache.ratis.server.impl.ServerState.initRaftLog(ServerState.java:236)
	at org.apache.ratis.server.impl.ServerState.initRaftLog(ServerState.java:217)
	at org.apache.ratis.server.impl.ServerState.lambda$new$5(ServerState.java:160)
	at org.apache.ratis.util.MemoizedSupplier.get(MemoizedSupplier.java:62)
	at org.apache.ratis.server.impl.ServerState.initialize(ServerState.java:174)
	at org.apache.ratis.server.impl.RaftServerImpl.start(RaftServerImpl.java:330)
```
There were no manual operations involved with RaftLog. The RaftLog is manipulated purely by Ratis code.
After careful investigation, we suspected that this is a bug triggered by **inappropriate log purging order**.

### Cause
1. Current implementation picks the logs to purge in a reversed order, see [here](https://github.com/apache/ratis/blob/2b1b1b57f01dd629147ea1c956721520761e9126/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java#L321). 
2. The purge task is executed asynchronously following the reversed order, one segment by one segment, see [here](https://github.com/apache/ratis/blob/2b1b1b57f01dd629147ea1c956721520761e9126/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java#L472). 
3. Say, if logs 0-8000 are selected to be purged by `StateMachineUpdater`, in the meanwhile there are more logs 8001-8010 being appended to RaftLog by `RaftLogWorker`. If we interrupt in the middle of the `PurgeLog` task and close RaftServer, there will be unfinished logs left to be purged, 1-4000 as a example. This will lead to a gap between logs(4000-8000 in this case), exactly as the exception stack indicates.

### Proposed solution
There seems to be no obligations to enforce a reversed order. So I change it to the normal order.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1763

## How was this patch tested?
unit tests

