### PR TITLE
RATIS-1815. GitHub: Enable autolink to Jira

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,6 +24,7 @@ github:
     squash:  true
     merge:   false
     rebase:  false
+  autolink_jira: RATIS
 
 notifications:
   commits:      commits@ratis.apache.org


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable autolink to Jira on GitHub.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1815

## How was this patch tested?

For example:
https://github.com/apache/flink-connector-kafka/commits/main
https://github.com/apache/incubator-celeborn/commits/main