### PR TITLE
RATIS-1865. Add leader lease bound ratio configuration

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
@@ -76,6 +76,15 @@ public interface ConfUtils {
     };
   }
 
+  static BiConsumer<String, Double> requireMin(double min) {
+    return (key, value) -> {
+      if (value < min) {
+        throw new IllegalArgumentException(
+            key + " = " + value + " < min = " + min);
+      }
+    };
+  }
+
   static BiConsumer<String, Double> requireMax(double max) {
     return (key, value) -> {
       if (value > max) {

--- a/ratis-docs/src/site/markdown/configurations.md
+++ b/ratis-docs/src/site/markdown/configurations.md
@@ -187,7 +187,7 @@ treat the peer as caught-up. Increase this number when write throughput is high.
 
 | **Property**    | `raft.server.read.leader.lease.timeout.ratio` |
 |:----------------|:----------------------------------------------|
-| **Description** | maximum bound ratio of leader lease timeout   |
+| **Description** | maximum timeout ratio of leader lease         |
 | **Type**        | double, ranging from (0.0,1.0)                |
 | **Default**     | 0.9                                           |
 
@@ -601,8 +601,6 @@ First election timeout is introduced to reduce unavailable time when a RaftGroup
 | **Description** | when a leader steps down, it can't be re-elected until `wait-time` elapsed |
 | **Type**        | TimeDuration                                                               |
 | **Default**     | 10s                                                                        |
-
-
 
 | **Property**    | `raft.server.leaderelection.pre-vote` |
 |:----------------|:--------------------------------------|

--- a/ratis-docs/src/site/markdown/configurations.md
+++ b/ratis-docs/src/site/markdown/configurations.md
@@ -185,6 +185,13 @@ treat the peer as caught-up. Increase this number when write throughput is high.
 
 --------------------------------------------------------------------------------
 
+| **Property**    | `raft.server.read.leader.lease.timeout.ratio` |
+|:----------------|:----------------------------------------------|
+| **Description** | maximum bound ratio of leader lease timeout   |
+| **Type**        | double, ranging from (0.0,1.0)                |
+| **Default**     | 0.9                                           |
+
+
 ### Write - Configurations related to write requests.
 
 * Limits on pending write requests
@@ -595,12 +602,6 @@ First election timeout is introduced to reduce unavailable time when a RaftGroup
 | **Type**        | TimeDuration                                                               |
 | **Default**     | 10s                                                                        |
 
-
-| **Property**    | `raft.server.leaderelection.leader.lease.timeout-bound.ratio` |
-|:----------------|:--------------------------------------------------------------|
-| **Description** | maximum bound ratio of leader lease timeout                   |
-| **Type**        | int, ranging from (0,100]                                     |
-| **Default**     | 90                                                            |
 
 
 | **Property**    | `raft.server.leaderelection.pre-vote` |

--- a/ratis-docs/src/site/markdown/configurations.md
+++ b/ratis-docs/src/site/markdown/configurations.md
@@ -595,6 +595,14 @@ First election timeout is introduced to reduce unavailable time when a RaftGroup
 | **Type**        | TimeDuration                                                               |
 | **Default**     | 10s                                                                        |
 
+
+| **Property**    | `raft.server.leaderelection.leader.lease.timeout-bound.ratio` |
+|:----------------|:--------------------------------------------------------------|
+| **Description** | maximum bound ratio of leader lease timeout                   |
+| **Type**        | int, ranging from (0,100]                                     |
+| **Default**     | 90                                                            |
+
+
 | **Property**    | `raft.server.leaderelection.pre-vote` |
 |:----------------|:--------------------------------------|
 | **Description** | enable pre-vote                       |

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/DivisionProperties.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/DivisionProperties.java
@@ -47,14 +47,6 @@ public interface DivisionProperties {
     return maxRpcTimeout().toIntExact(TimeUnit.MILLISECONDS);
   }
 
-  /** @return the bound of leader lease timeout */
-  TimeDuration leaderLeaseTimeout();
-
-  /** @return the bound of leader lease timeout in milliseconds */
-  default int leaderLeaseTimeoutMs() {
-    return leaderLeaseTimeout().toIntExact(TimeUnit.MILLISECONDS);
-  }
-
   /** @return the rpc sleep time period. */
   TimeDuration rpcSleepTime();
 

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/DivisionProperties.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/DivisionProperties.java
@@ -47,6 +47,14 @@ public interface DivisionProperties {
     return maxRpcTimeout().toIntExact(TimeUnit.MILLISECONDS);
   }
 
+  /** @return the bound of leader lease timeout */
+  TimeDuration leaderLeaseTimeout();
+
+  /** @return the bound of leader lease timeout in milliseconds */
+  default int leaderLeaseTimeoutMs() {
+    return leaderLeaseTimeout().toIntExact(TimeUnit.MILLISECONDS);
+  }
+
   /** @return the rpc sleep time period. */
   TimeDuration rpcSleepTime();
 

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -773,13 +773,13 @@ public interface RaftServerConfigKeys {
 
     String LEADER_LEASE_TIMEOUT_BOUND_RATIO_KEY = PREFIX + ".leader.lease.timeout-bound.ratio";
     int LEADER_LEASE_TIMEOUT_BOUND_RATIO_DEFAULT = 90;
-    static int leaderLeaseTimeoutRatio(RaftProperties properties) {
+    static int leaderLeaseTimeoutBoundRatio(RaftProperties properties) {
       return getInt(properties::getInt, LEADER_LEASE_TIMEOUT_BOUND_RATIO_KEY,
           LEADER_LEASE_TIMEOUT_BOUND_RATIO_DEFAULT, getDefaultLog(),
           requireMin(0), requireMax(100));
     }
 
-    static void setLeaderLeaseTimeoutRatio(RaftProperties properties, int ratio) {
+    static void setLeaderLeaseTimeoutBoundRatio(RaftProperties properties, int ratio) {
       setInt(properties::setInt, LEADER_LEASE_TIMEOUT_BOUND_RATIO_KEY, ratio);
     }
   }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -773,7 +773,7 @@ public interface RaftServerConfigKeys {
 
     String LEADER_LEASE_TIMEOUT_BOUND_RATIO_KEY = PREFIX + ".leader.lease.timeout-bound.ratio";
     int LEADER_LEASE_TIMEOUT_BOUND_RATIO_DEFAULT = 90;
-    static int getLeaderLeaseTimeoutRatio(RaftProperties properties) {
+    static int leaderLeaseTimeoutRatio(RaftProperties properties) {
       return getInt(properties::getInt, LEADER_LEASE_TIMEOUT_BOUND_RATIO_KEY,
           LEADER_LEASE_TIMEOUT_BOUND_RATIO_DEFAULT, getDefaultLog(),
           requireMin(0), requireMax(100));

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -191,6 +191,18 @@ public interface RaftServerConfigKeys {
     static void setOption(RaftProperties properties, Option option) {
       set(properties::setEnum, OPTION_KEY, option);
     }
+
+    String LEADER_LEASE_TIMEOUT_RATIO_KEY = PREFIX + ".leader.lease.timeout.ratio";
+    double LEADER_LEASE_TIMEOUT_RATIO_DEFAULT = 0.9;
+    static double leaderLeaseTimeoutRatio(RaftProperties properties) {
+      return getDouble(properties::getDouble, LEADER_LEASE_TIMEOUT_RATIO_KEY,
+          LEADER_LEASE_TIMEOUT_RATIO_DEFAULT, getDefaultLog(),
+          requireMin(0.0), requireMax(1.0));
+    }
+
+    static void setLeaderLeaseTimeoutRatio(RaftProperties properties, double ratio) {
+      setDouble(properties::setDouble, LEADER_LEASE_TIMEOUT_RATIO_KEY, ratio);
+    }
   }
 
   interface Write {
@@ -769,18 +781,6 @@ public interface RaftServerConfigKeys {
     }
     static void setSlownessTimeout(RaftProperties properties, TimeDuration expiryTime) {
       setTimeDuration(properties::setTimeDuration, SLOWNESS_TIMEOUT_KEY, expiryTime);
-    }
-
-    String LEADER_LEASE_TIMEOUT_BOUND_RATIO_KEY = PREFIX + ".leader.lease.timeout-bound.ratio";
-    int LEADER_LEASE_TIMEOUT_BOUND_RATIO_DEFAULT = 90;
-    static int leaderLeaseTimeoutBoundRatio(RaftProperties properties) {
-      return getInt(properties::getInt, LEADER_LEASE_TIMEOUT_BOUND_RATIO_KEY,
-          LEADER_LEASE_TIMEOUT_BOUND_RATIO_DEFAULT, getDefaultLog(),
-          requireMin(0), requireMax(100));
-    }
-
-    static void setLeaderLeaseTimeoutBoundRatio(RaftProperties properties, int ratio) {
-      setInt(properties::setInt, LEADER_LEASE_TIMEOUT_BOUND_RATIO_KEY, ratio);
     }
   }
 

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -770,6 +770,18 @@ public interface RaftServerConfigKeys {
     static void setSlownessTimeout(RaftProperties properties, TimeDuration expiryTime) {
       setTimeDuration(properties::setTimeDuration, SLOWNESS_TIMEOUT_KEY, expiryTime);
     }
+
+    String LEADER_LEASE_TIMEOUT_BOUND_RATIO_KEY = PREFIX + ".leader.lease.timeout-bound.ratio";
+    int LEADER_LEASE_TIMEOUT_BOUND_RATIO_DEFAULT = 90;
+    static int getLeaderLeaseTimeoutRatio(RaftProperties properties) {
+      return getInt(properties::getInt, LEADER_LEASE_TIMEOUT_BOUND_RATIO_KEY,
+          LEADER_LEASE_TIMEOUT_BOUND_RATIO_DEFAULT, getDefaultLog(),
+          requireMin(0), requireMax(100));
+    }
+
+    static void setLeaderLeaseTimeoutRatio(RaftProperties properties, int ratio) {
+      setInt(properties::setInt, LEADER_LEASE_TIMEOUT_BOUND_RATIO_KEY, ratio);
+    }
   }
 
   /** server retry cache related */

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
@@ -55,7 +55,7 @@ class DivisionPropertiesImpl implements DivisionProperties {
     return rpcTimeoutMax;
   }
 
-  @Override
+  /** @return the ratio of leader lease timeout */
   public TimeDuration leaderLeaseTimeout() {
     return leaderLeaseTimeout;
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
@@ -36,7 +36,7 @@ class DivisionPropertiesImpl implements DivisionProperties {
     Preconditions.assertTrue(rpcTimeoutMax.compareTo(rpcTimeoutMin) >= 0,
         "rpcTimeoutMax = %s < rpcTimeoutMin = %s", rpcTimeoutMax, rpcTimeoutMin);
 
-    final double leaderLeaseBoundRatio = RaftServerConfigKeys.Rpc.getLeaderLeaseTimeoutRatio(properties) * 1.0 / 100;
+    final double leaderLeaseBoundRatio = RaftServerConfigKeys.Rpc.leaderLeaseTimeoutRatio(properties) * 1.0 / 100;
     this.leaderLeaseTimeout = this.rpcTimeoutMin.multiply(leaderLeaseBoundRatio);
     Preconditions.assertTrue(rpcTimeoutMin.compareTo(leaderLeaseTimeout) >= 0,
         "rpcTimeoutMin = %s < leaderLeaseTimeout = %s", rpcTimeoutMin, leaderLeaseTimeout);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
@@ -36,8 +36,8 @@ class DivisionPropertiesImpl implements DivisionProperties {
     Preconditions.assertTrue(rpcTimeoutMax.compareTo(rpcTimeoutMin) >= 0,
         "rpcTimeoutMax = %s < rpcTimeoutMin = %s", rpcTimeoutMax, rpcTimeoutMin);
 
-    final double leaderLeaseBoundRatio = RaftServerConfigKeys.Rpc.leaderLeaseTimeoutBoundRatio(properties) * 1.0 / 100;
-    this.leaderLeaseTimeout = this.rpcTimeoutMin.multiply(leaderLeaseBoundRatio);
+    final double leaderLeaseTimeoutRatio = RaftServerConfigKeys.Read.leaderLeaseTimeoutRatio(properties);
+    this.leaderLeaseTimeout = this.rpcTimeoutMin.multiply(leaderLeaseTimeoutRatio);
     Preconditions.assertTrue(rpcTimeoutMin.compareTo(leaderLeaseTimeout) >= 0,
         "rpcTimeoutMin = %s < leaderLeaseTimeout = %s", rpcTimeoutMin, leaderLeaseTimeout);
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
@@ -36,7 +36,7 @@ class DivisionPropertiesImpl implements DivisionProperties {
     Preconditions.assertTrue(rpcTimeoutMax.compareTo(rpcTimeoutMin) >= 0,
         "rpcTimeoutMax = %s < rpcTimeoutMin = %s", rpcTimeoutMax, rpcTimeoutMin);
 
-    final double leaderLeaseBoundRatio = RaftServerConfigKeys.Rpc.leaderLeaseTimeoutRatio(properties) * 1.0 / 100;
+    final double leaderLeaseBoundRatio = RaftServerConfigKeys.Rpc.leaderLeaseTimeoutBoundRatio(properties) * 1.0 / 100;
     this.leaderLeaseTimeout = this.rpcTimeoutMin.multiply(leaderLeaseBoundRatio);
     Preconditions.assertTrue(rpcTimeoutMin.compareTo(leaderLeaseTimeout) >= 0,
         "rpcTimeoutMin = %s < leaderLeaseTimeout = %s", rpcTimeoutMin, leaderLeaseTimeout);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
@@ -28,12 +28,18 @@ class DivisionPropertiesImpl implements DivisionProperties {
   private final TimeDuration rpcTimeoutMax;
   private final TimeDuration rpcSleepTime;
   private final TimeDuration rpcSlownessTimeout;
+  private final TimeDuration leaderLeaseTimeout;
 
   DivisionPropertiesImpl(RaftProperties properties) {
     this.rpcTimeoutMin = RaftServerConfigKeys.Rpc.timeoutMin(properties);
     this.rpcTimeoutMax = RaftServerConfigKeys.Rpc.timeoutMax(properties);
     Preconditions.assertTrue(rpcTimeoutMax.compareTo(rpcTimeoutMin) >= 0,
         "rpcTimeoutMax = %s < rpcTimeoutMin = %s", rpcTimeoutMax, rpcTimeoutMin);
+
+    final double leaderLeaseBoundRatio = RaftServerConfigKeys.Rpc.getLeaderLeaseTimeoutRatio(properties) * 1.0 / 100;
+    this.leaderLeaseTimeout = this.rpcTimeoutMin.multiply(leaderLeaseBoundRatio);
+    Preconditions.assertTrue(rpcTimeoutMin.compareTo(leaderLeaseTimeout) >= 0,
+        "rpcTimeoutMin = %s < leaderLeaseTimeout = %s", rpcTimeoutMin, leaderLeaseTimeout);
 
     this.rpcSleepTime = RaftServerConfigKeys.Rpc.sleepTime(properties);
     this.rpcSlownessTimeout = RaftServerConfigKeys.Rpc.slownessTimeout(properties);
@@ -47,6 +53,11 @@ class DivisionPropertiesImpl implements DivisionProperties {
   @Override
   public TimeDuration maxRpcTimeout() {
     return rpcTimeoutMax;
+  }
+
+  @Override
+  public TimeDuration leaderLeaseTimeout() {
+    return leaderLeaseTimeout;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

See https://issues.apache.org/jira/browse/RATIS-1865.

Previous discussions in this thread at https://github.com/apache/ratis/pull/383#issuecomment-756887260 have concluded that the leader lease timeout ratio is unnecessary since the min-rpc-timeout provides sufficient safety. However, it's worth noting that CPU drifts among group peers can vary. Introducing this option enables users to adapt to diverse environments, such as CI or production settings.