### PR TITLE
RATIS-1873. Remove RetryCache assertion that doesn't hold

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1765,9 +1765,9 @@ class RaftServerImpl implements RaftServer.Division,
     final ClientInvocationId invocationId = ClientInvocationId.valueOf(logEntry.getStateMachineLogEntry());
     // update the retry cache
     final CacheEntry cacheEntry = retryCache.getOrCreateEntry(invocationId);
-    if (getInfo().isLeader()) {
-      Preconditions.assertTrue(cacheEntry != null && !cacheEntry.isCompletedNormally(),
-              "retry cache entry should be pending: %s", cacheEntry);
+    Preconditions.assertTrue(cacheEntry != null);
+    if (getInfo().isLeader() && !cacheEntry.isCompletedNormally()) {
+      LOG.warn("{} retry cache entry of leader should be pending: {}", this, cacheEntry);
     }
     if (cacheEntry.isFailed()) {
       retryCache.refreshEntry(new CacheEntry(cacheEntry.getKey()));


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1873.

An IllegalStateException is thrown on retry cache entry:
```
2023-08-14 21:59:51,099 [7@group-000200000003-StateMachineUpdater] ERR0R o.a.r.s.i.StateMachineUpdater:196 - 7@group-000200000003-StateMachineUpdater caught a Throwable. 
org.apache.ratis.server.raftlog.RaftLogIOException: java.lang.IllegalStateException: retry cache entry should be pending: l9@client-D8ECBF42B70A:done
    at org.apache.ratis.server.impl.RaftServerImpl.applyLogToStateMachine(RaftServerImpl.java:1780)
    at org.apache.ratis.server.impl.StateMachineUpdater.applyLog(StateMachineUpdater.java:242)
    at org.apache.ratis.server.impl.stateMachineUpdater.run(StateMachineUpdater.java:184)
    at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.IllegalStateException: retry cache entry should be pending: 19@client-D8ECBF42B70A:done
    at org.apache.ratis.util.Preconditions.assertTrue(Preconditions.java:60)
    at org.apache.ratis.server.impl.RaftServerImpl.replyPendingRequest(RaftServerImpl.java:1727)
    at org.apache.ratis.server.imp.RaftServerImp1.applyLogTostateMachine(RaftServerImp.java:1778)
```

This assertion may not remain valid in certain edge cases. For instance, when an `apply` operation takes too long (such as triggering a blocking snapshot process), the cached entry might expire, leading to the failure of this assertion. Therefore, we should consider changing this arbitrary assertion into a moderate warning.
