### PR TITLE
RATIS-1801. Fix flaky test of TestLogAppenderWithGrpc.testPendingLimits

### DIFF
--- a/ratis-common/src/test/java/org/apache/ratis/BaseTest.java
+++ b/ratis-common/src/test/java/org/apache/ratis/BaseTest.java
@@ -52,7 +52,6 @@ public abstract class BaseTest {
   public static final TimeDuration HUNDRED_MILLIS = TimeDuration.valueOf(100, TimeUnit.MILLISECONDS);
   public static final TimeDuration ONE_SECOND = TimeDuration.ONE_SECOND;
   public static final TimeDuration FIVE_SECONDS = TimeDuration.valueOf(5, TimeUnit.SECONDS);
-  public static final TimeDuration TEN_SECONDS = TimeDuration.valueOf(10, TimeUnit.SECONDS);
 
   {
     Slf4jUtils.setLogLevel(ConfUtils.LOG, Level.WARN);

--- a/ratis-common/src/test/java/org/apache/ratis/BaseTest.java
+++ b/ratis-common/src/test/java/org/apache/ratis/BaseTest.java
@@ -52,6 +52,7 @@ public abstract class BaseTest {
   public static final TimeDuration HUNDRED_MILLIS = TimeDuration.valueOf(100, TimeUnit.MILLISECONDS);
   public static final TimeDuration ONE_SECOND = TimeDuration.ONE_SECOND;
   public static final TimeDuration FIVE_SECONDS = TimeDuration.valueOf(5, TimeUnit.SECONDS);
+  public static final TimeDuration TEN_SECONDS = TimeDuration.valueOf(10, TimeUnit.SECONDS);
 
   {
     Slf4jUtils.setLogLevel(ConfUtils.LOG, Level.WARN);

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
@@ -89,7 +89,7 @@ public class TestLogAppenderWithGrpc
         futures.add(client.async().send(new RaftTestUtil.SimpleMessage("m")));
       }
 
-      FIVE_SECONDS.sleep();
+      TEN_SECONDS.sleep();
       for (long nextIndex : leader.getInfo().getFollowerNextIndices()) {
         // Verify nextIndex does not progress due to pendingRequests limit
         Assert.assertEquals(initialNextIndex + maxAppends, nextIndex);

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
@@ -88,7 +88,7 @@ public class TestLogAppenderWithGrpc
       for (int i = 0; i < maxAppends * 2; i++) {
         futures.add(client.async().send(new RaftTestUtil.SimpleMessage("m")));
       }
-      
+
       JavaUtils.attempt(() -> {
         for (long nextIndex : leader.getInfo().getFollowerNextIndices()) {
           // Verify nextIndex does not progress due to pendingRequests limit


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix flasky test of TestLogAppenderWithGrpc.testPendingLimits

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1801

## How was this patch tested?

Existed UT