### PR TITLE
RATIS-1835. Keep nextIndex unchanged when leader sending heartbeat to restarting followers

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -128,6 +128,9 @@ public class GrpcLogAppender extends LogAppenderBase {
           " keep nextIndex ({}) unchanged and retry.", this, f.getNextIndex());
         return;
       }
+      if (request != null && request.isHeartbeat()) {
+        return;
+      }
       getFollower().decreaseNextIndex(nextIndex);
     } catch (IOException ie) {
       LOG.warn(this + ": Failed to getClient for " + getFollowerId(), ie);


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/RATIS-1835.

When a new leader is elected and starts sending heartbeats to followers, it will first send out an empty appendEntries RPC. If the target follower is down so that this heartbeat fails, the nextIndex of this follower will be set to 0.  see [Here](https://github.com/apache/ratis/blob/master/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java#L122-L131)

However, this strategy may cause unexpected errors. 

The leader will send a snapshot to the follower if the log with index 0 is not present. If the follower's log is fresher than this snapshot, an `IllegalStateException` will be thrown and the system cannot recover from this state. See [here](https://github.com/apache/ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java#L177-L179).

Therefore, this PR proposes to keep the nextIndex unchanged in `onError`::`resetClient`.