### PR TITLE
RATIS-1822. Disable first election on changeToFollower

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -545,6 +545,7 @@ class RaftServerImpl implements RaftServer.Division,
         role.shutdownFollowerState();
       }
       role.startFollowerState(this, reason);
+      firstElectionSinceStartup.set(false);
     }
     return metadataUpdated;
   }
@@ -1852,7 +1853,6 @@ class RaftServerImpl implements RaftServer.Division,
   }
 
   void onGroupLeaderElected() {
-    this.firstElectionSinceStartup.set(false);
     transferLeadership.complete(TransferLeadership.Result.SUCCESS);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, first election is disabled on `setLeader`. However, it does not cover all scenarios. For example, when a candidate receives `DISCOVERED_A_NEW_TERM` as the response to `PreVote`, it should also disable first election.

Therefore, I propose to disable first election on `changeToFollower`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1822

## How was this patch tested?
Existing unit tests.
