### PR TITLE
RATIS-1792. Replace parallelStream usage in PeerProxyMap

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/PeerProxyMap.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/PeerProxyMap.java
@@ -165,8 +165,10 @@ public class PeerProxyMap<PROXY extends Closeable> implements RaftPeer.Add, Clos
 
   @Override
   public void close() {
-    peers.values().parallelStream().forEach(
-        pp -> pp.setNullProxyAndClose().ifPresent(proxy -> closeProxy(proxy, pp)));
+    ConcurrentUtils.parallelForEachAsync(peers.values(),
+        pp -> pp.setNullProxyAndClose().ifPresent(proxy -> closeProxy(proxy, pp)),
+        r -> new Thread(r).start()
+    );
   }
 
   private void closeProxy(PROXY proxy, PeerAndProxy pp) {

--- a/ratis-common/src/main/java/org/apache/ratis/util/PeerProxyMap.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/PeerProxyMap.java
@@ -168,7 +168,7 @@ public class PeerProxyMap<PROXY extends Closeable> implements RaftPeer.Add, Clos
     ConcurrentUtils.parallelForEachAsync(peers.values(),
         pp -> pp.setNullProxyAndClose().ifPresent(proxy -> closeProxy(proxy, pp)),
         r -> new Thread(r).start()
-    );
+    ).join();
   }
 
   private void closeProxy(PROXY proxy, PeerAndProxy pp) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace usage of `parallelStream` in `PeerProxyMap#close` with a per-task parallel forEach.

https://issues.apache.org/jira/browse/RATIS-1792

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/incubator-ratis/actions/runs/4264373621