### PR TITLE
RATIS-1848. Simplify PeerMap inheritance

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/PeerProxyMap.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/PeerProxyMap.java
@@ -94,11 +94,6 @@ public class PeerProxyMap<PROXY extends Closeable> implements RaftPeer.Add, Clos
     this.createProxy = createProxy;
   }
 
-  public PeerProxyMap(String name) {
-    this.name = name;
-    this.createProxy = this::createProxyImpl;
-  }
-
   public String getName() {
     return name;
   }
@@ -150,17 +145,13 @@ public class PeerProxyMap<PROXY extends Closeable> implements RaftPeer.Add, Clos
     optional.ifPresent(proxy -> closeProxy(proxy, pp));
   }
 
-  /** @return true if the given throwable is handled; otherwise, the call is an no-op, return false. */
+  /** @return true if the given throwable is handled; otherwise, the call is a no-op, return false. */
   public boolean handleException(RaftPeerId serverId, Throwable e, boolean reconnect) {
     if (reconnect || IOUtils.shouldReconnect(e)) {
       resetProxy(serverId);
       return true;
     }
     return false;
-  }
-
-  public PROXY createProxyImpl(RaftPeer peer) throws IOException {
-    throw new UnsupportedOperationException();
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

`createProxyImpl` is implemented for Netty variant only while the gRPC variant pass the handle to constructor directly. Perhaps it's better to use the same flavor so that improving readability and avoid unexpected `UnsupportedOperationException`.

## What is the link to the Apache JIRA

Chore work. If it's good to have and a JIRA ticket is required, I'll file one.

https://issues.apache.org/jira/browse/RATIS-1848

## How was this patch tested?

Compiled.
