### PR TITLE
RATIS-1843. Add existing markdown documents to site.xml in the ratis-docs project

### DIFF
--- a/ratis-docs/src/site/markdown/configurations.md
+++ b/ratis-docs/src/site/markdown/configurations.md
@@ -288,7 +288,6 @@ Ratis will temporarily stall the new IO Tasks.
 | **Description** | preserve logs when purging logs up to snapshot index |
 | **Type**        | long                                                 |
 | **Default**     | 0                                                    |
---------------------------------------------------------------------------------
 
 | **Property**    | `raft.server.log.segment.size.max`          |
 |:----------------|:--------------------------------------------|
@@ -307,28 +306,24 @@ Ratis will temporarily stall the new IO Tasks.
 | **Description** | the maximum byte size of segments caching log entries |
 | **Type**        | SizeInBytes                                           |
 | **Default**     | 200MB                                                 |
---------------------------------------------------------------------------------
 
 | **Property**    | `raft.server.log.preallocated.size` |
 |:----------------|:------------------------------------|
 | **Description** | preallocate size of log segment     |
 | **Type**        | SizeInBytes                         |
 | **Default**     | 4MB                                 |
---------------------------------------------------------------------------------
 
 | **Property**    | `raft.server.log.write.buffer.size`                         |
 |:----------------|:------------------------------------------------------------|
 | **Description** | size of direct byte buffer for SegmentedRaftLog FileChannel |
 | **Type**        | SizeInBytes                                                 |
 | **Default**     | 64KB                                                        |
---------------------------------------------------------------------------------
 
 | **Property**    | `raft.server.log.force.sync.num`                                                |
 |:----------------|:--------------------------------------------------------------------------------|
 | **Description** | perform RaftLog flush tasks when pending flush tasks num exceeds force.sync.num |
 | **Type**        | int                                                                             |
 | **Default**     | 128                                                                             |
---------------------------------------------------------------------------------
 
 | **Property**    | `raft.server.log.unsafe-flush.enabled`                                                        |
 |:----------------|:----------------------------------------------------------------------------------------------|
@@ -341,7 +336,6 @@ Ratis will temporarily stall the new IO Tasks.
 | **Description** | async-flush enables to flush the RaftLog asynchronously |
 | **Type**        | boolean                                                 |
 | **Default**     | false                                                   |
---------------------------------------------------------------------------------
 
 | **Property**    | `raft.server.log.corruption.policy`                          |
 |:----------------|:-------------------------------------------------------------|
@@ -488,7 +482,7 @@ The follower's statemachine is responsible for fetching and installing snapshot 
 | **Description** | maximumPoolSize for async request pool                   |
 | **Type**        | int                                                      |
 | **Default**     | 32                                                       |
---------------------------------------------------------------------------------
+
 
 | **Property**    | `raft.server.data-stream.async.write.thread.pool.cached` |
 |:----------------|:---------------------------------------------------------|
@@ -501,7 +495,7 @@ The follower's statemachine is responsible for fetching and installing snapshot 
 | **Description** | maximumPoolSize for async write pool                   |
 | **Type**        | int                                                    |
 | **Default**     | 16                                                     |
---------------------------------------------------------------------------------
+
 
 | **Property**    | `raft.server.data-stream.client.pool.size`  |
 |:----------------|:--------------------------------------------|

--- a/ratis-docs/src/site/site.xml
+++ b/ratis-docs/src/site/site.xml
@@ -35,6 +35,9 @@
             <item name="Getting Started" href="start/index.html"/>
             <item name="Concepts" href="concept/index.html"/>
             <item name="Ratis-shell" href="cli.html" />
+            <item name="Snapshot" href="snapshot.html" />
+            <item name="Metrics" href="metrics.html" />
+            <item name="Configurations" href="configurations.html" />
         </menu>
     </body>
 </project>

--- a/ratis-docs/src/site/site.xml
+++ b/ratis-docs/src/site/site.xml
@@ -32,12 +32,12 @@
         </links>
 
         <menu name="Apache Ratis">
-            <item name="Getting Started" href="start/index.html"/>
-            <item name="Concepts" href="concept/index.html"/>
+            <item name="Concepts" href="concept/index.html" />
+            <item name="Configurations" href="configurations.html" />
+            <item name="Getting Started" href="start/index.html" />
+            <item name="Metrics" href="metrics.html" />
             <item name="Ratis-shell" href="cli.html" />
             <item name="Snapshot" href="snapshot.html" />
-            <item name="Metrics" href="metrics.html" />
-            <item name="Configurations" href="configurations.html" />
         </menu>
     </body>
 </project>


### PR DESCRIPTION

## What changes were proposed in this pull request?

As a noob, I've been hoping for more documentation. I noticed some md files were merged but not added to site.xml.
According to [RATIS-1630](https://issues.apache.org/jira/browse/RATIS-1630)
Maybe we can add this markdown to site.xml so we can view the documentation locally.   
### after
![image](https://github.com/apache/ratis/assets/32935220/d79bec70-00bc-45dc-b03b-8a0fcc498ec7)   
When i view the document locally. I found some formatting issues like below:    
![image](https://github.com/apache/ratis/assets/32935220/46032564-a532-47b1-adcd-d5bd86b8f552)    
I fixed this at the issue:   
![image](https://github.com/apache/ratis/assets/32935220/4f0c9639-e0fd-4dc0-8dd9-5b901c62c41b)


## What is the link to the Apache JIRA

[RATIS-1843](https://issues.apache.org/jira/browse/RATIS-1843)


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
