### PR TITLE
RATIS-1832. Intermittent failure in TestStreamObserverWithTimeout

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/grpc/util/GrpcTestServer.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/util/GrpcTestServer.java
@@ -71,7 +71,7 @@ class GrpcTestServer implements Closeable {
 
     GreeterImpl(int slow, TimeDuration timeout) {
       this.slow = slow;
-      this.shortSleepTime = timeout.multiply(0.25);
+      this.shortSleepTime = timeout.multiply(0.1);
       this.longSleepTime = timeout.multiply(2);
     }
 

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/util/TestStreamObserverWithTimeout.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/util/TestStreamObserverWithTimeout.java
@@ -58,14 +58,14 @@ public class TestStreamObserverWithTimeout extends BaseTest {
   @Test
   public void testWithDeadline() throws Exception {
     //the total sleep time is within the deadline
-    runTestTimeout(2, Type.WithDeadline);
+    runTestTimeout(8, Type.WithDeadline);
   }
 
   @Test
   public void testWithDeadlineFailure() {
     //Expected to have DEADLINE_EXCEEDED
     testFailureCase("total sleep time is longer than the deadline",
-        () -> runTestTimeout(5, Type.WithDeadline),
+        () -> runTestTimeout(12, Type.WithDeadline),
         ExecutionException.class, StatusRuntimeException.class);
   }
 
@@ -73,7 +73,7 @@ public class TestStreamObserverWithTimeout extends BaseTest {
   public void testWithTimeout() throws Exception {
     //Each sleep time is within the timeout,
     //Note that the total sleep time is longer than the timeout, but it does not matter.
-    runTestTimeout(5, Type.WithTimeout);
+    runTestTimeout(12, Type.WithTimeout);
   }
 
   void runTestTimeout(int slow, Type type) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix flaky test TestStreamObserverWithTimeout

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1832

## How was this patch tested?

Repeat 400x TestStreamObserverWithTimeout in CI:
Before: https://github.com/kaijchen/ratis/actions/runs/4697491698
After: https://github.com/kaijchen/ratis/actions/runs/4697492709
