### PR TITLE
RATIS-1829. Support magic links to PR and JIRA in IDEA

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="RATIS\-\d+" />
+          <option name="linkRegexp" value="https://issues.apache.org/jira/browse/$0" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)"/>
+          <option name="linkRegexp" value="https://github.com/apache/ratis/pull/$1"/>
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
+</project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve dev experience when using IDEA. When I'm browsing among commits, I can jump to the associated PRs and JIRA tickets with a click.

This config file (trick) is also used by Flink - https://github.com/apache/flink/blob/master/.idea/vcs.xml

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/18818196/230726765-0c88b553-f021-4ac0-a643-28066650367b.png">

## What is the link to the Apache JIRA

~~Not yet. If it's good to go, I can create one.~~

RATIS-1829

## How was this patch tested?

Manually.

cc @szetszwo @SzyWilliam 
