### PR TITLE
RATIS-1861. NullPointerException in readAsync when Ratis leader is changing

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -597,10 +597,11 @@ class RaftServerImpl implements RaftServer.Division,
     Preconditions.assertTrue(getInfo().isCandidate());
     role.shutdownLeaderElection();
     setRole(RaftPeerRole.LEADER, "changeToLeader");
+    role.updateLeaderState(this);
     state.becomeLeader();
 
     // start sending AppendEntries RPC to followers
-    final LogEntryProto e = role.startLeaderState(this);
+    final LogEntryProto e = role.startLeaderState();
     getState().setRaftConf(e);
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -597,11 +597,11 @@ class RaftServerImpl implements RaftServer.Division,
     Preconditions.assertTrue(getInfo().isCandidate());
     role.shutdownLeaderElection();
     setRole(RaftPeerRole.LEADER, "changeToLeader");
-    role.updateLeaderState(this);
+    final LeaderStateImpl leader = role.updateLeaderState(this);
     state.becomeLeader();
 
     // start sending AppendEntries RPC to followers
-    final LogEntryProto e = role.startLeaderState();
+    final LogEntryProto e = leader.start();
     getState().setRaftConf(e);
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
@@ -79,12 +79,8 @@ class RoleInfo {
     return Objects.requireNonNull(leaderState.get(), "leaderState is null");
   }
 
-  void updateLeaderState(RaftServerImpl server) {
-    updateAndGet(leaderState, new LeaderStateImpl(server));
-  }
-
-  LogEntryProto startLeaderState() {
-    return leaderState.get().start();
+  LeaderStateImpl updateLeaderState(RaftServerImpl server) {
+    return updateAndGet(leaderState, new LeaderStateImpl(server));
   }
 
   void shutdownLeaderState(boolean allowNull) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
@@ -18,7 +18,6 @@
 
 package org.apache.ratis.server.impl;
 
-import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.util.Preconditions;

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
@@ -79,8 +79,12 @@ class RoleInfo {
     return Objects.requireNonNull(leaderState.get(), "leaderState is null");
   }
 
-  LogEntryProto startLeaderState(RaftServerImpl server) {
-    return updateAndGet(leaderState, new LeaderStateImpl(server)).start();
+  void updateLeaderState(RaftServerImpl server) {
+    updateAndGet(leaderState, new LeaderStateImpl(server));
+  }
+
+  LogEntryProto startLeaderState() {
+    return leaderState.get().start();
   }
 
   void shutdownLeaderState(boolean allowNull) {


### PR DESCRIPTION
see [jira1861](https://issues.apache.org/jira/browse/RATIS-1861).