### PR TITLE
RATIS-1868. Handling Netty back pressure when streaming ratis log

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -26,6 +26,7 @@ import org.apache.ratis.thirdparty.io.grpc.ManagedChannel;
 import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;
 import org.apache.ratis.thirdparty.io.grpc.netty.NegotiationType;
 import org.apache.ratis.thirdparty.io.grpc.netty.NettyChannelBuilder;
+import org.apache.ratis.thirdparty.io.grpc.stub.CallStreamObserver;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.proto.RaftProtos.*;
 import org.apache.ratis.proto.grpc.RaftServerProtocolServiceGrpc;
@@ -128,12 +129,12 @@ public class GrpcServerProtocolClient implements Closeable {
         .readIndex(request, s);
   }
 
-  StreamObserver<AppendEntriesRequestProto> appendEntries(
+  CallStreamObserver<AppendEntriesRequestProto> appendEntries(
       StreamObserver<AppendEntriesReplyProto> responseHandler, boolean isHeartbeat) {
     if (isHeartbeat && useSeparateHBChannel) {
-      return hbAsyncStub.appendEntries(responseHandler);
+      return (CallStreamObserver<AppendEntriesRequestProto>) hbAsyncStub.appendEntries(responseHandler);
     } else {
-      return asyncStub.appendEntries(responseHandler);
+      return (CallStreamObserver<AppendEntriesRequestProto>) asyncStub.appendEntries(responseHandler);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Delay putting more messages to `appendLog` stream until the stream is ready.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1868

## How was this patch tested?

Unit tested.


