### PR TITLE
RATIS-1856. Notify apply index change of all RaftLog entries

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
@@ -244,6 +244,8 @@ class StateMachineUpdater implements Runnable {
         if (f != null) {
           futures.get().add(f);
           f.thenAccept(m -> notifyAppliedIndex(incremented));
+        } else {
+          notifyAppliedIndex(incremented);
         }
       } else {
         LOG.debug("{}: logEntry {} is null. There may be snapshot to load. state:{}",

--- a/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
@@ -288,7 +288,7 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
     }
 
     private void timeoutIncrement() {
-      sleepQuietly(2500);
+      sleepQuietly(5000);
       increment();
     }
 

--- a/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestWithLongTimeoutTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestWithLongTimeoutTests.java
@@ -18,6 +18,7 @@
 package org.apache.ratis;
 
 import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.client.RaftClientConfigKeys;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
@@ -71,6 +72,7 @@ public abstract class ReadOnlyRequestWithLongTimeoutTests<CLUSTER extends MiniRa
     RaftServerConfigKeys.Rpc.setTimeoutMin(p, TimeDuration.valueOf(3, TimeUnit.SECONDS));
     RaftServerConfigKeys.Rpc.setTimeoutMax(p, TimeDuration.valueOf(6, TimeUnit.SECONDS));
     RaftServerConfigKeys.Rpc.setRequestTimeout(p, TimeDuration.valueOf(10, TimeUnit.SECONDS));
+    RaftClientConfigKeys.Rpc.setRequestTimeout(p, TimeDuration.valueOf(10, TimeUnit.SECONDS));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
`ReadIndex` depends on `StateMachineUpdater` to notify apply index changes. Current implementation only notifies when a `StateMachineLogEntry` is applied. 
In this PR, I propose to notify the `ReadIndex` listener when any types of RaftLog is applied.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1856

## How was this patch tested?
1.  unit tests.
2. manual test (perform `read-index read` successfully after configuration changes of a raft group).
