### PR TITLE
RATIS-1827. Update installed snapshot index only when InstallSnapshot is done

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -397,9 +397,11 @@ class ServerState {
     getStateMachineUpdater().notifyUpdater();
   }
 
-  void reloadStateMachine(long lastIndexInSnapshot) {
-    getLog().updateSnapshotIndex(lastIndexInSnapshot);
+  void reloadStateMachine(TermIndex snapshotTermIndex) {
     getStateMachineUpdater().reloadStateMachine();
+
+    getLog().onSnapshotInstalled(snapshotTermIndex.getIndex());
+    latestInstalledSnapshot.set(snapshotTermIndex);
   }
 
   void close() {
@@ -441,12 +443,6 @@ class ServerState {
     StateMachine sm = server.getStateMachine();
     sm.pause(); // pause the SM to prepare for install snapshot
     snapshotManager.installSnapshot(request, sm);
-    updateInstalledSnapshotIndex(TermIndex.valueOf(request.getSnapshotChunk().getTermIndex()));
-  }
-
-  void updateInstalledSnapshotIndex(TermIndex lastTermIndexInSnapshot) {
-    getLog().onSnapshotInstalled(lastTermIndexInSnapshot.getIndex());
-    latestInstalledSnapshot.set(lastTermIndexInSnapshot);
   }
 
   private SnapshotInfo getLatestSnapshot() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -478,6 +478,7 @@ public class SegmentedRaftLog extends RaftLogBase {
 
   @Override
   public CompletableFuture<Long> onSnapshotInstalled(long lastSnapshotIndex) {
+    updateSnapshotIndex(lastSnapshotIndex);
     fileLogWorker.syncWithSnapshot(lastSnapshotIndex);
     // TODO purge normal/tmp/corrupt snapshot files
     // if the last index in snapshot is larger than the index of the last

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
@@ -36,6 +36,7 @@ import org.apache.ratis.statemachine.impl.FileListSnapshotInfo;
 import org.apache.ratis.statemachine.impl.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.util.FileUtils;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.SizeInBytes;
 import org.junit.Assert;
@@ -116,11 +117,13 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
 
       // Check the installed snapshot file number on each Follower matches with the
       // leader snapshot.
-      for (RaftServer.Division follower : cluster.getFollowers()) {
-        final SnapshotInfo info = follower.getStateMachine().getLatestSnapshot();
-        Assert.assertNotNull(info);
-        Assert.assertEquals(3, info.getFiles().size());
-      }
+      JavaUtils.attempt(() -> {
+        for (RaftServer.Division follower : cluster.getFollowers()) {
+          final SnapshotInfo info = follower.getStateMachine().getLatestSnapshot();
+          Assert.assertNotNull(info);
+          Assert.assertEquals(3, info.getFiles().size());
+        }
+      }, 10, ONE_SECOND, "check snapshot", LOG);
     } finally {
       cluster.shutdown();
     }

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -320,7 +320,7 @@ public class TestSegmentedRaftLog extends BaseTest {
         ex = e;
       }
       assertTrue(ex.getMessage().contains("Difference between entry index and RaftLog's latest snapshot " +
-          "index -1 is greater than 1"));
+          "index 999 is greater than 1"));
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Installed snapshot index was updated when installSnapshot is not done,
causing TestLeaderInstallSnapshot to be flaky.

This PR combines `updateInstalledSnapshotIndex` with `reloadStateMachine`,
which will only be called when installSnapshot is done.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1827

## How was this patch tested?

* 100x testSeparateSnapshotInstallPath
  * before: https://github.com/kaijchen/ratis/actions/runs/4561132033
  * after: https://github.com/kaijchen/ratis/actions/runs/4561544643
* 100x testMultiFileInstallSnapshot
  * before: https://github.com/kaijchen/ratis/actions/runs/4561143974
  * after: https://github.com/kaijchen/ratis/actions/runs/4561548069