### PR TITLE
RATIS-1770. Yield leader to higher priority peer by TransferLeadership

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
@@ -172,7 +172,7 @@ final class RaftConfigurationImpl implements RaftConfiguration {
     }
     Collection<RaftPeer> peers = getCurrentPeers();
     for (RaftPeer peer : peers) {
-      if (peer.getPriority() >= target.getPriority() && !peer.equals(target)) {
+      if (peer.getPriority() > target.getPriority() && !peer.equals(target)) {
         return false;
       }
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -317,6 +317,10 @@ class RaftServerImpl implements RaftServer.Division,
     return proxy;
   }
 
+  TransferLeadership getTransferLeadership() {
+    return transferLeadership;
+  }
+
   RaftServerRpc getServerRpc() {
     return proxy.getServerRpc();
   }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -185,12 +185,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         Assert.assertEquals(followers.size(), 2);
         RaftServer.Division newLeader = followers.get(0);
 
-        List<RaftPeer> peers = cluster.getPeers();
-        List<RaftPeer> peersWithNewPriority = getPeersWithPriority(peers, newLeader.getPeer());
-        RaftClientReply reply = client.admin().setConfiguration(peersWithNewPriority.toArray(new RaftPeer[0]));
-        Assert.assertTrue(reply.isSuccess());
-
-        reply = client.admin().transferLeadership(newLeader.getId(), 20000);
+        RaftClientReply reply = client.admin().transferLeadership(newLeader.getId(), 20000);
         assertTrue(reply.isSuccess());
 
         final RaftServer.Division currLeader = waitForLeader(cluster);
@@ -220,9 +215,6 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         isolate(cluster, newLeader.getId());
 
         List<RaftPeer> peers = cluster.getPeers();
-        List<RaftPeer> peersWithNewPriority = getPeersWithPriority(peers, newLeader.getPeer());
-        RaftClientReply reply = client.admin().setConfiguration(peersWithNewPriority.toArray(new RaftPeer[0]));
-        Assert.assertTrue(reply.isSuccess());
 
         CompletableFuture<Boolean> transferTimeoutFuture = CompletableFuture.supplyAsync(() -> {
           try {
@@ -256,7 +248,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         Assert.assertTrue(transferTimeoutFuture.get());
 
         // after transfer timeout, leader should accept request
-        reply = client.io().send(new RaftTestUtil.SimpleMessage("message"));
+        RaftClientReply reply = client.io().send(new RaftTestUtil.SimpleMessage("message"));
         Assert.assertTrue(reply.getReplierId().equals(leader.getId().toString()));
         Assert.assertTrue(reply.isSuccess());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Followup [RATIS-1762](https://issues.apache.org/jira/browse/RATIS-1762). Use the new TransferLeadership to yield leadership to higher priority peer.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1770

## How was this patch tested?

LeaderElectionTests#testYieldLeaderToHigherPriority()
