### PR TITLE
RATIS-1767. Initialize MatchIndex to RaftLog.INVALID_LOG_INDEX

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -37,7 +37,7 @@ class FollowerInfoImpl implements FollowerInfo {
   private final AtomicReference<Timestamp> lastRpcSendTime;
   private final AtomicReference<Timestamp> lastHeartbeatSendTime;
   private final RaftLogIndex nextIndex;
-  private final RaftLogIndex matchIndex = new RaftLogIndex("matchIndex", 0L);
+  private final RaftLogIndex matchIndex = new RaftLogIndex("matchIndex", RaftLog.INVALID_LOG_INDEX);
   private final RaftLogIndex commitIndex = new RaftLogIndex("commitIndex", RaftLog.INVALID_LOG_INDEX);
   private final RaftLogIndex snapshotIndex = new RaftLogIndex("snapshotIndex", 0L);
   private volatile boolean attendVote;


### PR DESCRIPTION
I noticed that matchIndex in leaderStateImpl in initialized with value and I think it is incorrect. 
https://github.com/apache/ratis/blob/d45dccc09c34d9dc51c52c6b14b468b2641692c2/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java#L40

As the Raft Paper[2] states, matchIndex is 'for each server, index of highest log entry known to be replicated on server’.
[2] https://raft.github.io/raft.pdf 

0 is considered to be a valid Raft Log index in Ratis, and if we initialize matchIndex to 0, the very first log entry will become committed as soon as it is flushed into leader’s LogSegment, instead of after receiving majority ack responses.

This incorrectly initialized matchIndex is **causing permanent Inconsistency problem in our CI environment**, see https://github.com/apache/iotdb/actions/runs/3874495006.
The problematic event sequence is as follows: A raft group of 3 members 1/2/3
1. Member 1 becomes the leader.
2. Leader 1 initializes the state, writes the first log (index=0) as an configuration entry.
3. This entry is mistakenly committed and be applied to Leader 1's StateMachine due to incorrect matchIndex.
4. Before 1 could appendEntries to 2/3, 2 & 3 both timeout and started election.
5. 2‘s requestVote has a higher term and forces Leader 1 down.
6. 2 becomes the new Leader, also writing the first log (index = 0) as an configuration entry.
7. Inconsistent appendEntries occurred when 2 tries to sync log to 1. And the group cannot automatically recover from this inconsistency.



