### PR TITLE
RATIS-1765. [GrpcLogAppender] Calculate streaming md5 file-wise when installSnapshot

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/FileChunkReader.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/FileChunkReader.java
@@ -73,14 +73,20 @@ public class FileChunkReader implements Closeable {
     final long remaining = info.getFileSize() - offset;
     final int chunkLength = remaining < chunkMaxSize ? (int) remaining : chunkMaxSize;
     final ByteString data = ByteString.readFrom(in, chunkLength);
-    final ByteString fileDigest = ByteString.copyFrom(
-            digester != null? digester.digest(): info.getFileDigest().getDigest());
+    final boolean isDone = offset + chunkLength == info.getFileSize();
+    final ByteString fileDigest;
+    if (digester != null) {
+      // file digest is calculated once and shipped with last FileChunkProto
+      fileDigest = isDone ? ByteString.copyFrom(digester.digest()) : ByteString.EMPTY;
+    } else {
+      fileDigest = ByteString.copyFrom(info.getFileDigest().getDigest());
+    }
 
     final FileChunkProto proto = FileChunkProto.newBuilder()
         .setFilename(relativePath.toString())
         .setOffset(offset)
         .setChunkIndex(chunkIndex)
-        .setDone(offset + chunkLength == info.getFileSize())
+        .setDone(isDone)
         .setData(data)
         .setFileDigest(fileDigest)
         .build();

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/FileChunkReader.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/FileChunkReader.java
@@ -73,10 +73,11 @@ public class FileChunkReader implements Closeable {
     final long remaining = info.getFileSize() - offset;
     final int chunkLength = remaining < chunkMaxSize ? (int) remaining : chunkMaxSize;
     final ByteString data = ByteString.readFrom(in, chunkLength);
+    // whether this chunk is the last chunk of current file
     final boolean isDone = offset + chunkLength == info.getFileSize();
     final ByteString fileDigest;
     if (digester != null) {
-      // file digest is calculated once and shipped with last FileChunkProto
+      // file digest is calculated once in the end and shipped with last FileChunkProto
       fileDigest = isDone ? ByteString.copyFrom(digester.digest()) : ByteString.EMPTY;
     } else {
       fileDigest = ByteString.copyFrom(info.getFileDigest().getDigest());

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
@@ -66,7 +66,7 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
     RaftServerConfigKeys.Snapshot.setAutoTriggerThreshold(
         prop, SNAPSHOT_TRIGGER_THRESHOLD);
     RaftServerConfigKeys.Snapshot.setAutoTriggerEnabled(prop, true);
-    RaftServerConfigKeys.Log.Appender.setSnapshotChunkSizeMax(prop, SizeInBytes.ONE_MB);
+    RaftServerConfigKeys.Log.Appender.setSnapshotChunkSizeMax(prop, SizeInBytes.ONE_KB);
   }
 
   private static final int SNAPSHOT_TRIGGER_THRESHOLD = 64;
@@ -171,9 +171,7 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
           final byte[] data = new byte[4096];
           Arrays.fill(data, (byte)0x01);
           try (FileOutputStream fout = new FileOutputStream(file2)) {
-            for (int i = 0; i < 1024; i++) {
               fout.write(data);
-            }
           }
         }
 

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
@@ -117,7 +117,9 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
       // Check the installed snapshot file number on each Follower matches with the
       // leader snapshot.
       for (RaftServer.Division follower : cluster.getFollowers()) {
-        Assert.assertEquals(3, follower.getStateMachine().getLatestSnapshot().getFiles().size());
+        final SnapshotInfo info = follower.getStateMachine().getLatestSnapshot();
+        Assert.assertNotNull(info);
+        Assert.assertEquals(3, info.getFiles().size());
       }
     } finally {
       cluster.shutdown();

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
@@ -37,12 +37,14 @@ import org.apache.ratis.statemachine.impl.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.LifeCycle;
+import org.apache.ratis.util.SizeInBytes;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -64,6 +66,7 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
     RaftServerConfigKeys.Snapshot.setAutoTriggerThreshold(
         prop, SNAPSHOT_TRIGGER_THRESHOLD);
     RaftServerConfigKeys.Snapshot.setAutoTriggerEnabled(prop, true);
+    RaftServerConfigKeys.Log.Appender.setSnapshotChunkSizeMax(prop, SizeInBytes.ONE_MB);
   }
 
   private static final int SNAPSHOT_TRIGGER_THRESHOLD = 64;
@@ -162,6 +165,14 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
           FileUtils.createDirectories(file2.getParentFile());
           FileUtils.createNewFile(file1.toPath());
           FileUtils.createNewFile(file2.toPath());
+          // write 4MB data to simulate multiple chunk scene
+          final byte[] data = new byte[4096];
+          Arrays.fill(data, (byte)0x01);
+          try (FileOutputStream fout = new FileOutputStream(file2)) {
+            for (int i = 0; i < 1024; i++) {
+              fout.write(data);
+            }
+          }
         }
 
       } catch (IOException ioException) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Stream MD5 is introduced  by https://github.com/apache/ratis/commit/db3623a22e39a7957d9985fc9fe6784fe977f070 to reduce duplicate IO costs. However, current implementation calculates MD5 chunk-wise instead of file-wise.
We should calculate MD5 once per file, instead of many times per chunk.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1765

## How was this patch tested?

1. unit tests.
2. new unit tests.
