### PR TITLE
RATIS-1800. Remove unused ratis-shell properties

### DIFF
--- a/ratis-shell/src/main/libexec/ratis-shell-config.sh
+++ b/ratis-shell/src/main/libexec/ratis-shell-config.sh
@@ -75,7 +75,7 @@ if [[ -n "${RATIS_SHELL_HOME}" ]]; then
   RATIS_SHELL_JAVA_OPTS+=" -Dratis.shell.home=${RATIS_SHELL_HOME}"
 fi
 
-RATIS_SHELL_JAVA_OPTS+=" -Dratis.shell.conf.dir=${RATIS_SHELL_CONF_DIR} -Dratis.shell.logs.dir=${RATIS_SHELL_LOGS_DIR} -Dratis.shell.user.logs.dir=${RATIS_SHELL_USER_LOGS_DIR}"
+RATIS_SHELL_JAVA_OPTS+=" -Dratis.shell.conf.dir=${RATIS_SHELL_CONF_DIR} -Dratis.shell.logs.dir=${RATIS_SHELL_LOGS_DIR}"
 
 RATIS_SHELL_JAVA_OPTS+=" -Dlog4j.configuration=file:${RATIS_SHELL_CONF_DIR}/log4j.properties"
 RATIS_SHELL_JAVA_OPTS+=" -Dorg.apache.jasper.compiler.disablejsr199=true"

--- a/ratis-shell/src/main/libexec/ratis-shell-config.sh
+++ b/ratis-shell/src/main/libexec/ratis-shell-config.sh
@@ -71,11 +71,7 @@ done < <(find "$RATIS_SHELL_LIB_DIR" ! -type d -name '*.jar' -print0 | sort -z)
 
 RATIS_SHELL_CLIENT_CLASSPATH="${RATIS_SHELL_CONF_DIR}/:${RATIS_SHELL_CLASSPATH}:${RATIS_SHELL_ASSEMBLY_CLIENT_JAR}"
 
-if [[ -n "${RATIS_SHELL_HOME}" ]]; then
-  RATIS_SHELL_JAVA_OPTS+=" -Dratis.shell.home=${RATIS_SHELL_HOME}"
-fi
-
-RATIS_SHELL_JAVA_OPTS+=" -Dratis.shell.conf.dir=${RATIS_SHELL_CONF_DIR} -Dratis.shell.logs.dir=${RATIS_SHELL_LOGS_DIR}"
+RATIS_SHELL_JAVA_OPTS+=" -Dratis.shell.logs.dir=${RATIS_SHELL_LOGS_DIR}"
 
 RATIS_SHELL_JAVA_OPTS+=" -Dlog4j.configuration=file:${RATIS_SHELL_CONF_DIR}/log4j.properties"
 RATIS_SHELL_JAVA_OPTS+=" -Dorg.apache.jasper.compiler.disablejsr199=true"


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove unused properties ratis.shell.user.logs.dir

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1800

## How was this patch tested?

Not need