### PR TITLE
RATIS-1784. Ignore .vscode in source repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ target
 build
 patchprocess
 dependency-reduced-pom.xml
+.vscode/


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ignore .vscode/ which is created by VSCode, a popular editor.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1784

## How was this patch tested?

Manually verified the directory no longer shows up in git status.
