### PR TITLE
RATIS-1810. Intermittent failure in TestRaftServerWithGrpc#testRaftClientMetrics

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -891,9 +891,7 @@ class RaftServerImpl implements RaftServer.Division,
 
     final RaftClientRequest.Type type = request.getType();
     replyFuture.whenComplete((clientReply, exception) -> {
-      if (clientReply.isSuccess()) {
-        timerContext.ifPresent(Timekeeper.Context::stop);
-      }
+      timerContext.ifPresent(Timekeeper.Context::stop);
       if (exception != null || clientReply.getException() != null) {
         raftServerMetrics.incFailedRequestCount(type);
       }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftServerWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftServerWithGrpc.java
@@ -23,6 +23,7 @@ import static org.apache.ratis.server.metrics.RaftServerMetricsImpl.RAFT_CLIENT_
 import static org.apache.ratis.server.metrics.RaftServerMetricsImpl.RAFT_CLIENT_WRITE_REQUEST;
 
 import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.util.JavaUtils;
 import org.slf4j.event.Level;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.security.SecurityTestUtils;
@@ -313,30 +314,35 @@ public class TestRaftServerWithGrpc extends BaseTest implements MiniRaftClusterW
       final CompletableFuture<RaftClientReply> f1 = client.async().send(new SimpleMessage("testing"));
       Assert.assertTrue(f1.get().isSuccess());
       final DefaultTimekeeperImpl write = (DefaultTimekeeperImpl) registry.timer(RAFT_CLIENT_WRITE_REQUEST);
-      Assert.assertTrue(write.getTimer().getCount() > 0);
+      JavaUtils.attempt(() -> Assert.assertTrue(write.getTimer().getCount() > 0),
+          3, TimeDuration.ONE_SECOND, "writeTimer metrics", LOG);
 
       final CompletableFuture<RaftClientReply> f2 = client.async().sendReadOnly(new SimpleMessage("testing"));
       Assert.assertTrue(f2.get().isSuccess());
       final DefaultTimekeeperImpl read = (DefaultTimekeeperImpl) registry.timer(RAFT_CLIENT_READ_REQUEST);
-      Assert.assertTrue(read.getTimer().getCount() > 0);
+      JavaUtils.attempt(() -> Assert.assertTrue(read.getTimer().getCount() > 0),
+          3, TimeDuration.ONE_SECOND, "readTimer metrics", LOG);
 
       final CompletableFuture<RaftClientReply> f3 = client.async().sendStaleRead(new SimpleMessage("testing"),
           0, leader.getId());
       Assert.assertTrue(f3.get().isSuccess());
       final DefaultTimekeeperImpl staleRead = (DefaultTimekeeperImpl) registry.timer(RAFT_CLIENT_STALE_READ_REQUEST);
-      Assert.assertTrue(staleRead.getTimer().getCount() > 0);
+      JavaUtils.attempt(() -> Assert.assertTrue(staleRead.getTimer().getCount() > 0),
+          3, TimeDuration.ONE_SECOND, "staleReadTimer metrics", LOG);
 
       final CompletableFuture<RaftClientReply> f4 = client.async().watch(0, RaftProtos.ReplicationLevel.ALL);
       Assert.assertTrue(f4.get().isSuccess());
       final DefaultTimekeeperImpl watchAll = (DefaultTimekeeperImpl) registry.timer(
           String.format(RAFT_CLIENT_WATCH_REQUEST, "-ALL"));
-      Assert.assertTrue(watchAll.getTimer().getCount() > 0);
+      JavaUtils.attempt(() -> Assert.assertTrue(watchAll.getTimer().getCount() > 0),
+          3, TimeDuration.ONE_SECOND, "watchAllTimer metrics", LOG);
 
       final CompletableFuture<RaftClientReply> f5 = client.async().watch(0, RaftProtos.ReplicationLevel.MAJORITY);
       Assert.assertTrue(f5.get().isSuccess());
       final DefaultTimekeeperImpl watch = (DefaultTimekeeperImpl) registry.timer(
           String.format(RAFT_CLIENT_WATCH_REQUEST, ""));
-      Assert.assertTrue(watch.getTimer().getCount() > 0);
+      JavaUtils.attempt(() -> Assert.assertTrue(watch.getTimer().getCount() > 0),
+          3, TimeDuration.ONE_SECOND, "watchTimer metrics", LOG);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Address flaky test TestRaftServerWithGrpc#testRaftClientMetrics.
The metrics are updated asynchronously, sometimes it hasn't been updated before assertions.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1810

## How was this patch tested?

100x TestRaftServerWithGrpc#testRaftClientMetrics in CI.
Before: https://github.com/kaijchen/ratis/actions/runs/4345085390
After: https://github.com/kaijchen/ratis/actions/runs/4353918913