### PR TITLE
RATIS-1878. checkstyle fails with UnsupportedClassVersionError.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
 
     <!-- Maven plugin versions -->
     <maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
-    <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
     <maven-clover2-plugin.version>4.0.6</maven-clover2-plugin.version>
     <maven-pdf-plugin.version>1.6.1</maven-pdf-plugin.version>
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
@@ -189,7 +189,6 @@
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <copy-rename-maven-plugin.version>1.0</copy-rename-maven-plugin.version>
 
-    <checkstyle.version>10.9.2</checkstyle.version>
     <spotbugs.version>4.2.1</spotbugs.version>
     <spotbugs-plugin.version>4.2.0</spotbugs-plugin.version>
 
@@ -746,13 +745,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>${maven-checkstyle-plugin.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>${checkstyle.version}</version>
-          </dependency>
-        </dependencies>
         <configuration>
           <configLocation>dev-support/checkstyle.xml</configLocation>
           <failOnViolation>false</failOnViolation>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
-    <license-maven-plugin.version>4.1</license-maven-plugin.version>
+    <license-maven-plugin.version>2.2.0</license-maven-plugin.version>
 
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <copy-rename-maven-plugin.version>1.0</copy-rename-maven-plugin.version>
@@ -747,7 +747,7 @@
         <version>${maven-checkstyle-plugin.version}</version>
         <configuration>
           <configLocation>dev-support/checkstyle.xml</configLocation>
-          <failOnViolation>false</failOnViolation>
+          <failOnViolation>true</failOnViolation>
           <linkXRef>false</linkXRef>
         </configuration>
       </plugin>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1878

Let's upgrade maven-checkstyle-plugin version to 3.3.0 which uses checkstyle version 9.3 (the latest version supporting JDK 8) by default.  See https://maven.apache.org/plugins/maven-checkstyle-plugin/history.html