### PR TITLE
RATIS-1853. When the stream server channelInactive, all requests in the channel.

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -417,7 +417,8 @@ public class DataStreamManagement {
       TimeoutExecutor.getInstance().onTimeout(channelInactiveGracePeriod,
           () -> {
             for (ClientInvocationId clientInvocationId : ids) {
-              Optional.ofNullable(streams.remove(clientInvocationId)).ifPresent(removed -> removed.getLocal().cleanUp());
+              Optional.ofNullable(streams.remove(clientInvocationId)).ifPresent(removed ->
+                  removed.getLocal().cleanUp());
             }
           },
           LOG, () -> "Timeout check failed, clientInvocationIds=" + streamIds);

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -64,7 +64,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -75,7 +74,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -168,6 +168,7 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
 
     this.channelInactiveGracePeriod = NettyConfigKeys.DataStream.Server
         .channelInactiveGracePeriod(properties);
+
     this.proxies = new ProxiesPool(name, properties, parameters);
 
     final boolean useEpoll = NettyConfigKeys.DataStream.Server.useEpoll(properties);
@@ -221,8 +222,6 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
       return ref.getAndSet(null);
     }
   }
-
-
 
   private ChannelInboundHandler newChannelInboundHandlerAdapter(){
     return new ChannelInboundHandlerAdapter(){

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -242,7 +242,7 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
 
       @Override
       public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        requests.cleanUpOnChannelInactive(ctx, channelInactiveGracePeriod);
+        requests.cleanUpOnChannelInactive(ctx.channel().id(), channelInactiveGracePeriod);
       }
 
       @Override

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -158,7 +158,6 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
 
   private final TimeDuration channelInactiveGracePeriod;
 
-
   public NettyServerStreamRpc(RaftServer server, Parameters parameters) {
     this.name = server.getId() + "-" + JavaUtils.getClassSimpleName(getClass());
     this.metrics = new NettyServerStreamRpcMetrics(this.name);


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the stream server channelInactive, all requests in the channel.

At the same time, there will be multiple stream sessions, using the same channel, for transmission, and when the connection is broken, we should clean up more stream sessions

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1853

