### PR TITLE
[RATIS-1805] Add doc about GENERIC_COMMAND_OPTIONS of ratis-shell

### DIFF
--- a/ratis-docs/src/site/markdown/cli.md
+++ b/ratis-docs/src/site/markdown/cli.md
@@ -83,9 +83,11 @@ Usage: ratis sh [generic options]
 ```
 
 ## generic options
-The `generic options` pass values for a given ratis-shell property.
-It supports the following content:
+The `generic options` supports the following content:
 `-D*`, `-X*`, `-agentlib*`, `-javaagent*`
+
+The `-D*` can pass values for a given ratis property to ratis-shell client RaftProperties.
+
 ```
 $ ratis sh -D<property=value> ...
 ```

--- a/ratis-docs/src/site/markdown/cli.md
+++ b/ratis-docs/src/site/markdown/cli.md
@@ -82,6 +82,14 @@ Usage: ratis sh [generic options]
          [snapshot [create]]
 ```
 
+## generic options
+The `generic options` pass values for a given ratis-shell property.
+It supports the following content:
+`-D*`, `-X*`, `-agentlib*`, `-javaagent*`
+```
+$ ratis sh -D<property=value> ...
+```
+
 ## election
 The `election` command manages leader election.
 It has the following subcommands:


### PR DESCRIPTION
## What changes were proposed in this pull request?
 Add doc about GENERIC_COMMAND_OPTIONS of ratis-shell, it's necesary.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1805


## How was this patch tested?
<img width="580" alt="截屏2023-03-03 下午2 23 34" src="https://user-images.githubusercontent.com/46485123/222646884-31097022-4647-4315-8a8d-d81eff4e251a.png">

