### PR TITLE
RATIS-1796. Fix TransferLeadership stopped by heartbeat from old leader

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -198,7 +198,7 @@ class LeaderElection implements Runnable {
         !RaftServerConfigKeys.LeaderElection.preVote(
             server.getRaftServer().getProperties());
     try {
-      // increase term of the candidate early if it's forced to election
+      // increase term of the candidate in advance if it's forced to election
       this.round0 = force ? server.getState().initElection(Phase.ELECTION) : null;
     } catch (IOException e) {
       throw new IllegalStateException(name + ": Failed to initialize election", e);
@@ -310,7 +310,7 @@ class LeaderElection implements Runnable {
         return false;
       }
       // If round0 is non-null, we have already called initElection in the constructor,
-      // reuse round0 to skip term increment for the first round
+      // reuse round0 to avoid initElection again for the first round
       final ConfAndTerm confAndTerm = (round == 0 && round0 != null) ?
           round0 : server.getState().initElection(phase);
       electionTerm = confAndTerm.getTerm();

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -186,16 +186,23 @@ class LeaderElection implements Runnable {
 
   private final RaftServerImpl server;
   private final boolean skipPreVote;
+  private final ConfAndTerm round0;
 
-  LeaderElection(RaftServerImpl server, boolean skipPreVote) {
+  LeaderElection(RaftServerImpl server, boolean force) {
     this.name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass()) + COUNT.incrementAndGet();
     this.lifeCycle = new LifeCycle(this);
     this.daemon = Daemon.newBuilder().setName(name).setRunnable(this)
         .setThreadGroup(server.getThreadGroup()).build();
     this.server = server;
-    this.skipPreVote = skipPreVote ||
+    this.skipPreVote = force ||
         !RaftServerConfigKeys.LeaderElection.preVote(
             server.getRaftServer().getProperties());
+    try {
+      // increase term of the candidate early if it's forced to election
+      this.round0 = force ? server.getState().initElection(Phase.ELECTION) : null;
+    } catch (IOException e) {
+      throw new IllegalStateException(name + ": Failed to initialize election", e);
+    }
   }
 
   void start() {
@@ -302,7 +309,10 @@ class LeaderElection implements Runnable {
       if (!shouldRun()) {
         return false;
       }
-      final ConfAndTerm confAndTerm = server.getState().initElection(phase);
+      // If round0 is non-null, we have already called initElection in the constructor,
+      // reuse round0 to skip term increment for the first round
+      final ConfAndTerm confAndTerm = (round == 0 && round0 != null) ?
+          round0 : server.getState().initElection(phase);
       electionTerm = confAndTerm.getTerm();
       conf = confAndTerm.getConf();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix "TransferLeadership can be stopped by appendEntries from old leader", see Jira for details.

> 1. Transferee received startLeaderElection (RaftServerImpl#startLeaderElection:1700 -> RaftServerImpl#changeToCandidate:649 -> RoleInfo#startLeaderElection:121 -> start new thread LeaderElection)
> 2. Transferee received appendEntries (stack trace in the log above), and become follower.
> 3. LeaderElection thread in step 1 is running, found the CandidateState is already CLOSED by step 2.
> 
> The term of transferee is expected to be increased in step 3 (LeaderElection#run:238 -> LeaderElection#askForVotes:304 -> ServerState#initElection:221 -> currentTerm.incrementAndGet).
> But in this case, step 2 is executed before step 3 when the term hasn't been increased.

Increase term immediately when `LeaderElection(skipPreVote=true)`,
and skip `initElection(Phase.ELECTION)` in the first round in `askForVotes()`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1796

## How was this patch tested?

100x TestElectionCommandIntegrationWithGrpc#testElectionTransferCommand
Before: https://github.com/kaijchen/ratis/actions/runs/4341726755
After: https://github.com/kaijchen/ratis/actions/runs/4344253556