### PR TITLE
RATIS-1813. Allow ratis-shell to run in any JDK 8+ version

### DIFF
--- a/ratis-shell/src/main/libexec/ratis-shell-config.sh
+++ b/ratis-shell/src/main/libexec/ratis-shell-config.sh
@@ -50,12 +50,12 @@ if [[ -z "${JAVA}" ]]; then
   fi
 fi
 
-# Check Java version == 1.8 or == 11
+# Check Java version == 1.8 or >= 8
 JAVA_VERSION=$(${JAVA} -version 2>&1 | awk -F '"' '/version/ {print $2}')
-JAVA_MAJORMINOR=$(echo "${JAVA_VERSION}" | awk -F. '{printf("%03d%03d",$1,$2);}')
-JAVA_MAJOR=$(echo "${JAVA_VERSION}" | awk -F. '{printf("%03d",$1);}')
-if [[ ${JAVA_MAJORMINOR} != 001008 && ${JAVA_MAJOR} != 011 ]]; then
-  echo "Error: ratis-shell requires Java 8 or Java 11, currently Java $JAVA_VERSION found."
+JAVA_MAJORMINOR=$(echo "${JAVA_VERSION}" | awk -F. '{printf "%d.%d",$1,$2}')
+JAVA_MAJOR=$(echo "${JAVA_VERSION}" | awk -F. '{print $1}')
+if [[ ${JAVA_MAJORMINOR} != 1.8 && ${JAVA_MAJOR} -lt 8 ]]; then
+  echo "Error: ratis-shell requires Java 8+, currently Java $JAVA_VERSION found."
   exit 1
 fi
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is mainly for supporting Java 17, but any other Java 8+ version should be allowed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1813

## How was this patch tested?

 Before

```console
$ bin/ratis sh
Error: ratis-shell requires Java 8 or Java 11, currently Java 17.0.6 found. 
```

After (tested in Java 8 and Java 17)

```console
$ bin/ratis sh
[main] INFO org.reflections.Reflections - Reflections took 32 ms to scan 1 urls, producing 5 keys and 18 values
Usage: ratis sh [generic options]
	 [election [transfer] [stepDown] [pause] [resume]]         
	 [group [info] [list]]                                     
	 [peer [add] [remove] [setPriority]]                       
	 [snapshot [create]]                                       
```