### PR TITLE
RATIS-1806. Further fix for TestLogAppenderWithGrpc#testPendingLimits

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
@@ -102,7 +102,6 @@ public class TestLogAppenderWithGrpc
           Assert.assertEquals(initialNextIndex + maxAppends, nextIndex);
         }
       }, 5, ONE_SECOND, "matching nextIndex", LOG);
-      ONE_SECOND.sleep();
       for (RaftServer.Division server : cluster.getFollowers()) {
         // unblock the appends in the follower
         SimpleStateMachine4Testing.get(server).unblockWriteStateMachineData();

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
@@ -84,7 +84,7 @@ public class TestLogAppenderWithGrpc
         // Make sure followers are up-to-date before blocking the appends in the follower
         cluster.getFollowers().stream().mapToLong(RaftServerTestUtil::getNextIndex)
             .forEach(nextIndex -> Assert.assertEquals(initialNextIndex, nextIndex));
-      }, 5, ONE_SECOND, "matching initial nextIndex", LOG);
+      }, 10, ONE_SECOND, "matching initial nextIndex", LOG);
 
       for (RaftServer.Division server : cluster.getFollowers()) {
         // block the appends in the follower
@@ -100,7 +100,7 @@ public class TestLogAppenderWithGrpc
           // Verify nextIndex does not progress due to pendingRequests limit
           Assert.assertEquals(initialNextIndex + maxAppends, nextIndex);
         }
-      }, 5, ONE_SECOND, "matching nextIndex", LOG);
+      }, 10, ONE_SECOND, "matching nextIndex", LOG);
       for (RaftServer.Division server : cluster.getFollowers()) {
         // unblock the appends in the follower
         SimpleStateMachine4Testing.get(server).unblockWriteStateMachineData();

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
@@ -81,10 +81,9 @@ public class TestLogAppenderWithGrpc
       long initialNextIndex = RaftServerTestUtil.getNextIndex(leader);
 
       JavaUtils.attempt(() -> {
-        for (long nextIndex : leader.getInfo().getFollowerNextIndices()) {
-          // Make sure followers are up-to-date before blocking the appends in the follower
-          Assert.assertEquals(initialNextIndex, nextIndex);
-        }
+        // Make sure followers are up-to-date before blocking the appends in the follower
+        cluster.getFollowers().stream().mapToLong(RaftServerTestUtil::getNextIndex)
+            .forEach(nextIndex -> Assert.assertEquals(initialNextIndex, nextIndex));
       }, 5, ONE_SECOND, "matching initial nextIndex", LOG);
 
       for (RaftServer.Division server : cluster.getFollowers()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix flaky test, make sure followers are up-to-date before blocking the appends in the follower

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1801

## How was this patch tested?

Repeat the test 100x in CI
Before: https://github.com/kaijchen/ratis/actions/runs/4322045714
After: https://github.com/kaijchen/ratis/actions/runs/4323233058
