### PR TITLE
RATIS-1837. Restrict reading maxChunkSize bytes each installSnapshot RPC

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/FileChunkReader.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/FileChunkReader.java
@@ -20,6 +20,8 @@ package org.apache.ratis.server.storage;
 import org.apache.ratis.io.MD5Hash;
 import org.apache.ratis.proto.RaftProtos.FileChunkProto;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.com.google.protobuf.UnsafeByteOperations;
+import org.apache.ratis.util.IOUtils;
 import org.apache.ratis.util.JavaUtils;
 
 import java.io.Closeable;
@@ -72,7 +74,9 @@ public class FileChunkReader implements Closeable {
   public FileChunkProto readFileChunk(int chunkMaxSize) throws IOException {
     final long remaining = info.getFileSize() - offset;
     final int chunkLength = remaining < chunkMaxSize ? (int) remaining : chunkMaxSize;
-    final ByteString data = ByteString.readFrom(in, chunkLength);
+    final byte[] chunkBuffer = new byte[chunkLength];
+    IOUtils.readFully(in, chunkBuffer, 0, chunkBuffer.length);
+    final ByteString data = UnsafeByteOperations.unsafeWrap(chunkBuffer);
     // whether this chunk is the last chunk of current file
     final boolean isDone = offset + chunkLength == info.getFileSize();
     final ByteString fileDigest;


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1837
The observations refer to issue comments in https://github.com/apache/ratis/pull/876.

The cause is that `ByteString::readFrom` will drain out the inputStream and reads all data of a stream into memory, as stated in the doc https://javadoc.io/doc/com.google.protobuf/protobuf-java/2.5.0/com/google/protobuf/ByteString.html 
> Completely reads the given stream's bytes into a ByteString, blocking if necessary until all bytes are read through to the end of the stream.

When a snapshot file is of Gigabytes size, this `ByteString::readFrom` takes 6s to complete and by the time it returns, the follower already starves and starts a new election.
