### PR TITLE
RATIS-1854 Remove useless error logs when closing the ratisclient writing thread

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
@@ -222,6 +222,8 @@ public interface GrpcUtil {
         if (!managedChannel.awaitTermination(3, TimeUnit.SECONDS)) {
           LOG.warn("Timed out gracefully shutting down connection: {}. ", managedChannel);
         }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       } catch (Exception e) {
         LOG.error("Unexpected exception while waiting for channel termination", e);
       }
@@ -234,6 +236,8 @@ public interface GrpcUtil {
         if (!managedChannel.awaitTermination(2, TimeUnit.SECONDS)) {
           LOG.warn("Timed out forcefully shutting down connection: {}. ", managedChannel);
         }
+      }catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       } catch (Exception e) {
         LOG.error("Unexpected exception while waiting for channel termination", e);
       }


### PR DESCRIPTION
see [jira1854](https://issues.apache.org/jira/browse/RATIS-1854?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)