### PR TITLE
RATIS-1821. Upgrade ratis-thirdparty version to 1.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,11 +207,11 @@
     <maven.min.version>3.3.9</maven.min.version>
 
     <!-- Contains all shaded thirdparty dependencies -->
-    <ratis.thirdparty.version>1.0.3</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.4</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
     <shaded.protobuf.version>3.19.6</shaded.protobuf.version>
-    <shaded.grpc.version>1.48.1</shaded.grpc.version>
+    <shaded.grpc.version>1.51.1</shaded.grpc.version>
 
     <!-- Test properties -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/RATIS-1821