### PR TITLE
RATIS-1793. Enforce raft.server.log.appender.wait-time.min.

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
@@ -87,6 +87,9 @@ public interface FollowerInfo {
   /** @return the lastRpcResponseTime . */
   Timestamp getLastRpcResponseTime();
 
+  /** @return the lastRpcSendTime . */
+  Timestamp getLastRpcSendTime();
+
   /** Update lastRpcResponseTime to the current time. */
   void updateLastRpcResponseTime();
 

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -166,8 +166,8 @@ public interface LogAppender {
     return getFollower().getNextIndex() < getRaftLog().getNextIndex();
   }
 
-  /** send a heartbeat AppendEntries immediately */
-  void triggerHeartbeat() throws IOException;
+  /** Trigger to send a heartbeat AppendEntries. */
+  void triggerHeartbeat();
 
   /** @return the wait time in milliseconds to send the next heartbeat. */
   default long getHeartbeatWaitTimeMs() {

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/raftlog/RaftLogIndex.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/raftlog/RaftLogIndex.java
@@ -44,30 +44,44 @@ public class RaftLogIndex {
 
   public boolean setUnconditionally(long newIndex, Consumer<Object> log) {
     final long old = index.getAndSet(newIndex);
-    log.accept(StringUtils.stringSupplierAsObject(() -> name + ": setUnconditionally " + old + " -> " + newIndex));
-    return old != newIndex;
+    final boolean updated = old != newIndex;
+    if (updated) {
+      log.accept(StringUtils.stringSupplierAsObject(
+          () -> name + ": setUnconditionally " + old + " -> " + newIndex));
+    }
+    return updated;
   }
 
   public boolean updateUnconditionally(LongUnaryOperator update, Consumer<Object> log) {
     final long old = index.getAndUpdate(update);
     final long newIndex = update.applyAsLong(old);
-    log.accept(StringUtils.stringSupplierAsObject(() -> name + ": updateUnconditionally " + old + " -> " + newIndex));
-    return old != newIndex;
+    final boolean updated = old != newIndex;
+    if (updated) {
+      log.accept(StringUtils.stringSupplierAsObject(
+          () -> name + ": updateUnconditionally " + old + " -> " + newIndex));
+    }
+    return updated;
   }
 
   public boolean updateIncreasingly(long newIndex, Consumer<Object> log) {
     final long old = index.getAndSet(newIndex);
     Preconditions.assertTrue(old <= newIndex,
         () -> "Failed to updateIncreasingly for " + name + ": " + old + " -> " + newIndex);
-    log.accept(StringUtils.stringSupplierAsObject(() -> name + ": updateIncreasingly " + old + " -> " + newIndex));
-    return old != newIndex;
+    final boolean updated = old != newIndex;
+    if (updated) {
+      log.accept(StringUtils.stringSupplierAsObject(
+          () -> name + ": updateIncreasingly " + old + " -> " + newIndex));
+    }
+    return updated;
   }
 
   public boolean updateToMax(long newIndex, Consumer<Object> log) {
     final long old = index.getAndUpdate(oldIndex -> Math.max(oldIndex, newIndex));
     final boolean updated = old < newIndex;
-    log.accept(StringUtils.stringSupplierAsObject(
-        () -> name + ": updateToMax old=" + old + ", new=" + newIndex + ", updated? " + updated));
+    if (updated) {
+      log.accept(StringUtils.stringSupplierAsObject(
+          () -> name + ": updateToMax old=" + old + ", new=" + newIndex + ", updated? " + updated));
+    }
     return updated;
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -98,17 +98,20 @@ class FollowerInfoImpl implements FollowerInfo {
 
   @Override
   public void decreaseNextIndex(long newNextIndex) {
-    nextIndex.updateUnconditionally(old -> old <= 0L? old: Math.min(old - 1, newNextIndex), infoIndexChange);
+    nextIndex.updateUnconditionally(old -> old <= 0L? old: Math.min(old - 1, newNextIndex),
+        message -> infoIndexChange.accept("decreaseNextIndex " + message));
   }
 
   @Override
   public void setNextIndex(long newNextIndex) {
-    nextIndex.updateUnconditionally(old -> newNextIndex >= 0 ? newNextIndex : old, infoIndexChange);
+    nextIndex.updateUnconditionally(old -> newNextIndex >= 0 ? newNextIndex : old,
+        message -> infoIndexChange.accept("setNextIndex " + message));
   }
 
   @Override
   public void updateNextIndex(long newNextIndex) {
-    nextIndex.updateToMax(newNextIndex, infoIndexChange);
+    nextIndex.updateToMax(newNextIndex,
+        message -> infoIndexChange.accept("decreaseNextIndex " + message));
   }
 
   @Override
@@ -174,6 +177,11 @@ class FollowerInfoImpl implements FollowerInfo {
   @Override
   public Timestamp getLastRpcResponseTime() {
     return lastRpcResponseTime.get();
+  }
+
+  @Override
+  public Timestamp getLastRpcSendTime() {
+    return lastRpcSendTime.get();
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -1140,13 +1140,7 @@ class LeaderStateImpl implements LeaderState {
     }
 
     if (supplier.isInitialized()) {
-      senders.forEach(sender -> {
-        try {
-          sender.triggerHeartbeat();
-        } catch (IOException e) {
-          LOG.warn("{}: {} cannot trigger heartbeat due to {}", this, sender, e);
-        }
-      });
+      senders.forEach(LogAppender::triggerHeartbeat);
     }
 
     return listener.getFuture();


### PR DESCRIPTION
- Enforce raft.server.log.appender.wait-time.min.
- Move GrpcLogAppender.waitTimeMinMs to LogAppenderBase.
- Remove GrpcLogAppender.lastAppendEntries which duplicates lastRpcSendTime.
- Do not print log if no update in RaftLogIndex.

See https://issues.apache.org/jira/browse/RATIS-1793
 