### PR TITLE
RATIS-1819. Use Maven Wrapper in CI workflows

### DIFF
--- a/dev-support/checks/_mvn_unit_report.sh
+++ b/dev-support/checks/_mvn_unit_report.sh
@@ -75,7 +75,7 @@ for failed_test in $(< ${REPORT_DIR}/summary.txt); do
 done
 
 ## Check if Maven was killed
-if grep -q 'Killed.* mvn .* test ' "${REPORT_DIR}/output.log"; then
+if grep -q "Killed.* ${MVN} .* test " "${REPORT_DIR}/output.log"; then
   echo 'Maven test run was killed' >> "${REPORT_DIR}/summary.txt"
 fi
 

--- a/dev-support/checks/build.sh
+++ b/dev-support/checks/build.sh
@@ -16,6 +16,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../.." || exit 1
 
+source "${DIR}/../find_maven.sh"
+
 export MAVEN_OPTS="-Xmx4096m"
-mvn -V -B -Dmaven.javadoc.skip=true -DskipTests clean install "$@"
+${MVN} -V -B -Dmaven.javadoc.skip=true -DskipTests clean install "$@"
 exit $?

--- a/dev-support/checks/checkstyle.sh
+++ b/dev-support/checks/checkstyle.sh
@@ -16,6 +16,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../.." || exit 1
 
+source "${DIR}/../find_maven.sh"
+
 BASE_DIR="$(pwd -P)"
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../target/checkstyle"}
 mkdir -p "$REPORT_DIR"
@@ -24,10 +26,10 @@ REPORT_FILE="$REPORT_DIR/summary.txt"
 MAVEN_OPTIONS='-B -fae -Dcheckstyle.failOnViolation=false'
 
 declare -i rc
-mvn ${MAVEN_OPTIONS} checkstyle:check | tee  "${REPORT_DIR}/output.log"
+${MVN} ${MAVEN_OPTIONS} checkstyle:check | tee  "${REPORT_DIR}/output.log"
 rc=$?
 if [[ ${rc} -ne 0 ]]; then
-  mvn ${MAVEN_OPTIONS} clean test-compile checkstyle:check
+  ${MVN} ${MAVEN_OPTIONS} clean test-compile checkstyle:check
   rc=$?
   mkdir -p "$REPORT_DIR" # removed by mvn clean
 else

--- a/dev-support/checks/findbugs.sh
+++ b/dev-support/checks/findbugs.sh
@@ -16,16 +16,18 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../.." || exit 1
 
+source "${DIR}/../find_maven.sh"
+
 MAVEN_OPTIONS='-B -fae'
 
 if ! type unionBugs >/dev/null 2>&1 || ! type convertXmlToText >/dev/null 2>&1; then
   #shellcheck disable=SC2086
-  mvn ${MAVEN_OPTIONS} test-compile spotbugs:check
+  ${MVN} ${MAVEN_OPTIONS} test-compile spotbugs:check
   exit $?
 fi
 
 #shellcheck disable=SC2086
-mvn ${MAVEN_OPTIONS} test-compile spotbugs:spotbugs
+${MVN} ${MAVEN_OPTIONS} test-compile spotbugs:spotbugs
 rc=$?
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../target/findbugs"}

--- a/dev-support/checks/rat.sh
+++ b/dev-support/checks/rat.sh
@@ -16,12 +16,14 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../.." || exit 1
 
+source "${DIR}/../find_maven.sh"
+
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../target/rat"}
 mkdir -p "$REPORT_DIR"
 
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-mvn -B -fn org.apache.rat:apache-rat-plugin:0.13:check
+${MVN} -B -fn org.apache.rat:apache-rat-plugin:0.13:check
 
 cd "$DIR/../.." || exit 1
 

--- a/dev-support/checks/sonar.sh
+++ b/dev-support/checks/sonar.sh
@@ -16,8 +16,11 @@
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 cd "$DIR/../.." || exit 1
 
+source "${DIR}/../find_maven.sh"
+
 if [ ! "$SONAR_TOKEN" ]; then
   echo "SONAR_TOKEN environment variable should be set"
   exit 1
 fi
-mvn -B verify -DskipShade -DskipTests org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache-ratis
+
+${MVN} -B verify -DskipShade -DskipTests org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache-ratis

--- a/dev-support/checks/unit.sh
+++ b/dev-support/checks/unit.sh
@@ -19,6 +19,8 @@ set -o pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../.." || exit 1
 
+source "${DIR}/../find_maven.sh"
+
 : ${ITERATIONS:="1"}
 
 declare -i ITERATIONS
@@ -39,7 +41,7 @@ for i in $(seq 1 ${ITERATIONS}); do
     mkdir -p "${REPORT_DIR}"
   fi
 
-  mvn -B -fae test "$@" \
+  ${MVN} -B -fae test "$@" \
     | tee "${REPORT_DIR}/output.log"
   irc=$?
 

--- a/dev-support/find_maven.sh
+++ b/dev-support/find_maven.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function find_maven() {
+    if [ "$MAVEN" != "" ]; then
+      echo "${MAVEN}"
+    else
+      local DIR
+      DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+      ( cd "$DIR/.." || exit 1 ; echo "$( pwd -P )/mvnw" )
+    fi
+}
+
+MVN="$( find_maven )"
+export MVN

--- a/dev-support/make_rc.sh
+++ b/dev-support/make_rc.sh
@@ -27,17 +27,15 @@
 # Presumes your settings.xml all set up so can sign artifacts published to mvn, etc.
 set -e
 # Set mvn and mvnopts
-mvn=mvn
-if [ "$MAVEN" != "" ]; then
-  mvn="${MAVEN}"
-fi
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${DIR}/find_maven.sh"
 mvnopts="-Xmx1g"
 if [ "$MAVEN_OPTS" != "" ]; then
   mvnopts="${MAVEN_OPTS}"
 fi
 
 mvnGet() {
-  ${mvn} -q -Dexec.executable="echo" -Dexec.args="\${${1}}" --non-recursive \
+  ${MVN} -q -Dexec.executable="echo" -Dexec.args="\${${1}}" --non-recursive \
     org.codehaus.mojo:exec-maven-plugin:1.6.0:exec 2>/dev/null
 }
 
@@ -90,7 +88,7 @@ fi
 
 
 mvnFun() {
-  MAVEN_OPTS="${mvnopts}" ${mvn} -Dmaven.repo.local="${repodir}" "$@"
+  MAVEN_OPTS="${mvnopts}" ${MVN} -Dmaven.repo.local="${repodir}" "$@"
 }
 
 prepare-src() {

--- a/dev-support/run-test-repeatedly.sh
+++ b/dev-support/run-test-repeatedly.sh
@@ -24,10 +24,12 @@ fi
 TEST_PATTERN=$1
 TEST_NAME=`echo ${TEST_PATTERN} | cut -d# -f 1`
 
-MVN="mvn"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${DIR}/find_maven.sh"
+
 set -ex
 
-mvn clean
+${MVN} clean
 
 for i in `seq 1 99`;
 do


### PR DESCRIPTION
## What changes were proposed in this pull request?

Split from https://github.com/apache/ratis/pull/854. This is a follow-up for [RATIS-1795](https://issues.apache.org/jira/browse/RATIS-1795). By using Maven Wrapper in CI workflows, we build reproducibly as users/devs in local env.

## What is the link to the Apache JIRA

RATIS-1819

## How was this patch tested?

Should pass existing CI checks.

cc @szetszwo 
