### PR TITLE
RATIS-1870. Refactor hasMajority code during configuration changes

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -150,12 +151,17 @@ class PeerConfiguration {
 
   boolean hasMajority(Collection<RaftPeerId> others, RaftPeerId selfId) {
     Preconditions.assertTrue(!others.contains(selfId));
-    int num = 0;
-    if (contains(selfId)) {
-      num++;
+    return hasMajority(others::contains, contains(selfId));
+  }
+
+  boolean hasMajority(Predicate<RaftPeerId> activePeers, boolean includeSelf) {
+    if (peers.isEmpty() && !includeSelf) {
+      return true;
     }
-    for (RaftPeerId other : others) {
-      if (contains(other)) {
+
+    int num = includeSelf ? 1 : 0;
+    for (RaftPeerId peerId: peers.keySet()) {
+      if (activePeers.test(peerId)) {
         num++;
       }
     }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1870.

The patch includes two changes:
1. Add considerations on OldConf when deciding whether leader is working as `singleton`.
2. Move `hasMajority` related code to RaftConfigurationImpl.