### PR TITLE
RATIS-1791. Intermittent failure in ServerRestartTests#testRestartFollower

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
@@ -119,6 +119,8 @@ public abstract class ServerRestartTests<CLUSTER extends MiniRaftCluster>
     final RaftLog followerLog = follower.getRaftLog();
     final long followerLastIndex = followerLog.getLastEntryTermIndex().getIndex();
     Assert.assertTrue(followerLastIndex >= leaderLastIndex);
+    final long leaderFinalIndex = cluster.getLeader().getRaftLog().getLastEntryTermIndex().getIndex();
+    Assert.assertEquals(leaderFinalIndex, followerLastIndex);
 
     final File followerOpenLogFile = getOpenLogFile(follower);
     final File leaderOpenLogFile = getOpenLogFile(cluster.getDivision(leaderId));
@@ -132,7 +134,7 @@ public abstract class ServerRestartTests<CLUSTER extends MiniRaftCluster>
 
     // truncate log and
     assertTruncatedLog(followerId, followerOpenLogFile, followerLastIndex, cluster);
-    assertTruncatedLog(leaderId, leaderOpenLogFile, leaderLastIndex, cluster);
+    assertTruncatedLog(leaderId, leaderOpenLogFile, leaderFinalIndex, cluster);
 
     // restart and write something.
     cluster.restart(false);

--- a/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
@@ -124,9 +124,11 @@ public abstract class ServerRestartTests<CLUSTER extends MiniRaftCluster>
     final File leaderOpenLogFile = getOpenLogFile(cluster.getDivision(leaderId));
 
     // shutdown all servers
-    for(RaftServer s : cluster.getServers()) {
-      s.close();
+    // shutdown followers first, so there won't be any new leader elected
+    for (RaftServer.Division d : cluster.getFollowers()) {
+      d.close();
     }
+    cluster.getDivision(leaderId).close();
 
     // truncate log and
     assertTruncatedLog(followerId, followerOpenLogFile, followerLastIndex, cluster);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix flaky test ServerRestartTests#testRestartFollower.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1791

## How was this patch tested?

Repeat ServerRestartTests#testRestartFollower 100x in CI.

Before this patch, it fails very often:
https://github.com/kaijchen/ratis/actions/runs/4261054005

With ea73079ea24a39c7dc848152fc5dee8416744bcc only, 3/100 test failed:
https://github.com/kaijchen/ratis/actions/runs/4261055481

With both ea73079ea24a39c7dc848152fc5dee8416744bcc and 11c1c78d4a760f0aa344df33aec2ef34200abc8b, all tests passed:
https://github.com/kaijchen/ratis/actions/runs/4261057419