### PR TITLE
RATIS-1776. Switch to slf4j-reload4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
     <testsThreadCount>4</testsThreadCount>
 
     <bouncycastle.version>1.70</bouncycastle.version>
+    <slf4j.version>1.7.36</slf4j.version>
   </properties>
 
   <dependencyManagement>
@@ -400,18 +401,18 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.29</version>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
-        <version>1.7.29</version>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
+        <artifactId>slf4j-reload4j</artifactId>
         <scope>test</scope>
-        <version>1.7.29</version>
+        <version>${slf4j.version}</version>
       </dependency>
 
       <dependency>

--- a/ratis-examples/pom.xml
+++ b/ratis-examples/pom.xml
@@ -108,7 +108,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/ratis-experiments/pom.xml
+++ b/ratis-experiments/pom.xml
@@ -39,8 +39,8 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>compile</scope>
+      <artifactId>slf4j-reload4j</artifactId>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 

--- a/ratis-resource-bundle/src/main/resources/supplemental-models.xml
+++ b/ratis-resource-bundle/src/main/resources/supplemental-models.xml
@@ -284,8 +284,8 @@ under the License.
   <supplement>
     <project>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <name>SLF4J LOG4J-12 Binding</name>
+      <artifactId>slf4j-reload4j</artifactId>
+      <name>SLF4J Reload4j Binding</name>
 
       <licenses>
         <license>
@@ -293,7 +293,7 @@ under the License.
           <url>http://www.opensource.org/licenses/mit-license.php</url>
           <distribution>repo</distribution>
           <comments>
-            Copyright (c) 2004-2008 QOS.ch
+            Copyright (c) 2004-2017 QOS.ch
           </comments>
         </license>
       </licenses>

--- a/ratis-test/pom.xml
+++ b/ratis-test/pom.xml
@@ -116,7 +116,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Switch to `slf4j-reload4j` provider to avoid bundling `log4j` in Ratis distribution.

> The reload4j project is a fork of Apache log4j version 1.2.17 with the goal of fixing pressing security issues. It is intended as a drop-in replacement for log4j version 1.2.17. By drop-in, we mean the replacement of log4j.jar with reload4j.jar in your build with no source code changes in .java files being necessary.

https://issues.apache.org/jira/browse/RATIS-1776

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/incubator-ratis/actions/runs/3968298137/jobs/6801284615