### PR TITLE
RATIS-1866. Maintain leader lease after AppendEntries

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/Timestamp.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/Timestamp.java
@@ -51,6 +51,10 @@ public final class Timestamp implements Comparable<Timestamp> {
     return a.compareTo(b) > 0? a: b;
   }
 
+  public static Timestamp earliest(Timestamp a, Timestamp b) {
+    return a.compareTo(b) > 0? b: a;
+  }
+
   private final long nanos;
 
   private Timestamp(long nanos) {

--- a/ratis-common/src/main/java/org/apache/ratis/util/Timestamp.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/Timestamp.java
@@ -51,6 +51,7 @@ public final class Timestamp implements Comparable<Timestamp> {
     return a.compareTo(b) > 0? a: b;
   }
 
+  /** @return the earliest timestamp. */
   public static Timestamp earliest(Timestamp a, Timestamp b) {
     return a.compareTo(b) > 0? b: a;
   }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -390,10 +390,10 @@ public class GrpcLogAppender extends LogAppenderBase {
       AppendEntriesRequest request = pendingRequests.remove(reply);
       if (request != null) {
         request.stopRequestTimer(); // Update completion time
-        getFollower().updateLastAppendEntriesResponseTime(request.getSendTime()); // Update the last rpc time
-      } else {
-        getFollower().updateLastRpcResponseTime();
+        getFollower().updateLastRespondedAppendEntriesSendTime(request.getSendTime());
       }
+      getFollower().updateLastRpcResponseTime();
+
 
       if (LOG.isDebugEnabled()) {
         LOG.debug("{}: received {} reply {}, request={}",

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -394,7 +394,6 @@ public class GrpcLogAppender extends LogAppenderBase {
       }
       getFollower().updateLastRpcResponseTime();
 
-
       if (LOG.isDebugEnabled()) {
         LOG.debug("{}: received {} reply {}, request={}",
             this, firstResponseReceived? "a": "the first",

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
@@ -106,5 +106,5 @@ public interface FollowerInfo {
   Timestamp getLastRespondedAppendEntriesSendTime();
 
   /** Update lastRpcResponseTime and LastRespondedAppendEntriesSendTime */
-  void updateLastAppendEntriesResponseTime(Timestamp sendTime);
+  void updateLastRespondedAppendEntriesSendTime(Timestamp sendTime);
 }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
@@ -101,4 +101,10 @@ public interface FollowerInfo {
 
   /** @return the latest heartbeat send time. */
   Timestamp getLastHeartbeatSendTime();
+
+  /** @return the send time of last responded rpc */
+  Timestamp getLastRespondedAppendEntriesSendTime();
+
+  /** Update lastRpcResponseTime and LastRespondedAppendEntriesSendTime */
+  void updateLastAppendEntriesResponseTime(Timestamp sendTime);
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
@@ -28,18 +28,12 @@ class DivisionPropertiesImpl implements DivisionProperties {
   private final TimeDuration rpcTimeoutMax;
   private final TimeDuration rpcSleepTime;
   private final TimeDuration rpcSlownessTimeout;
-  private final TimeDuration leaderLeaseTimeout;
 
   DivisionPropertiesImpl(RaftProperties properties) {
     this.rpcTimeoutMin = RaftServerConfigKeys.Rpc.timeoutMin(properties);
     this.rpcTimeoutMax = RaftServerConfigKeys.Rpc.timeoutMax(properties);
     Preconditions.assertTrue(rpcTimeoutMax.compareTo(rpcTimeoutMin) >= 0,
         "rpcTimeoutMax = %s < rpcTimeoutMin = %s", rpcTimeoutMax, rpcTimeoutMin);
-
-    final double leaderLeaseTimeoutRatio = RaftServerConfigKeys.Read.leaderLeaseTimeoutRatio(properties);
-    this.leaderLeaseTimeout = this.rpcTimeoutMin.multiply(leaderLeaseTimeoutRatio);
-    Preconditions.assertTrue(rpcTimeoutMin.compareTo(leaderLeaseTimeout) >= 0,
-        "rpcTimeoutMin = %s < leaderLeaseTimeout = %s", rpcTimeoutMin, leaderLeaseTimeout);
 
     this.rpcSleepTime = RaftServerConfigKeys.Rpc.sleepTime(properties);
     this.rpcSlownessTimeout = RaftServerConfigKeys.Rpc.slownessTimeout(properties);
@@ -53,11 +47,6 @@ class DivisionPropertiesImpl implements DivisionProperties {
   @Override
   public TimeDuration maxRpcTimeout() {
     return rpcTimeoutMax;
-  }
-
-  /** @return the ratio of leader lease timeout */
-  public TimeDuration leaderLeaseTimeout() {
-    return leaderLeaseTimeout;
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -39,6 +39,7 @@ class FollowerInfoImpl implements FollowerInfo {
   private final AtomicReference<Timestamp> lastRpcResponseTime;
   private final AtomicReference<Timestamp> lastRpcSendTime;
   private final AtomicReference<Timestamp> lastHeartbeatSendTime;
+  private final AtomicReference<Timestamp> lastRespondedAppendEntriesSendTime;
   private final RaftLogIndex nextIndex;
   private final RaftLogIndex matchIndex = new RaftLogIndex("matchIndex", RaftLog.INVALID_LOG_INDEX);
   private final RaftLogIndex commitIndex = new RaftLogIndex("commitIndex", RaftLog.INVALID_LOG_INDEX);
@@ -57,6 +58,7 @@ class FollowerInfoImpl implements FollowerInfo {
     this.lastRpcResponseTime = new AtomicReference<>(lastRpcTime);
     this.lastRpcSendTime = new AtomicReference<>(lastRpcTime);
     this.lastHeartbeatSendTime = new AtomicReference<>(lastRpcTime);
+    this.lastRespondedAppendEntriesSendTime = new AtomicReference<>(lastRpcTime);
     this.nextIndex = new RaftLogIndex("nextIndex", nextIndex);
     this.caughtUp = caughtUp;
   }
@@ -201,5 +203,16 @@ class FollowerInfoImpl implements FollowerInfo {
   @Override
   public Timestamp getLastHeartbeatSendTime() {
     return lastHeartbeatSendTime.get();
+  }
+
+  @Override
+  public Timestamp getLastRespondedAppendEntriesSendTime() {
+    return lastRespondedAppendEntriesSendTime.get();
+  }
+
+  @Override
+  public void updateLastAppendEntriesResponseTime(Timestamp sendTime) {
+    updateLastRpcResponseTime();
+    lastRespondedAppendEntriesSendTime.set(sendTime);
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -211,8 +211,7 @@ class FollowerInfoImpl implements FollowerInfo {
   }
 
   @Override
-  public void updateLastAppendEntriesResponseTime(Timestamp sendTime) {
-    updateLastRpcResponseTime();
+  public void updateLastRespondedAppendEntriesSendTime(Timestamp sendTime) {
     lastRespondedAppendEntriesSendTime.set(sendTime);
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderLease.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderLease.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server.impl;
+
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.server.leader.FollowerInfo;
+import org.apache.ratis.util.Preconditions;
+import org.apache.ratis.util.Timestamp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public class LeaderLease {
+
+  private final long leaseTimeoutMs;
+  // TODO invalidate leader lease when stepDown / transferLeader
+  private final AtomicReference<Timestamp> lease = new AtomicReference<>(Timestamp.currentTime());
+
+  public LeaderLease(RaftProperties properties) {
+    final double leaseRatio = RaftServerConfigKeys.Read.leaderLeaseTimeoutRatio(properties);
+    Preconditions.assertTrue(leaseRatio > 0.0 && leaseRatio <= 1.0,
+        "leader ratio should sit in (0,1], now is " + leaseRatio);
+    this.leaseTimeoutMs = RaftServerConfigKeys.Rpc.timeoutMin(properties)
+        .multiply(leaseRatio)
+        .toIntExact(TimeUnit.MILLISECONDS);
+  }
+
+  boolean isValid() {
+    return lease.get().elapsedTimeMs() < leaseTimeoutMs;
+  }
+
+  void extendLeaderLease(Stream<FollowerInfo> allFollowers, Predicate<List<RaftPeerId>> hasMajority) {
+    // check the latest heartbeats of all peers (including those in transitional)
+    final List<RaftPeerId> activePeers = new ArrayList<>();
+    final List<Timestamp> lastRespondedAppendEntriesSendTimes = new ArrayList<>();
+
+    allFollowers.forEach(follower -> {
+      final Timestamp lastRespondedAppendEntriesSendTime = follower.getLastRespondedAppendEntriesSendTime();
+      lastRespondedAppendEntriesSendTimes.add(lastRespondedAppendEntriesSendTime);
+      if (lastRespondedAppendEntriesSendTime.elapsedTimeMs() < leaseTimeoutMs) {
+        activePeers.add(follower.getId());
+      }
+    });
+
+    if (hasMajority.test(activePeers)) {
+      // can extend leader lease
+      if (lastRespondedAppendEntriesSendTimes.isEmpty()) {
+        lease.set(Timestamp.currentTime());
+      } else {
+        Collections.sort(lastRespondedAppendEntriesSendTimes);
+        final Timestamp newLease =
+            lastRespondedAppendEntriesSendTimes.get(lastRespondedAppendEntriesSendTimes.size() / 2);
+        lease.set(newLease);
+      }
+    }
+  }
+}

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderLease.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderLease.java
@@ -77,16 +77,18 @@ class LeaderLease {
    * return maximum timestamp at when the majority of followers are known to be active
    * return {@link Timestamp#currentTime()} if peers are empty
    */
-  private Timestamp getMaxTimestampWithMajorityAck(List<FollowerInfo> peers) {
-    if (peers == null || peers.isEmpty()) {
+  private Timestamp getMaxTimestampWithMajorityAck(List<FollowerInfo> followers) {
+    if (followers == null || followers.isEmpty()) {
       return Timestamp.currentTime();
     }
 
-    final List<Timestamp> lastRespondedAppendEntriesSendTimes = peers.stream()
+    final int mid = followers.size() / 2;
+    return followers.stream()
         .map(FollowerInfo::getLastRespondedAppendEntriesSendTime)
         .sorted()
-        .collect(Collectors.toList());
-
-    return lastRespondedAppendEntriesSendTimes.get(lastRespondedAppendEntriesSendTimes.size() / 2);
+        .limit(mid+1)
+        .skip(mid)
+        .iterator()
+        .next();
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderLease.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderLease.java
@@ -67,14 +67,17 @@ class LeaderLease {
       return;
     }
 
-    lease.set(Timestamp.earliest(getMaxOfMajorityAck(current), getMaxOfMajorityAck(old)));
+    // update the new lease
+    final Timestamp newLease =
+        Timestamp.earliest(getMaxTimestampWithMajorityAck(current), getMaxTimestampWithMajorityAck(old));
+    lease.set(newLease);
   }
 
   /**
    * return maximum timestamp at when the majority of followers are known to be active
    * return {@link Timestamp#currentTime()} if peers are empty
    */
-  private Timestamp getMaxOfMajorityAck(List<FollowerInfo> peers) {
+  private Timestamp getMaxTimestampWithMajorityAck(List<FollowerInfo> peers) {
     if (peers == null || peers.isEmpty()) {
       return Timestamp.currentTime();
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -247,11 +247,6 @@ class LeaderStateImpl implements LeaderState {
     List<FollowerInfo> getOld() {
       return old;
     }
-
-    Stream<FollowerInfo> getCurrentAndOld() {
-      return Stream.concat(current.stream(),
-          Optional.ofNullable(old).map(List::stream).orElse(Stream.empty()));
-    }
   }
 
   static boolean isSameSize(List<FollowerInfo> infos, PeerConfiguration conf) {
@@ -1142,7 +1137,7 @@ class LeaderStateImpl implements LeaderState {
     // try extending the leader lease
     final RaftConfigurationImpl conf = server.getRaftConf();
     final CurrentOldFollowerInfos info = followerInfoMap.getFollowerInfos(conf);
-    lease.extendLeaderLease(info.getCurrentAndOld(), peers -> conf.hasMajority(peers, server.getId()));
+    lease.extend(info.getCurrent(), info.getOld(), peers -> conf.hasMajority(peers, server.getId()));
 
     return checkLeaderLease();
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
@@ -26,6 +26,7 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLogIOException;
 import org.apache.ratis.server.util.ServerStringUtils;
 import org.apache.ratis.statemachine.SnapshotInfo;
+import org.apache.ratis.util.Timestamp;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -73,9 +74,10 @@ class LogAppenderDefault extends LogAppenderBase {
         }
 
         resetHeartbeatTrigger();
+        final Timestamp sendTime = Timestamp.currentTime();
         getFollower().updateLastRpcSendTime(request.getEntriesCount() == 0);
         final AppendEntriesReplyProto r = getServerRpc().appendEntries(request);
-        getFollower().updateLastRpcResponseTime();
+        getFollower().updateLastAppendEntriesResponseTime(sendTime);
 
         getLeaderState().onFollowerCommitIndex(getFollower(), r.getFollowerCommit());
         return r;

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
@@ -77,7 +77,8 @@ class LogAppenderDefault extends LogAppenderBase {
         final Timestamp sendTime = Timestamp.currentTime();
         getFollower().updateLastRpcSendTime(request.getEntriesCount() == 0);
         final AppendEntriesReplyProto r = getServerRpc().appendEntries(request);
-        getFollower().updateLastAppendEntriesResponseTime(sendTime);
+        getFollower().updateLastRpcResponseTime();
+        getFollower().updateLastRespondedAppendEntriesSendTime(sendTime);
 
         getLeaderState().onFollowerCommitIndex(getFollower(), r.getFollowerCommit());
         return r;

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -43,6 +43,7 @@ import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.Slf4jUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.Timestamp;
+import org.apache.ratis.util.function.CheckedBiConsumer;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -639,6 +640,87 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
           20, HUNDRED_MILLIS, "check new leader", LOG);
     }
   }
+
+  private void runLeaseTest(CLUSTER cluster, CheckedBiConsumer<CLUSTER, Long, Exception> testCase) throws Exception {
+    final double leaseRatio = RaftServerConfigKeys.Read.leaderLeaseTimeoutRatio(getProperties());
+    final long leaseTimeoutMs = RaftServerConfigKeys.Rpc.timeoutMin(getProperties())
+        .multiply(leaseRatio)
+        .toIntExact(TimeUnit.MILLISECONDS);
+    testCase.accept(cluster, leaseTimeoutMs);
+  }
+
+  @Test
+  public void testLeaderLease() throws Exception {
+    // use a strict lease
+    RaftServerConfigKeys.Read.setLeaderLeaseTimeoutRatio(getProperties(), 0.5);
+    runWithNewCluster(3, c -> runLeaseTest(c, this::runTestLeaderLease));
+  }
+
+  void runTestLeaderLease(CLUSTER cluster, long leaseTimeoutMs) throws Exception {
+    final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster);
+    try (final RaftClient client = cluster.createClient(leader.getId())) {
+      client.io().send(new RaftTestUtil.SimpleMessage("message"));
+
+      Assert.assertTrue(leader.getInfo().isLeader());
+      Assert.assertTrue(leader.getInfo().isLeaderReady());
+      RaftServerTestUtil.assertLeaderLease(leader, true);
+
+      isolate(cluster, leader.getId());
+      Thread.sleep(leaseTimeoutMs);
+
+      Assert.assertTrue(leader.getInfo().isLeader());
+      Assert.assertTrue(leader.getInfo().isLeaderReady());
+      RaftServerTestUtil.assertLeaderLease(leader, false);
+    } finally {
+      deIsolate(cluster, leader.getId());
+    }
+  }
+
+  @Test
+  public void testLeaderLeaseDuringReconfiguration() throws Exception {
+    // use a strict lease
+    RaftServerConfigKeys.Read.setLeaderLeaseTimeoutRatio(getProperties(), 0.5);
+    runWithNewCluster(3, c -> runLeaseTest(c, this::runTestLeaderLeaseDuringReconfiguration));
+  }
+
+  void runTestLeaderLeaseDuringReconfiguration(CLUSTER cluster, long leaseTimeoutMs) throws Exception {
+    final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster);
+    try (final RaftClient client = cluster.createClient(leader.getId())) {
+      client.io().send(new RaftTestUtil.SimpleMessage("message"));
+
+      Assert.assertTrue(leader.getInfo().isLeader());
+      Assert.assertTrue(leader.getInfo().isLeaderReady());
+      RaftServerTestUtil.assertLeaderLease(leader, true);
+
+      final List<RaftServer.Division> followers = cluster.getFollowers();
+      final MiniRaftCluster.PeerChanges changes = cluster.addNewPeers(2, true);
+
+      // blocking the original 2 followers
+      BlockRequestHandlingInjection.getInstance().blockReplier(followers.get(0).getId().toString());
+      BlockRequestHandlingInjection.getInstance().blockReplier(followers.get(1).getId().toString());
+
+      // start reconfiguration in another thread, shall fail eventually
+      new Thread(() -> {
+        try {
+          client.admin().setConfiguration(changes.allPeersInNewConf);
+        } catch (IOException e) {
+          System.out.println("as expected: " + e.getMessage());
+        }
+      }).start();
+
+      Thread.sleep(leaseTimeoutMs);
+
+      Assert.assertTrue(leader.getInfo().isLeader());
+      Assert.assertTrue(leader.getInfo().isLeaderReady());
+      RaftServerTestUtil.assertLeaderLease(leader, false);
+
+    } finally {
+      BlockRequestHandlingInjection.getInstance().unblockAll();
+    }
+  }
+
+
+
 
   private static RaftServerImpl createMockServer(boolean alive) {
     final DivisionInfo info = mock(DivisionInfo.class);

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
@@ -147,6 +147,12 @@ public class RaftServerTestUtil {
     return getLeaderState(server).map(LeaderStateImpl::getLogAppenders).orElse(null);
   }
 
+  public static void assertLeaderLease(RaftServer.Division leader, boolean hasLease) {
+    final LeaderStateImpl l = getLeaderState(leader).orElse(null);
+    Assert.assertNotNull(l);
+    Assert.assertEquals(l.hasLease(), hasLease);
+  }
+
   public static void restartLogAppenders(RaftServer.Division server) {
     final LeaderStateImpl leaderState = getLeaderState(server).orElseThrow(
         () -> new IllegalStateException(server + " is not the leader"));


### PR DESCRIPTION
# What is a Leader Lease
In Raft, the leader is responsible for processing and coordinating client requests, replicating data among other followers, and maintaining the distributed state machine. 
Vanilla Raft requires the leader to obtain majority acknowledgements before serving every read requests. During normal operations, this prerequisite leads to unnecessary rpcs exchanged among the cluster, diminished read throughput and increased latency. 
The leader lease is a concept that allows the leader to maintain its leadership without obtaining majority acknowledgements for a certain period of time (lease duration), during which it can directly serve client read requests. 

# How to extend lease during normal operations
### Prerequisite
- Suppose the CPU clocks are perfectly synchronized among cluster machines.
- Let each AppendEntries request AE(i) contain a send time T(i)
### Initialize
Once a leader is elected and its authority being comfirmed by majorities through successfully replicating its first no-op log, the leader gains the lease. The lease validity starts from T(0).
### Renewal 
As long as the leader continues to send heartbeats and receives acknowledgments from a majority of other nodes, it can renew its lease. Theoretically, if the most recent acknowledged heartbeat was sent at time T(n), the validity of the new lease commences at T(n).
In practice, rather than updating the lease with every heartbeat, we opt for a more efficient approach by lazily updating the leader's lease upon each query. Here's how it works:
At time T(n), when the leader is questioned about its authority, it first collects the send times of the last replied AppendEntries from each of its followers, denoted as TR(1), TR(2), ..., TR(2n), sorted in descending order.
Next, it selects the maximum timestamp at when the majority of followers are known to be active, that is, TR(n). 
If TR(n) falls within the time range [T(n), T(n) + LeaseTimeoutDuration], then the lease can be successfully renewed.
### Revoke
If the lease is expired and the leader cannot renew it, it loses the lease and stops serving read-only requests directly.
# How to handle lease during configuration changes
During the configuration changes, the lease can only be renewed if acknowledgments be received by both the old group and the new group. It is the same to leader election restrictions during reconfiguration.
# What to do when forced step down
When a leader is forced down, its lease should be effectively revoked.
# How to handle CPU drifts
We can lower the ratio allowed for lease timeouts. If the CPU drifts are unbound, better not to use lease read :)

See https://issues.apache.org/jira/browse/RATIS-1866.
