### PR TITLE
RATIS-1802. GrpcServerProtocolService encounters IllegalStateException: call already closed.

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -92,7 +92,9 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
 
     private void handleError(Throwable e, REQUEST request) {
       GrpcUtil.warn(LOG, () -> getId() + ": Failed " + op + " request " + requestToString(request), e);
-      responseObserver.onError(wrapException(e, request));
+      if (isClosed.compareAndSet(false, true)) {
+        responseObserver.onError(wrapException(e, request));
+      }
     }
 
     private synchronized void handleReply(REPLY reply) {

--- a/ratis-proto/src/main/proto/Grpc.proto
+++ b/ratis-proto/src/main/proto/Grpc.proto
@@ -47,7 +47,7 @@ service RaftServerProtocolService {
       returns(stream ratis.common.InstallSnapshotReplyProto) {}
 
   rpc readIndex(ratis.common.ReadIndexRequestProto)
-      returns(stream ratis.common.ReadIndexReplyProto) {}
+      returns(ratis.common.ReadIndexReplyProto) {}
 }
 
 service AdminProtocolService {


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1802