### PR TITLE
RATIS-1828. Enable TestServerRestartWithNetty

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/netty/TestServerRestartWithNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/netty/TestServerRestartWithNetty.java
@@ -18,11 +18,7 @@
 package org.apache.ratis.netty;
 
 import org.apache.ratis.server.ServerRestartTests;
-import org.junit.Ignore;
 
-// TODO: If all tests run together, the last test will fail with BindException.
-//       It can pass if the tests are run individually.
-@Ignore
 public class TestServerRestartWithNetty
     extends ServerRestartTests<MiniRaftClusterWithNetty>
     implements MiniRaftClusterWithNetty.FactoryGet {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable TestServerRestartWithNetty since it's no longer failing with BindException

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1828

## How was this patch tested?

Repeated a few runs in CI:

1. https://github.com/kaijchen/ratis/actions/runs/4605971572
2. https://github.com/kaijchen/ratis/actions/runs/4606036607
3. https://github.com/kaijchen/ratis/actions/runs/4606037179
4. https://github.com/kaijchen/ratis/actions/runs/4606038027
5. https://github.com/kaijchen/ratis/actions/runs/4606039730
