### PR TITLE
RATIS-1621. Fix intermittent failure in TestLeaderElectionMetrics

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/server/metrics/TestLeaderElectionMetrics.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/metrics/TestLeaderElectionMetrics.java
@@ -52,7 +52,7 @@ public class TestLeaderElectionMetrics {
     leaderElectionMetrics.onNewLeaderElectionCompletion();
     Long leaderElectionLatency = (Long) ratisMetricRegistry.getGauges((s, metric) ->
         s.contains(LAST_LEADER_ELECTION_ELAPSED_TIME)).values().iterator().next().getValue();
-    assertTrue(leaderElectionLatency > 0L);
+    assertTrue(leaderElectionLatency >= 0L);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Backport RATIS-1621 to `branch-2`.

https://issues.apache.org/jira/browse/RATIS-1621

## How was this patch tested?

Ran locally:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.103 s - in org.apache.ratis.server.metrics.TestLeaderElectionMetrics
```

Full CI:
https://github.com/adoroszlai/incubator-ratis/actions/runs/4264785210