### PR TITLE
RATIS-1796. [WIP] Add PRE_CANDIDATE and refactor LeaderElection

### DIFF
--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -276,6 +276,7 @@ enum RaftPeerRole {
   CANDIDATE = 1;
   FOLLOWER = 2;
   LISTENER = 3;
+  PRE_CANDIDATE = 4;
 }
 
 message WriteRequestTypeProto {

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/DivisionInfo.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/DivisionInfo.java
@@ -35,6 +35,11 @@ public interface DivisionInfo {
     return getCurrentRole() == RaftPeerRole.FOLLOWER;
   }
 
+  /** Is this server division currently a pre-candidate? */
+  default boolean isPreCandidate() {
+    return getCurrentRole() == RaftPeerRole.PRE_CANDIDATE;
+  }
+
   /** Is this server division currently a candidate? */
   default boolean isCandidate() {
     return getCurrentRole() == RaftPeerRole.CANDIDATE;

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.server.impl;
 
 import org.apache.ratis.server.DivisionInfo;
+import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.leader.LeaderState;
 import org.apache.ratis.util.Daemon;
 import org.apache.ratis.util.JavaUtils;
@@ -143,8 +144,12 @@ class FollowerState extends Daemon {
             LOG.info("{}: change to CANDIDATE, lastRpcElapsedTime:{}, electionTimeout:{}",
                 this, lastRpcTime.elapsedTime(), electionTimeout);
             server.getLeaderElectionMetrics().onLeaderElectionTimeout(); // Update timeout metric counters.
-            // election timeout, should become a candidate
-            server.changeToCandidate(false);
+            // election timeout, should become a candidate or preCandidate
+            if (RaftServerConfigKeys.LeaderElection.preVote(server.getRaftServer().getProperties())) {
+              server.changeToPreCandidate();
+            } else {
+              server.changeToCandidate();
+            }
             break;
           }
         }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
@@ -113,11 +113,11 @@ class RoleInfo {
     }
   }
 
-  void startLeaderElection(RaftServerImpl server, boolean force) {
+  void startLeaderElection(RaftServerImpl server, LeaderElection.Phase phase) {
     if (pauseLeaderElection.get()) {
       return;
     }
-    updateAndGet(leaderElection, new LeaderElection(server, force)).start();
+    updateAndGet(leaderElection, new LeaderElection(server, phase)).start();
   }
 
   void setLeaderElectionPause(boolean pause) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -212,7 +212,7 @@ class ServerState {
   /**
    * Become a candidate and start leader election
    */
-  LeaderElection.ConfAndTerm initElection(Phase phase) throws IOException {
+  LeaderElection.ConfAndTerm initElection(Phase phase) {
     setLeader(null, phase);
     final long term;
     if (phase == Phase.PRE_VOTE) {
@@ -220,7 +220,11 @@ class ServerState {
     } else if (phase == Phase.ELECTION) {
       term = currentTerm.incrementAndGet();
       votedFor = getMemberId().getPeerId();
-      persistMetadata();
+      try {
+        persistMetadata();
+      } catch (IOException e) {
+        throw new IllegalStateException("Failed to persist metadata for term:" + term, e);
+      }
     } else {
       throw new IllegalArgumentException("Unexpected phase " + phase);
     }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -68,6 +69,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -500,7 +502,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
   @Test
   public void testImmediatelyRevertedToFollower() {
     RaftServerImpl server = createMockServer(true);
-    LeaderElection subject = new LeaderElection(server, false);
+    LeaderElection subject = new LeaderElection(server, LeaderElection.Phase.PRE_VOTE);
 
     try {
       subject.startInForeground();
@@ -514,7 +516,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
   @Test
   public void testShutdownBeforeStart() {
     RaftServerImpl server = createMockServer(false);
-    LeaderElection subject = new LeaderElection(server, false);
+    LeaderElection subject = new LeaderElection(server, LeaderElection.Phase.PRE_VOTE);
 
     try {
       subject.shutdown();
@@ -628,6 +630,10 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
     RaftServerConfigKeys.LeaderElection.setPreVote(properties, true);
     when(proxy.getProperties()).thenReturn(properties);
     when(server.getRaftServer()).thenReturn(proxy);
+    final ServerState state = mock(ServerState.class);
+    RaftConfigurationImpl conf = RaftServerTestUtil.newRaftConfiguration(Collections.emptyList());
+    when(state.initElection(any())).thenReturn(new LeaderElection.ConfAndTerm(conf, 999));
+    when(server.getState()).thenReturn(state);
     return server;
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
@@ -131,7 +131,7 @@ public class RaftServerTestUtil {
     return (ConfigurationManager) RaftTestUtil.getDeclaredField(getState(server), "configurationManager");
   }
 
-  public static RaftConfiguration newRaftConfiguration(Collection<RaftPeer> peers) {
+  public static RaftConfigurationImpl newRaftConfiguration(Collection<RaftPeer> peers) {
     return RaftConfigurationImpl.newBuilder().setConf(peers).build();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

> TransferLeadership can be stopped by appendEntries from old leader, see Jira for details
>
> 1. Transferee received startLeaderElection (RaftServerImpl#startLeaderElection:1700 -> RaftServerImpl#changeToCandidate:649 -> RoleInfo#startLeaderElection:121 -> start new thread LeaderElection)
> 2. Transferee received appendEntries (stack trace in the log above), and become follower.
> 3. LeaderElection thread in step 1 is running, found the CandidateState is already CLOSED by step 2.
> 
> The term of transferee is expected to be increased in step 3 (LeaderElection#run:238 -> LeaderElection#askForVotes:304 -> ServerState#initElection:221 -> currentTerm.incrementAndGet).
> But in this case, step 2 is executed before step 3 when the term hasn't been increased.

Maybe we can introduce a Pre-Candidate state along with the Candidate state.
And increase the term when a peer becomes Candidate instead of in LeaderElection.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1796

## How was this patch tested?

100x TestElectionCommandIntegrationWithGrpc#testElectionTransferCommand
Before: https://github.com/kaijchen/ratis/actions/runs/4341726755
After: https://github.com/kaijchen/ratis/actions/runs/4341982282

100x LeaderElectionTests
Before: https://github.com/kaijchen/ratis/actions/runs/4341978875
After: https://github.com/kaijchen/ratis/actions/runs/4342023911
