### PR TITLE
RATIS-1817. Do not send StartLeaderElection when leaderLastEntry is null

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
@@ -184,12 +184,16 @@ public class TransferLeadership {
   static Result isFollowerUpToDate(FollowerInfo follower, TermIndex leaderLastEntry) {
     if (follower == null) {
       return Result.NULL_FOLLOWER;
-    } else if (leaderLastEntry != null) {
-      final long followerMatchIndex = follower.getMatchIndex();
-      if (followerMatchIndex < leaderLastEntry.getIndex()) {
-        return new Result(Result.Type.NOT_UP_TO_DATE, "followerMatchIndex = " + followerMatchIndex
-            + " < leaderLastEntry.getIndex() = " + leaderLastEntry.getIndex());
-      }
+    }
+    if (leaderLastEntry == null) {
+      // The transferee is expecting leaderLastEntry to be non-null,
+      // return NOT_UP_TO_DATE to indicate TransferLeadership should wait.
+      return new Result(Result.Type.NOT_UP_TO_DATE, "leaderLastEntry is null");
+    }
+    final long followerMatchIndex = follower.getMatchIndex();
+    if (followerMatchIndex < leaderLastEntry.getIndex()) {
+      return new Result(Result.Type.NOT_UP_TO_DATE, "followerMatchIndex = " + followerMatchIndex
+          + " < leaderLastEntry.getIndex() = " + leaderLastEntry.getIndex());
     }
     return Result.SUCCESS;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should not send StartLeaderElection to the transferee when `leaderLastEntry` is null.
Because `leaderLastEntry` is expected to be non-null in `RaftServerImpl#startLeaderElection`:

```java
if (leaderLastEntry == null) {
  LOG.warn("{}: receive null leaderLastEntry which is unexpected", getMemberId());
  return ServerProtoUtils.toStartLeaderElectionReplyProto(leaderId, getMemberId(), false);
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1817

## How was this patch tested?

Existing tests in CI.
