### PR TITLE
RATIS-1818. Make StartLeaderElection idempotent

### DIFF
--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -472,6 +472,7 @@ message SnapshotCreateRequestProto {
 message StartLeaderElectionRequestProto {
   RaftRpcRequestProto serverRequest = 1;
   TermIndexProto leaderLastEntry = 2;
+  uint64 term = 3;
 }
 
 message StartLeaderElectionReplyProto {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
@@ -66,9 +66,10 @@ final class ServerProtoUtils {
   }
 
   static StartLeaderElectionRequestProto toStartLeaderElectionRequestProto(
-      RaftGroupMemberId requestorId, RaftPeerId replyId, TermIndex lastEntry) {
+      RaftGroupMemberId requestorId, RaftPeerId replyId, long term, TermIndex lastEntry) {
     final StartLeaderElectionRequestProto.Builder b = StartLeaderElectionRequestProto.newBuilder()
-        .setServerRequest(ClientProtoUtils.toRaftRpcRequestProtoBuilder(requestorId, replyId));
+        .setServerRequest(ClientProtoUtils.toRaftRpcRequestProtoBuilder(requestorId, replyId))
+        .setTerm(term);
     if (lastEntry != null) {
       b.setLeaderLastEntry(lastEntry.toProto());
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/TransferLeadership.java
@@ -203,11 +203,12 @@ public class TransferLeadership {
     }
 
     final RaftPeerId transferee = follower.getId();
-    LOG.info("{}: sendStartLeaderElection to follower {}, lastEntry={}",
-        server.getMemberId(), transferee, lastEntry);
+    final long term = server.getState().getCurrentTerm();
+    LOG.info("{}: sendStartLeaderElection to follower {} in term {}, lastEntry={}",
+        server.getMemberId(), transferee, term, lastEntry);
 
     final RaftProtos.StartLeaderElectionRequestProto r = ServerProtoUtils.toStartLeaderElectionRequestProto(
-        server.getMemberId(), transferee, lastEntry);
+        server.getMemberId(), transferee, term, lastEntry);
     final CompletableFuture<RaftProtos.StartLeaderElectionReplyProto> f = CompletableFuture.supplyAsync(() -> {
       server.getLeaderElectionMetrics().onTransferLeadership();
       try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, it is possible for a leader at term `x` to send StartLeaderElection twice to a follower, making the follower become term `x + 2`.

We can make StartLeaderElection idempotent by including a `term` in StartLeaderElectionRequest. And the receiver should ignore the StartLeaderElectionRequest from lower term.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1818

## How was this patch tested?

TODO.