### PR TITLE
RATIS-1790. Reset deadline for each streaming installSnapshot message

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/DeadlineClientInterceptor.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/DeadlineClientInterceptor.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.grpc.client;
+
+import org.apache.ratis.thirdparty.io.grpc.CallOptions;
+import org.apache.ratis.thirdparty.io.grpc.Channel;
+import org.apache.ratis.thirdparty.io.grpc.ClientCall;
+import org.apache.ratis.thirdparty.io.grpc.ClientInterceptor;
+import org.apache.ratis.thirdparty.io.grpc.MethodDescriptor;
+import org.apache.ratis.util.TimeDuration;
+
+/**
+ * Intercepts the messages and reset corrects the deadline for streaming messages.
+ */
+public class DeadlineClientInterceptor implements ClientInterceptor {
+  private final TimeDuration timeout;
+  public DeadlineClientInterceptor(TimeDuration timeout) {
+    this.timeout = timeout;
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+    // reset the deadline
+    final CallOptions newCallOptions = callOptions.withDeadlineAfter(timeout.getDuration(), timeout.getUnit());
+    return next.newCall(method, newCallOptions);
+  }
+}

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/DeadlineClientInterceptor.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/DeadlineClientInterceptor.java
@@ -25,7 +25,7 @@ import org.apache.ratis.thirdparty.io.grpc.MethodDescriptor;
 import org.apache.ratis.util.TimeDuration;
 
 /**
- * Intercepts the messages and reset corrects the deadline for streaming messages.
+ * Intercepts the messages and resets the deadline for each streaming call.
  */
 public class DeadlineClientInterceptor implements ClientInterceptor {
   private final TimeDuration timeout;

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/DeadlineClientInterceptor.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/DeadlineClientInterceptor.java
@@ -38,7 +38,7 @@ import static org.apache.ratis.thirdparty.io.grpc.internal.GrpcUtil.TIMER_SERVIC
  */
 public class DeadlineClientInterceptor implements ClientInterceptor {
   private final TimeDuration timeout;
-  private static final ScheduledExecutorService Timer = SharedResourceHolder.get(TIMER_SERVICE);
+  private static final ScheduledExecutorService TIMER = SharedResourceHolder.get(TIMER_SERVICE);
   public DeadlineClientInterceptor(TimeDuration timeout) {
     this.timeout = timeout;
   }
@@ -55,7 +55,7 @@ public class DeadlineClientInterceptor implements ClientInterceptor {
 
     private CallWithDeadline(ClientCall<ReqT, RespT> delegate, TimeDuration timeout) {
       super(delegate);
-      timeoutFuture = Timer.schedule(() -> cancel("streaming call timeouts", null),
+      timeoutFuture = TIMER.schedule(() -> cancel("streaming call timeouts", null),
           timeout.getDuration(), timeout.getUnit());
     }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/DeadlineClientInterceptor.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/DeadlineClientInterceptor.java
@@ -15,20 +15,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.ratis.grpc.client;
+package org.apache.ratis.grpc.server;
 
 import org.apache.ratis.thirdparty.io.grpc.CallOptions;
 import org.apache.ratis.thirdparty.io.grpc.Channel;
 import org.apache.ratis.thirdparty.io.grpc.ClientCall;
 import org.apache.ratis.thirdparty.io.grpc.ClientInterceptor;
+import org.apache.ratis.thirdparty.io.grpc.ForwardingClientCall;
+import org.apache.ratis.thirdparty.io.grpc.ForwardingClientCallListener;
+import org.apache.ratis.thirdparty.io.grpc.Metadata;
 import org.apache.ratis.thirdparty.io.grpc.MethodDescriptor;
+import org.apache.ratis.thirdparty.io.grpc.internal.SharedResourceHolder;
 import org.apache.ratis.util.TimeDuration;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+
+import static org.apache.ratis.thirdparty.io.grpc.internal.GrpcUtil.TIMER_SERVICE;
 
 /**
  * Intercepts the messages and resets the deadline for each streaming call.
  */
 public class DeadlineClientInterceptor implements ClientInterceptor {
   private final TimeDuration timeout;
+  private static final ScheduledExecutorService Timer = SharedResourceHolder.get(TIMER_SERVICE);
   public DeadlineClientInterceptor(TimeDuration timeout) {
     this.timeout = timeout;
   }
@@ -36,8 +46,29 @@ public class DeadlineClientInterceptor implements ClientInterceptor {
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
       MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
-    // reset the deadline
-    final CallOptions newCallOptions = callOptions.withDeadlineAfter(timeout.getDuration(), timeout.getUnit());
-    return next.newCall(method, newCallOptions);
+    return new CallWithDeadline<>(next.newCall(method, callOptions), timeout);
+  }
+
+  private static final class CallWithDeadline<ReqT, RespT>
+    extends ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT> {
+    private final ScheduledFuture<?> timeoutFuture;
+
+    private CallWithDeadline(ClientCall<ReqT, RespT> delegate, TimeDuration timeout) {
+      super(delegate);
+      timeoutFuture = Timer.schedule(() -> cancel("streaming call timeouts", null),
+          timeout.getDuration(), timeout.getUnit());
+    }
+
+    @Override
+    public void start(Listener<RespT> responseListener, Metadata headers) {
+      super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(responseListener) {
+        @Override
+        public void onHeaders(Metadata headers) {
+          // on receiving response headers, we should cancel the deadline timer
+          timeoutFuture.cancel(false);
+          super.onHeaders(headers);
+        }
+      }, headers);
+    }
   }
 }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -19,7 +19,6 @@ package org.apache.ratis.grpc.server;
 
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.grpc.GrpcUtil;
-import org.apache.ratis.grpc.client.DeadlineClientInterceptor;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -19,17 +19,27 @@ package org.apache.ratis.grpc.server;
 
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.grpc.GrpcUtil;
+import org.apache.ratis.grpc.client.DeadlineClientInterceptor;
+import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
+import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
+import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
+import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
+import org.apache.ratis.proto.RaftProtos.ReadIndexReplyProto;
+import org.apache.ratis.proto.RaftProtos.ReadIndexRequestProto;
+import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
+import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionReplyProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionRequestProto;
+import org.apache.ratis.proto.grpc.RaftServerProtocolServiceGrpc;
+import org.apache.ratis.proto.grpc.RaftServerProtocolServiceGrpc.RaftServerProtocolServiceBlockingStub;
+import org.apache.ratis.proto.grpc.RaftServerProtocolServiceGrpc.RaftServerProtocolServiceStub;
+import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.thirdparty.io.grpc.ManagedChannel;
 import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;
 import org.apache.ratis.thirdparty.io.grpc.netty.NegotiationType;
 import org.apache.ratis.thirdparty.io.grpc.netty.NettyChannelBuilder;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
-import org.apache.ratis.proto.RaftProtos.*;
-import org.apache.ratis.proto.grpc.RaftServerProtocolServiceGrpc;
-import org.apache.ratis.proto.grpc.RaftServerProtocolServiceGrpc.RaftServerProtocolServiceBlockingStub;
-import org.apache.ratis.proto.grpc.RaftServerProtocolServiceGrpc.RaftServerProtocolServiceStub;
-import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
 import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
@@ -137,7 +147,7 @@ public class GrpcServerProtocolClient implements Closeable {
 
   StreamObserver<InstallSnapshotRequestProto> installSnapshot(
       StreamObserver<InstallSnapshotReplyProto> responseHandler) {
-    return asyncStub.withDeadlineAfter(requestTimeoutDuration.getDuration(), requestTimeoutDuration.getUnit())
+    return asyncStub.withInterceptors(new DeadlineClientInterceptor(requestTimeoutDuration))
         .installSnapshot(responseHandler);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
see https://issues.apache.org/jira/browse/RATIS-1790.
This PR attempts to refresh and reset the deadline for each installSnapshot streaming calls.

## How was this patch tested?
manual tests.
