### PR TITLE
RATIS-1770. Yield leader to higher priority peer by TransferLeadership

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -677,7 +677,7 @@ class LeaderStateImpl implements LeaderState {
 
   private static LogAppender chooseUpToDateFollower(List<LogAppender> followers, TermIndex leaderLastEntry) {
     for(LogAppender f : followers) {
-      if (isFollowerUpToDate(f.getFollower(), leaderLastEntry) == null) {
+      if (isFollowerUpToDate(f.getFollower(), leaderLastEntry) == TransferLeadership.Result.SUCCESS) {
         return f;
       }
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -749,7 +749,7 @@ class LeaderStateImpl implements LeaderState {
     } else {
       eventQueue.submit(checkStagingEvent);
     }
-    server.getTransferLeadership().onFollowerAppendEntriesReply(this, follower);
+    server.getTransferLeadership().onFollowerAppendEntriesReply(follower);
   }
 
   @Override
@@ -1034,7 +1034,7 @@ class LeaderStateImpl implements LeaderState {
     final TermIndex leaderLastEntry = getLastEntry();
     final LogAppender appender = chooseUpToDateFollower(highestPriorityInfos, leaderLastEntry);
     if (appender != null) {
-      server.getTransferLeadership().start(appender, leaderLastEntry);
+      server.getTransferLeadership().start(appender);
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -661,23 +661,10 @@ class LeaderStateImpl implements LeaderState {
     return pendingStepDown.submitAsync(request);
   }
 
-  static TransferLeadership.Result isFollowerUpToDate(FollowerInfo follower, TermIndex leaderLastEntry) {
-    if (follower == null) {
-      return TransferLeadership.Result.NULL_FOLLOWER;
-    } else if (leaderLastEntry != null) {
-      final long followerMatchIndex = follower.getMatchIndex();
-      if (followerMatchIndex < leaderLastEntry.getIndex()) {
-        return new TransferLeadership.Result(TransferLeadership.Result.Type.NOT_UP_TO_DATE,
-            "followerMatchIndex = " + followerMatchIndex
-                + " < leaderLastEntry.getIndex() = " + leaderLastEntry.getIndex());
-      }
-    }
-    return TransferLeadership.Result.SUCCESS;
-  }
-
   private static LogAppender chooseUpToDateFollower(List<LogAppender> followers, TermIndex leaderLastEntry) {
     for(LogAppender f : followers) {
-      if (isFollowerUpToDate(f.getFollower(), leaderLastEntry) == TransferLeadership.Result.SUCCESS) {
+      if (TransferLeadership.isFollowerUpToDate(f.getFollower(), leaderLastEntry)
+          == TransferLeadership.Result.SUCCESS) {
         return f;
       }
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -260,7 +260,6 @@ class ServerState {
       LOG.info("{}: change Leader from {} to {} at term {} for {}{}",
           getMemberId(), oldLeaderId, newLeaderId, getCurrentTerm(), op, suffix);
       if (newLeaderId != null) {
-        server.finishTransferLeadership();
         server.onGroupLeaderElected();
       }
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
@@ -17,14 +17,19 @@
  */
 package org.apache.ratis.server.impl;
 
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.TransferLeadershipRequest;
 import org.apache.ratis.protocol.exceptions.TransferLeadershipException;
+import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.leader.FollowerInfo;
 import org.apache.ratis.server.leader.LogAppender;
+import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.MemoizedSupplier;
+import org.apache.ratis.util.StringUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.TimeoutExecutor;
 import org.slf4j.Logger;
@@ -34,9 +39,91 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 public class TransferLeadership {
   public static final Logger LOG = LoggerFactory.getLogger(TransferLeadership.class);
+
+  private static class Context {
+    private final TransferLeadershipRequest request;
+    private final Supplier<TermIndex> leaderLastEntry;
+    private final Supplier<LogAppender> transferee;
+
+    Context(TransferLeadershipRequest request, Supplier<TermIndex> leaderLastEntry, Supplier<LogAppender> transferee) {
+      this.request = request;
+      this.leaderLastEntry = leaderLastEntry;
+      this.transferee = transferee;
+    }
+
+    TransferLeadershipRequest getRequest() {
+      return request;
+    }
+
+    RaftPeerId getTransfereeId() {
+      return request.getNewLeader();
+    }
+
+    LogAppender getTransfereeLogAppender() {
+      return transferee.get();
+    }
+
+    TermIndex getLeaderLastEntry() {
+      return leaderLastEntry.get();
+    }
+  }
+
+  static class Result {
+    enum Type {
+      SUCCESS,
+      DIFFERENT_LEADER,
+      NULL_FOLLOWER,
+      NULL_LOG_APPENDER,
+      NOT_UP_TO_DATE,
+      TIMED_OUT,
+      FAILED_TO_START,
+      LAST_ENTRY_CHANGED,
+      COMPLETED_EXCEPTIONALLY,
+    }
+
+    static final Result SUCCESS = new Result(Type.SUCCESS);
+    static final Result DIFFERENT_LEADER = new Result(Type.DIFFERENT_LEADER);
+    static final Result NULL_FOLLOWER = new Result(Type.NULL_FOLLOWER);
+    static final Result NULL_LOG_APPENDER = new Result(Type.NULL_LOG_APPENDER);
+
+    private final Type type;
+    private final String errorMessage;
+    private final Throwable exception;
+
+    private Result(Type type) {
+      this(type, null);
+    }
+
+    private Result(Type type, String errorMessage, Throwable exception) {
+      this.type = type;
+      this.errorMessage = errorMessage;
+      this.exception = exception;
+    }
+
+    Result(Type type, String errorMessage) {
+      this(type, errorMessage, null);
+    }
+
+    Result(Throwable t) {
+      this(Type.COMPLETED_EXCEPTIONALLY, null, t);
+    }
+
+    Type getType() {
+      return type;
+    }
+
+    @Override
+    public String toString() {
+      if (exception == null) {
+        return type + (errorMessage == null ? "" : "(" + errorMessage + ")");
+      }
+      return type + ": " + StringUtils.stringifyException(exception);
+    }
+  }
 
   class PendingRequest {
     private final TransferLeadershipRequest request;
@@ -54,17 +141,20 @@ public class TransferLeadership {
       return replyFuture;
     }
 
-    void complete(RaftPeerId currentLeader, boolean timeout) {
+    void complete(Result result) {
       if (replyFuture.isDone()) {
         return;
       }
-
+      final RaftPeerId currentLeader = server.getState().getLeaderId();
       if (currentLeader != null && currentLeader.equals(request.getNewLeader())) {
         replyFuture.complete(server.newSuccessReply(request));
-      } else if (timeout) {
+      } else {
+        if (result.getType() == Result.Type.SUCCESS) {
+          result = Result.DIFFERENT_LEADER;
+        }
         final TransferLeadershipException tle = new TransferLeadershipException(server.getMemberId()
             + ": Failed to transfer leadership to " + request.getNewLeader()
-            + " (timed out " + request.getTimeoutMs() + "ms): current leader is " + currentLeader);
+            + " (the current leader is " + currentLeader + "): " + result);
         replyFuture.complete(server.newExceptionReply(request, tle));
       }
     }
@@ -76,11 +166,14 @@ public class TransferLeadership {
   }
 
   private final RaftServerImpl server;
+  private final TimeDuration requestTimeout;
   private final TimeoutExecutor scheduler = TimeoutExecutor.getInstance();
+
   private final AtomicReference<PendingRequest> pending = new AtomicReference<>();
 
-  TransferLeadership(RaftServerImpl server) {
+  TransferLeadership(RaftServerImpl server, RaftProperties properties) {
     this.server = server;
+    this.requestTimeout = RaftServerConfigKeys.Rpc.requestTimeout(properties);
   }
 
   private Optional<RaftPeerId> getTransferee() {
@@ -93,49 +186,74 @@ public class TransferLeadership {
   }
 
   void onFollowerAppendEntriesReply(LeaderStateImpl leaderState, FollowerInfo follower) {
-    final Optional<RaftPeerId> transferee = getTransferee();
     // If the transferee has just append some entries and becomes up-to-date,
     // send StartLeaderElection to it
-    if (transferee.filter(t -> t.equals(follower.getId())).isPresent()
-        && leaderState.sendStartLeaderElection(follower)) {
-      LOG.info("{}: sent StartLeaderElection to transferee {} after received AppendEntriesResponse",
-          server.getMemberId(), transferee.get());
+    if (getTransferee().filter(t -> t.equals(follower.getId())).isPresent()) {
+      final Result error = leaderState.sendStartLeaderElection(follower, leaderState.getLastEntry());
+      if (error == Result.SUCCESS) {
+        LOG.info("{}: sent StartLeaderElection to transferee {} after received AppendEntriesResponse",
+            server.getMemberId(), follower.getId());
+      }
     }
   }
 
-  private void tryTransferLeadership(LeaderStateImpl leaderState, RaftPeerId transferee) {
+  private Result tryTransferLeadership(LeaderStateImpl leaderState, Context context) {
+    final RaftPeerId transferee = context.getTransfereeId();
     LOG.info("{}: start transferring leadership to {}", server.getMemberId(), transferee);
-    final LogAppender appender = leaderState.getLogAppender(transferee).orElse(null);
-
+    final LogAppender appender = context.getTransfereeLogAppender();
     if (appender == null) {
-      LOG.error("{}: cannot find LogAppender for transferee {}", server.getMemberId(), transferee);
-      return;
+      return Result.NULL_LOG_APPENDER;
     }
     final FollowerInfo follower = appender.getFollower();
-    if (leaderState.sendStartLeaderElection(follower)) {
-      LOG.info("{}: sent StartLeaderElection to transferee {} immediately as it already has up-to-date log",
-          server.getMemberId(), transferee);
-    } else {
-      LOG.info("{}: notifying LogAppender to send AppendEntries as transferee {} is not up-to-date",
-          server.getMemberId(), transferee);
+    final Result result = leaderState.sendStartLeaderElection(follower, context.getLeaderLastEntry());
+    if (result.getType() == Result.Type.SUCCESS) {
+      LOG.info("{}: {} sent StartLeaderElection to transferee {} immediately as it already has up-to-date log",
+          server.getMemberId(), result, transferee);
+    } else if (result.getType() == Result.Type.NOT_UP_TO_DATE) {
+      LOG.info("{}: {} notifying LogAppender to send AppendEntries to transferee {}",
+          server.getMemberId(), result, transferee);
       appender.notifyLogAppender();
     }
+    return result;
+  }
+
+  void start(LeaderStateImpl leaderState, LogAppender transferee, TermIndex leaderLastEntry) {
+    // TransferLeadership will block client request, so we don't want wait too long.
+    // If everything goes well, transferee should be elected within the min rpc timeout.
+    final long timeout = server.properties().minRpcTimeoutMs();
+    final TransferLeadershipRequest request = new TransferLeadershipRequest(ClientId.emptyClientId(),
+        server.getId(), server.getMemberId().getGroupId(), 0, transferee.getFollowerId(), timeout);
+    start(leaderState, new Context(request, () -> leaderLastEntry, () -> transferee));
   }
 
   CompletableFuture<RaftClientReply> start(LeaderStateImpl leaderState, TransferLeadershipRequest request) {
+    final Context context = new Context(request,
+        JavaUtils.memoize(leaderState::getLastEntry),
+        JavaUtils.memoize(() -> leaderState.getLogAppender(request.getNewLeader()).orElse(null)));
+    return start(leaderState, context);
+  }
+
+  private CompletableFuture<RaftClientReply> start(LeaderStateImpl leaderState, Context context) {
+    final TransferLeadershipRequest request = context.getRequest();
     final MemoizedSupplier<PendingRequest> supplier = JavaUtils.memoize(() -> new PendingRequest(request));
     final PendingRequest previous = pending.getAndUpdate(f -> f != null? f: supplier.get());
     if (previous != null) {
       return createReplyFutureFromPreviousRequest(request, previous);
     }
-    tryTransferLeadership(leaderState, request.getNewLeader());
-
-    // if timeout is not specified in request, default to random election timeout
-    final TimeDuration timeout = request.getTimeoutMs() == 0 ? server.getRandomElectionTimeout()
-        : TimeDuration.valueOf(request.getTimeoutMs(), TimeUnit.MILLISECONDS);
-    scheduler.onTimeout(timeout, () -> finish(server.getState().getLeaderId(), true),
-        LOG, () -> "Failed to transfer leadership to " + request.getNewLeader() + ": timeout after " + timeout);
-    return supplier.get().getReplyFuture();
+    final PendingRequest pendingRequest = supplier.get();
+    final Result result = tryTransferLeadership(leaderState, context);
+    final Result.Type type = result.getType();
+    if (type != Result.Type.SUCCESS && type != Result.Type.NOT_UP_TO_DATE) {
+      pendingRequest.complete(result);
+    } else {
+      // if timeout is not specified in request, use default request timeout
+      final TimeDuration timeout = request.getTimeoutMs() == 0 ? requestTimeout
+          : TimeDuration.valueOf(request.getTimeoutMs(), TimeUnit.MILLISECONDS);
+      scheduler.onTimeout(timeout, () -> complete(new Result(Result.Type.TIMED_OUT,
+              timeout.toString(TimeUnit.SECONDS, 3))),
+          LOG, () -> "Failed to handle timeout");
+    }
+    return pendingRequest.getReplyFuture();
   }
 
   private CompletableFuture<RaftClientReply> createReplyFutureFromPreviousRequest(
@@ -158,8 +276,8 @@ public class TransferLeadership {
     }
   }
 
-  void finish(RaftPeerId currentLeader, boolean timeout) {
+  void complete(Result result) {
     Optional.ofNullable(pending.getAndSet(null))
-        .ifPresent(r -> r.complete(currentLeader, timeout));
+        .ifPresent(r -> r.complete(result));
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
@@ -194,9 +194,8 @@ public class TransferLeadership {
     } else if (leaderLastEntry != null) {
       final long followerMatchIndex = follower.getMatchIndex();
       if (followerMatchIndex < leaderLastEntry.getIndex()) {
-        return new Result(Result.Type.NOT_UP_TO_DATE,
-            "followerMatchIndex = " + followerMatchIndex
-                + " < leaderLastEntry.getIndex() = " + leaderLastEntry.getIndex());
+        return new Result(Result.Type.NOT_UP_TO_DATE, "followerMatchIndex = " + followerMatchIndex
+            + " < leaderLastEntry.getIndex() = " + leaderLastEntry.getIndex());
       }
     }
     return Result.SUCCESS;

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
@@ -247,15 +247,18 @@ public class TransferLeadership {
     return Result.SUCCESS;
   }
 
+  /**
+   * If the transferee has just append some entries and becomes up-to-date,
+   * send StartLeaderElection to it
+   */
   void onFollowerAppendEntriesReply(LeaderStateImpl leaderState, FollowerInfo follower) {
-    // If the transferee has just append some entries and becomes up-to-date,
-    // send StartLeaderElection to it
-    if (getTransferee().filter(t -> t.equals(follower.getId())).isPresent()) {
-      final Result error = sendStartLeaderElection(follower, leaderState.getLastEntry());
-      if (error == Result.SUCCESS) {
-        LOG.info("{}: sent StartLeaderElection to transferee {} after received AppendEntriesResponse",
-            server.getMemberId(), follower.getId());
-      }
+    if (!getTransferee().filter(t -> t.equals(follower.getId())).isPresent()) {
+      return;
+    }
+    final Result result = sendStartLeaderElection(follower, leaderState.getLastEntry());
+    if (result == Result.SUCCESS) {
+      LOG.info("{}: sent StartLeaderElection to transferee {} after received AppendEntriesResponse",
+          server.getMemberId(), follower.getId());
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
@@ -202,15 +202,15 @@ public class TransferLeadership {
   }
 
   private Result sendStartLeaderElection(FollowerInfo follower, TermIndex lastEntry) {
-    final Result result = isFollowerUpToDate(follower, lastEntry);
-    if (result != Result.SUCCESS) {
-      return result;
-    }
-
     final TermIndex currLastEntry = server.getState().getLastEntry();
     if (ServerState.compareLog(currLastEntry, lastEntry) != 0) {
       return new Result(Result.Type.LAST_ENTRY_CHANGED,
           "leader lastEntry changed from " + lastEntry + " to " + currLastEntry);
+    }
+
+    final Result result = isFollowerUpToDate(follower, lastEntry);
+    if (result != Result.SUCCESS) {
+      return result;
     }
 
     final RaftPeerId transferee = follower.getId();

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
@@ -188,8 +188,22 @@ public class TransferLeadership {
     return pending.get() != null;
   }
 
+  static Result isFollowerUpToDate(FollowerInfo follower, TermIndex leaderLastEntry) {
+    if (follower == null) {
+      return Result.NULL_FOLLOWER;
+    } else if (leaderLastEntry != null) {
+      final long followerMatchIndex = follower.getMatchIndex();
+      if (followerMatchIndex < leaderLastEntry.getIndex()) {
+        return new Result(Result.Type.NOT_UP_TO_DATE,
+            "followerMatchIndex = " + followerMatchIndex
+                + " < leaderLastEntry.getIndex() = " + leaderLastEntry.getIndex());
+      }
+    }
+    return Result.SUCCESS;
+  }
+
   private Result sendStartLeaderElection(FollowerInfo transferee, TermIndex leaderLastEntry) {
-    final Result result = LeaderStateImpl.isFollowerUpToDate(transferee, leaderLastEntry);
+    final Result result = isFollowerUpToDate(transferee, leaderLastEntry);
     if (result != Result.SUCCESS) {
       return result;
     }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -260,7 +260,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
               long cost = System.currentTimeMillis() - start;
               Assert.assertTrue(cost > timeoutMs);
               Assert.assertTrue(e.getMessage().contains("Failed to transfer leadership to"));
-              Assert.assertTrue(e.getMessage().contains("timed out"));
+              Assert.assertTrue(e.getMessage().contains(TransferLeadership.Result.Type.TIMED_OUT.toString()));
             }
 
             return true;
@@ -283,7 +283,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
 
         // after transfer timeout, leader should accept request
         RaftClientReply reply = client.io().send(new RaftTestUtil.SimpleMessage("message"));
-        Assert.assertTrue(reply.getReplierId().equals(leader.getId().toString()));
+        Assert.assertEquals(leader.getId().toString(), reply.getReplierId());
         Assert.assertTrue(reply.isSuccess());
 
         deIsolate(cluster, newLeader.getId());

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/election/TransferCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/election/TransferCommand.java
@@ -58,12 +58,8 @@ public class TransferCommand extends AbstractRatisCommand {
     super.run(cl);
 
     String strAddr = cl.getOptionValue(ADDRESS_OPTION_NAME);
-    // TODO: Default timeout should be set to 0, which means let server decide (based on election timeout).
-    //       However, occasionally the request could timeout too fast while the transfer is in progress.
-    //       i.e. request timeout doesn't mean transfer leadership has failed.
-    //       Currently, Ratis shell returns merely based on the result of the request.
-    //       So we set a larger default timeout here (3s).
-    final TimeDuration timeoutDefault = TimeDuration.valueOf(3, TimeUnit.SECONDS);
+    // Default timeout is 0, which means let server decide (will use default request timeout).
+    final TimeDuration timeoutDefault = TimeDuration.ZERO;
     // Default timeout for legacy mode matches with the legacy command (version 2.4.x and older).
     final TimeDuration timeoutLegacy = TimeDuration.valueOf(60, TimeUnit.SECONDS);
     final Optional<TimeDuration> timeout = !cl.hasOption(TIMEOUT_OPTION_NAME) ? Optional.empty() :


### PR DESCRIPTION
## What changes were proposed in this pull request?

Yield leader to higher priority peer by TransferLeadership.
To avoid blocking client requests for a long time,
it will only start TransferLeadership when the higher priority peer is up-to-date.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1770

## How was this patch tested?

Covered by `LeaderElectionTests#testYieldLeaderToHigherPriority()`.
