### PR TITLE
RATIS-1812. Enforce a outstanding request limit in StreamObserverWithTimeout

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -595,7 +595,7 @@ public class GrpcLogAppender extends LogAppenderBase {
     final String requestId = UUID.randomUUID().toString();
     try {
       snapshotRequestObserver = getClient().installSnapshot(getFollower().getName() + "-installSnapshot",
-          requestTimeoutDuration, responseHandler);
+          requestTimeoutDuration, 8, responseHandler); //FIXME: RATIS-1809
       for (InstallSnapshotRequestProto request : newInstallSnapshotRequests(requestId, snapshot)) {
         if (isRunning()) {
           snapshotRequestObserver.onNext(request);
@@ -646,7 +646,7 @@ public class GrpcLogAppender extends LogAppenderBase {
     }
     try {
       snapshotRequestObserver = getClient().installSnapshot(getFollower().getName() + "-notifyInstallSnapshot",
-          requestTimeoutDuration, responseHandler);
+          requestTimeoutDuration, 0, responseHandler);
 
       snapshotRequestObserver.onNext(request);
       getFollower().updateLastRpcSendTime(false);

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -137,8 +137,8 @@ public class GrpcServerProtocolClient implements Closeable {
   }
 
   StreamObserver<InstallSnapshotRequestProto> installSnapshot(
-      String name, TimeDuration timeout, StreamObserver<InstallSnapshotReplyProto> responseHandler) {
-    return StreamObserverWithTimeout.newInstance(name, timeout,
+      String name, TimeDuration timeout, int limit, StreamObserver<InstallSnapshotReplyProto> responseHandler) {
+    return StreamObserverWithTimeout.newInstance(name, timeout, limit,
         i -> asyncStub.withInterceptors(i).installSnapshot(responseHandler));
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/InstallSnapshotRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/InstallSnapshotRequests.java
@@ -113,7 +113,7 @@ class InstallSnapshotRequests implements Iterable<InstallSnapshotRequestProto> {
   private InstallSnapshotRequestProto nextInstallSnapshotRequestProto() {
     final int numFiles = snapshot.getFiles().size();
     if (fileIndex >= numFiles) {
-      throw new NoSuchElementException();
+      throw new NoSuchElementException("fileIndex = " + fileIndex + " >= numFiles = " + numFiles);
     }
     final FileInfo info = snapshot.getFiles().get(fileIndex);
     try {

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/util/GrpcTestClient.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/util/GrpcTestClient.java
@@ -53,7 +53,7 @@ class GrpcTestClient implements Closeable {
   }
 
   static StreamObserverFactory withTimeout(TimeDuration timeout) {
-    return (stub, responseHandler) -> StreamObserverWithTimeout.newInstance("test", timeout,
+    return (stub, responseHandler) -> StreamObserverWithTimeout.newInstance("test", timeout, 2,
         i -> stub.withInterceptors(i).hello(responseHandler));
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/util/TestStreamObserverWithTimeout.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/util/TestStreamObserverWithTimeout.java
@@ -92,9 +92,6 @@ public class TestStreamObserverWithTimeout extends BaseTest {
 
         final List<CompletableFuture<String>> futures = new ArrayList<>();
         for (String m : messages) {
-          if (type == Type.WithTimeout) {
-            timeout.sleep();
-          }
           futures.add(client.send(m));
         }
 

--- a/ratis-test/src/test/java/org/apache/ratis/util/TestResourceSemaphore.java
+++ b/ratis-test/src/test/java/org/apache/ratis/util/TestResourceSemaphore.java
@@ -24,17 +24,17 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeoutException;
 
-import static org.apache.ratis.util.ResourceSemaphore.ResourceAcquireStatus.FAILED_IN_BYTE_SIZE_LIMIT;
-import static org.apache.ratis.util.ResourceSemaphore.ResourceAcquireStatus.FAILED_IN_ELEMENT_LIMIT;
-import static org.apache.ratis.util.ResourceSemaphore.ResourceAcquireStatus.SUCCESS;
+import static org.apache.ratis.util.ResourceSemaphore.Group.SUCCESS;
 
 public class TestResourceSemaphore extends BaseTest {
   @Test(timeout = 5000)
   public void testGroup() throws InterruptedException, TimeoutException {
+    final int FAILED_IN_ELEMENT_LIMIT = 0;
+    final int FAILED_IN_BYTE_SIZE_LIMIT = 1;
     final ResourceSemaphore.Group g = new ResourceSemaphore.Group(3, 1);
 
     assertUsed(g, 0, 0);
-    assertAcquire(g, ResourceSemaphore.ResourceAcquireStatus.SUCCESS, 1, 1);
+    assertAcquire(g, SUCCESS, 1, 1);
     assertUsed(g, 1, 1);
     assertAcquire(g, FAILED_IN_BYTE_SIZE_LIMIT, 1, 1);
     assertUsed(g, 1, 1);
@@ -86,9 +86,8 @@ public class TestResourceSemaphore extends BaseTest {
     }
   }
 
-  static void assertAcquire(ResourceSemaphore.Group g, ResourceSemaphore.ResourceAcquireStatus expected,
-      int... permits) {
-    final ResourceSemaphore.ResourceAcquireStatus computed = g.tryAcquire(permits);
+  static void assertAcquire(ResourceSemaphore.Group g, int expected, int... permits) {
+    final int computed = g.tryAcquire(permits);
     Assert.assertEquals(expected, computed);
   }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1812