### PR TITLE
RATIS-1809. Use separated timeout for GrpcLogAppender's streaming RPC

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
@@ -248,26 +248,26 @@ public interface GrpcConfigKeys {
       setInt(properties::setInt, LEADER_OUTSTANDING_APPENDS_MAX_KEY, maxAppend);
     }
 
-    String LEADER_OUTSTANDING_INSTALL_SNAPSHOTS_MAX_KEY = PREFIX + ".leader.outstanding.install_snapshots.max";
-    int LEADER_OUTSTANDING_INSTALL_SNAPSHOTS_MAX_DEFAULT = 8;
-    static int leaderOutstandingInstallSnapshotsMax(RaftProperties properties) {
-      return getInt(properties::getInt, LEADER_OUTSTANDING_INSTALL_SNAPSHOTS_MAX_KEY,
-          LEADER_OUTSTANDING_INSTALL_SNAPSHOTS_MAX_DEFAULT, getDefaultLog(), requireMin(0));
+    String INSTALL_SNAPSHOT_REQUEST_ELEMENT_LIMIT_KEY = PREFIX + ".install_snapshot.request.element-limit";
+    int INSTALL_SNAPSHOT_REQUEST_ELEMENT_LIMIT_DEFAULT = 8;
+    static int installSnapshotRequestElementLimit(RaftProperties properties) {
+      return getInt(properties::getInt, INSTALL_SNAPSHOT_REQUEST_ELEMENT_LIMIT_KEY,
+          INSTALL_SNAPSHOT_REQUEST_ELEMENT_LIMIT_DEFAULT, getDefaultLog(), requireMin(0));
     }
-    static void setLeaderOutstandingInstallSnapshotsMax(RaftProperties properties, int maxInstallSnapshots) {
-      setInt(properties::setInt, LEADER_OUTSTANDING_INSTALL_SNAPSHOTS_MAX_KEY, maxInstallSnapshots);
+    static void setInstallSnapshotRequestElementLimit(RaftProperties properties, int elementLimit) {
+      setInt(properties::setInt, INSTALL_SNAPSHOT_REQUEST_ELEMENT_LIMIT_KEY, elementLimit);
     }
 
-    String LEADER_INSTALL_SNAPSHOT_STREAM_TIMEOUT_KEY = PREFIX + ".leader.install_snapshot.stream.timeout";
-    TimeDuration LEADER_INSTALL_SNAPSHOT_STREAM_TIMEOUT_DEFAULT = RaftServerConfigKeys.Rpc.REQUEST_TIMEOUT_DEFAULT;
-    static TimeDuration leaderInstallSnapshotStreamTimeout(RaftProperties properties) {
-      return getTimeDuration(properties.getTimeDuration(LEADER_INSTALL_SNAPSHOT_STREAM_TIMEOUT_DEFAULT.getUnit()),
-          LEADER_INSTALL_SNAPSHOT_STREAM_TIMEOUT_KEY, LEADER_INSTALL_SNAPSHOT_STREAM_TIMEOUT_DEFAULT, getDefaultLog());
+    String INSTALL_SNAPSHOT_REQUEST_TIMEOUT_KEY = PREFIX + ".install_snapshot.request.timeout";
+    TimeDuration INSTALL_SNAPSHOT_REQUEST_TIMEOUT_DEFAULT = RaftServerConfigKeys.Rpc.REQUEST_TIMEOUT_DEFAULT;
+    static TimeDuration installSnapshotRequestTimeout(RaftProperties properties) {
+      return getTimeDuration(properties.getTimeDuration(INSTALL_SNAPSHOT_REQUEST_TIMEOUT_DEFAULT.getUnit()),
+          INSTALL_SNAPSHOT_REQUEST_TIMEOUT_KEY, INSTALL_SNAPSHOT_REQUEST_TIMEOUT_DEFAULT, getDefaultLog());
     }
-    static void setLeaderInstallSnapshotStreamTimeout(RaftProperties properties,
-                                                      TimeDuration installSnapshotStreamTimeout) {
+    static void setInstallSnapshotRequestTimeout(RaftProperties properties,
+                                                 TimeDuration installSnapshotRequestTimeout) {
       setTimeDuration(properties::setTimeDuration,
-          LEADER_INSTALL_SNAPSHOT_STREAM_TIMEOUT_KEY, installSnapshotStreamTimeout);
+          INSTALL_SNAPSHOT_REQUEST_TIMEOUT_KEY, installSnapshotRequestTimeout);
     }
 
     String HEARTBEAT_CHANNEL_KEY = PREFIX + ".heartbeat.channel";

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
@@ -19,13 +19,27 @@ package org.apache.ratis.grpc;
 
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.util.SizeInBytes;
+import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.function.Consumer;
 
-import static org.apache.ratis.conf.ConfUtils.*;
+import static org.apache.ratis.conf.ConfUtils.get;
+import static org.apache.ratis.conf.ConfUtils.getBoolean;
+import static org.apache.ratis.conf.ConfUtils.getInt;
+import static org.apache.ratis.conf.ConfUtils.getSizeInBytes;
+import static org.apache.ratis.conf.ConfUtils.getTimeDuration;
+import static org.apache.ratis.conf.ConfUtils.printAll;
+import static org.apache.ratis.conf.ConfUtils.requireMax;
+import static org.apache.ratis.conf.ConfUtils.requireMin;
+import static org.apache.ratis.conf.ConfUtils.set;
+import static org.apache.ratis.conf.ConfUtils.setBoolean;
+import static org.apache.ratis.conf.ConfUtils.setInt;
+import static org.apache.ratis.conf.ConfUtils.setSizeInBytes;
+import static org.apache.ratis.conf.ConfUtils.setTimeDuration;
 
 public interface GrpcConfigKeys {
   Logger LOG = LoggerFactory.getLogger(GrpcConfigKeys.class);
@@ -232,6 +246,28 @@ public interface GrpcConfigKeys {
     }
     static void setLeaderOutstandingAppendsMax(RaftProperties properties, int maxAppend) {
       setInt(properties::setInt, LEADER_OUTSTANDING_APPENDS_MAX_KEY, maxAppend);
+    }
+
+    String LEADER_OUTSTANDING_INSTALL_SNAPSHOTS_MAX_KEY = PREFIX + ".leader.outstanding.install_snapshots.max";
+    int LEADER_OUTSTANDING_INSTALL_SNAPSHOTS_MAX_DEFAULT = 8;
+    static int leaderOutstandingInstallSnapshotsMax(RaftProperties properties) {
+      return getInt(properties::getInt, LEADER_OUTSTANDING_INSTALL_SNAPSHOTS_MAX_KEY,
+          LEADER_OUTSTANDING_INSTALL_SNAPSHOTS_MAX_DEFAULT, getDefaultLog(), requireMin(0));
+    }
+    static void setLeaderOutstandingInstallSnapshotsMax(RaftProperties properties, int maxInstallSnapshots) {
+      setInt(properties::setInt, LEADER_OUTSTANDING_INSTALL_SNAPSHOTS_MAX_KEY, maxInstallSnapshots);
+    }
+
+    String LEADER_INSTALL_SNAPSHOT_STREAM_TIMEOUT_KEY = PREFIX + ".leader.install_snapshot.stream.timeout";
+    TimeDuration LEADER_INSTALL_SNAPSHOT_STREAM_TIMEOUT_DEFAULT = RaftServerConfigKeys.Rpc.REQUEST_TIMEOUT_DEFAULT;
+    static TimeDuration leaderInstallSnapshotStreamTimeout(RaftProperties properties) {
+      return getTimeDuration(properties.getTimeDuration(LEADER_INSTALL_SNAPSHOT_STREAM_TIMEOUT_DEFAULT.getUnit()),
+          LEADER_INSTALL_SNAPSHOT_STREAM_TIMEOUT_KEY, LEADER_INSTALL_SNAPSHOT_STREAM_TIMEOUT_DEFAULT, getDefaultLog());
+    }
+    static void setLeaderInstallSnapshotStreamTimeout(RaftProperties properties,
+                                                      TimeDuration installSnapshotStreamTimeout) {
+      setTimeDuration(properties::setTimeDuration,
+          LEADER_INSTALL_SNAPSHOT_STREAM_TIMEOUT_KEY, installSnapshotStreamTimeout);
     }
 
     String HEARTBEAT_CHANNEL_KEY = PREFIX + ".heartbeat.channel";

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -69,6 +69,8 @@ public class GrpcLogAppender extends LogAppenderBase {
   private final boolean installSnapshotEnabled;
 
   private final TimeDuration requestTimeoutDuration;
+  private final TimeDuration installSnapshotStreamTimeout;
+  private final int maxOutstandingInstallSnapshots;
   private final TimeoutExecutor scheduler = TimeoutExecutor.getInstance();
 
   private volatile StreamObservers appendLogRequestObserver;
@@ -87,6 +89,9 @@ public class GrpcLogAppender extends LogAppenderBase {
     final RaftProperties properties = server.getRaftServer().getProperties();
     this.maxPendingRequestsNum = GrpcConfigKeys.Server.leaderOutstandingAppendsMax(properties);
     this.requestTimeoutDuration = RaftServerConfigKeys.Rpc.requestTimeout(properties);
+    this.maxOutstandingInstallSnapshots = GrpcConfigKeys.Server.leaderOutstandingInstallSnapshotsMax(properties);
+    this.installSnapshotStreamTimeout = GrpcConfigKeys.Server.leaderInstallSnapshotStreamTimeout(properties)
+        .multiply(maxOutstandingInstallSnapshots);
     this.installSnapshotEnabled = RaftServerConfigKeys.Log.Appender.installSnapshotEnabled(properties);
     this.useSeparateHBChannel = GrpcConfigKeys.Server.heartbeatChannel(properties);
 
@@ -594,8 +599,9 @@ public class GrpcLogAppender extends LogAppenderBase {
     StreamObserver<InstallSnapshotRequestProto> snapshotRequestObserver = null;
     final String requestId = UUID.randomUUID().toString();
     try {
-      snapshotRequestObserver = getClient().installSnapshot(getFollower().getName() + "-installSnapshot",
-          requestTimeoutDuration, 8, responseHandler); //FIXME: RATIS-1809
+      snapshotRequestObserver = getClient().installSnapshot(
+          getFollower().getName() + "-installSnapshot-" + requestId,
+          installSnapshotStreamTimeout, maxOutstandingInstallSnapshots, responseHandler);
       for (InstallSnapshotRequestProto request : newInstallSnapshotRequests(requestId, snapshot)) {
         if (isRunning()) {
           snapshotRequestObserver.onNext(request);

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -89,8 +89,8 @@ public class GrpcLogAppender extends LogAppenderBase {
     final RaftProperties properties = server.getRaftServer().getProperties();
     this.maxPendingRequestsNum = GrpcConfigKeys.Server.leaderOutstandingAppendsMax(properties);
     this.requestTimeoutDuration = RaftServerConfigKeys.Rpc.requestTimeout(properties);
-    this.maxOutstandingInstallSnapshots = GrpcConfigKeys.Server.leaderOutstandingInstallSnapshotsMax(properties);
-    this.installSnapshotStreamTimeout = GrpcConfigKeys.Server.leaderInstallSnapshotStreamTimeout(properties)
+    this.maxOutstandingInstallSnapshots = GrpcConfigKeys.Server.installSnapshotRequestElementLimit(properties);
+    this.installSnapshotStreamTimeout = GrpcConfigKeys.Server.installSnapshotRequestTimeout(properties)
         .multiply(maxOutstandingInstallSnapshots);
     this.installSnapshotEnabled = RaftServerConfigKeys.Log.Appender.installSnapshotEnabled(properties);
     this.useSeparateHBChannel = GrpcConfigKeys.Server.heartbeatChannel(properties);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Separate the timeout between
1. one-time unary gRPC call
2. streaming gRPC call (installSnapshot)

See https://issues.apache.org/jira/browse/RATIS-1809

## How was this patch tested?
existing unit tests.
