### PR TITLE
RATIS-1662. Intermittent failure in testEnforceLeader

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -317,6 +317,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
       final RaftServer.Division currLeader = cluster.getLeader();
       LOG.info("try enforcing leader to " + newLeader + " but " +
           (currLeader == null ? "no leader for round " + i : "new leader is " + currLeader.getId()));
+      TimeDuration.ONE_SECOND.sleep();
     }
     LOG.info(cluster.printServers());
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/simulation/MiniRaftClusterWithSimulatedRpc.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/simulation/MiniRaftClusterWithSimulatedRpc.java
@@ -108,7 +108,7 @@ public class MiniRaftClusterWithSimulatedRpc extends MiniRaftCluster {
         .map(s -> serverRequestReply.getQueue(s.getId().toString()))
         .forEach(q -> q.delayTakeRequestTo.set(delayMs));
 
-    final long sleepMs = 3 * getTimeoutMax().toLong(TimeUnit.MILLISECONDS) / 2;
+    final long sleepMs = 3 * getTimeoutMax().toLong(TimeUnit.MILLISECONDS);
     Thread.sleep(sleepMs);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Increase sleep time in `blockQueueAndSetDelay()` to fix intermittent failure in `testEnforceLeader()`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1662

## How was this patch tested?

Repeat 400x in CI
Before: https://github.com/kaijchen/ratis/actions/runs/4477152298
After: https://github.com/kaijchen/ratis/actions/runs/4477155987