### PR TITLE
RATIS-1879. Handle RaftLog corruption when unsafe flush is enabled.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogConf.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogConf.java
@@ -41,18 +41,16 @@ public final class RaftLogConf {
   }
 
   private final long segmentMaxSize;
-
   private final int maxCachedSegments;
   private final long maxSegmentCacheSize;
-  private final SizeInBytes maxOpSize;
   private final boolean unsafeFlush;
+  private final SizeInBytes maxOpSize;
 
   private RaftLogConf(RaftProperties properties) {
     this.segmentMaxSize = RaftServerConfigKeys.Log.segmentSizeMax(properties).getSize();
     this.maxCachedSegments = RaftServerConfigKeys.Log.segmentCacheNumMax(properties);
     this.maxSegmentCacheSize = RaftServerConfigKeys.Log.segmentCacheSizeMax(properties).getSize();
     this.unsafeFlush = RaftServerConfigKeys.Log.unsafeFlushEnabled(properties);
-
     this.maxOpSize = RaftServerConfigKeys.Log.Appender.bufferByteLimit(properties);
   }
 
@@ -68,11 +66,11 @@ public final class RaftLogConf {
     return maxSegmentCacheSize;
   }
 
-  public SizeInBytes getMaxOpSize() {
-    return maxOpSize;
-  }
-
   public boolean isUnsafeFlush() {
     return unsafeFlush;
+  }
+
+  public SizeInBytes getMaxOpSize() {
+    return maxOpSize;
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogConf.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogConf.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server.raftlog;
+
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.util.MemoizedSupplier;
+import org.apache.ratis.util.SizeInBytes;
+
+import java.util.function.Supplier;
+
+/**
+ * {@link RaftLog} related {@link RaftServerConfigKeys}.
+ */
+public final class RaftLogConf {
+  private static final Supplier<RaftLogConf> DEFAULT = MemoizedSupplier.valueOf(() -> get(new RaftProperties()));
+
+  /** @return the default conf. */
+  public static RaftLogConf get() {
+    return DEFAULT.get();
+  }
+
+  /** @return the conf from the given properties. */
+  public static RaftLogConf get(RaftProperties properties) {
+    return new RaftLogConf(properties);
+  }
+
+  private final long segmentMaxSize;
+
+  private final int maxCachedSegments;
+  private final long maxSegmentCacheSize;
+  private final SizeInBytes maxOpSize;
+  private final boolean unsafeFlush;
+
+  private RaftLogConf(RaftProperties properties) {
+    this.segmentMaxSize = RaftServerConfigKeys.Log.segmentSizeMax(properties).getSize();
+    this.maxCachedSegments = RaftServerConfigKeys.Log.segmentCacheNumMax(properties);
+    this.maxSegmentCacheSize = RaftServerConfigKeys.Log.segmentCacheSizeMax(properties).getSize();
+    this.unsafeFlush = RaftServerConfigKeys.Log.unsafeFlushEnabled(properties);
+
+    this.maxOpSize = RaftServerConfigKeys.Log.Appender.bufferByteLimit(properties);
+  }
+
+  public long getSegmentMaxSize() {
+    return segmentMaxSize;
+  }
+
+  public int getMaxCachedSegments() {
+    return maxCachedSegments;
+  }
+
+  public long getMaxSegmentCacheSize() {
+    return maxSegmentCacheSize;
+  }
+
+  public SizeInBytes getMaxOpSize() {
+    return maxOpSize;
+  }
+
+  public boolean isUnsafeFlush() {
+    return unsafeFlush;
+  }
+}

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -161,8 +161,7 @@ public final class LogSegment implements Comparable<Long> {
     final LogSegment segment = newLogSegment(storage, startEnd, conf, raftLogMetrics);
     final CorruptionPolicy corruptionPolicy = CorruptionPolicy.get(storage, RaftStorage::getLogCorruptionPolicy);
     final boolean isOpen = startEnd.isOpen();
-    final int entryCount = readSegmentFile(file, startEnd, conf, corruptionPolicy, raftLogMetrics,
-        entry -> {
+    final int entryCount = readSegmentFile(file, startEnd, conf, corruptionPolicy, raftLogMetrics, entry -> {
       segment.append(keepEntryInCache || isOpen, entry, Op.LOAD_SEGMENT_FILE);
       if (logConsumer != null) {
         logConsumer.accept(entry);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -17,9 +17,7 @@
  */
 package org.apache.ratis.server.raftlog.segmented;
 
-import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
-import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.metrics.SegmentedRaftLogMetrics;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.LogEntryHeader;
@@ -33,7 +31,6 @@ import org.apache.ratis.util.AutoCloseableLock;
 import org.apache.ratis.util.AutoCloseableReadWriteLock;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Preconditions;
-import org.apache.ratis.util.SizeInBytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogInputStream.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogInputStream.java
@@ -25,10 +25,10 @@ import java.util.Optional;
 
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.server.metrics.SegmentedRaftLogMetrics;
+import org.apache.ratis.server.raftlog.RaftLogConf;
 import org.apache.ratis.util.IOUtils;
 import org.apache.ratis.util.OpenCloseState;
 import org.apache.ratis.util.Preconditions;
-import org.apache.ratis.util.SizeInBytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,12 +67,12 @@ public class SegmentedRaftLogInputStream implements Closeable {
   private final boolean isOpen;
   private final OpenCloseState state;
   private SegmentedRaftLogReader reader;
-  private final SizeInBytes maxOpSize;
+  private final RaftLogConf conf;
   private final SegmentedRaftLogMetrics raftLogMetrics;
 
   SegmentedRaftLogInputStream(File log, long startIndex, long endIndex, boolean isOpen,
-      SizeInBytes maxOpSize, SegmentedRaftLogMetrics raftLogMetrics) {
-    this.maxOpSize = maxOpSize;
+      RaftLogConf conf, SegmentedRaftLogMetrics raftLogMetrics) {
+    this.conf = conf;
     if (isOpen) {
       Preconditions.assertTrue(endIndex == INVALID_LOG_INDEX);
     } else {
@@ -91,7 +91,7 @@ public class SegmentedRaftLogInputStream implements Closeable {
     state.open();
     boolean initSuccess = false;
     try {
-      reader = new SegmentedRaftLogReader(logFile, maxOpSize, raftLogMetrics);
+      reader = new SegmentedRaftLogReader(logFile, conf, raftLogMetrics);
       initSuccess = reader.verifyHeader();
     } finally {
       if (!initSuccess) {
@@ -190,11 +190,11 @@ public class SegmentedRaftLogInputStream implements Closeable {
    * @return Result of the validation
    * @throws IOException
    */
-  static LogValidation scanEditLog(File file, long maxTxIdToScan, SizeInBytes maxOpSize)
+  static LogValidation scanEditLog(File file, long maxTxIdToScan, RaftLogConf conf)
       throws IOException {
     SegmentedRaftLogInputStream in;
     try {
-      in = new SegmentedRaftLogInputStream(file, INVALID_LOG_INDEX, INVALID_LOG_INDEX, false, maxOpSize, null);
+      in = new SegmentedRaftLogInputStream(file, INVALID_LOG_INDEX, INVALID_LOG_INDEX, false, conf, null);
       // read the header, initialize the inputstream
       in.init();
     } catch (EOFException e) {

--- a/ratis-server/src/test/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogTestUtils.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogTestUtils.java
@@ -17,18 +17,16 @@
  */
 package org.apache.ratis.server.raftlog.segmented;
 
-import org.apache.ratis.util.SizeInBytes;
+import org.apache.ratis.server.raftlog.RaftLogConf;
 import org.apache.ratis.util.Slf4jUtils;
 import org.slf4j.event.Level;
 
 import java.io.File;
 
 public interface SegmentedRaftLogTestUtils {
-  SizeInBytes MAX_OP_SIZE = SizeInBytes.valueOf("32MB");
-
   static SegmentedRaftLogInputStream newSegmentedRaftLogInputStream(File log,
       long startIndex, long endIndex, boolean isOpen) {
-    return new SegmentedRaftLogInputStream(log, startIndex, endIndex, isOpen, MAX_OP_SIZE, null);
+    return new SegmentedRaftLogInputStream(log, startIndex, endIndex, isOpen, RaftLogConf.get(), null);
   }
 
   static void setRaftLogWorkerLogLevel(Level level) {

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestCacheEviction.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestCacheEviction.java
@@ -30,6 +30,7 @@ import org.apache.ratis.server.impl.MiniRaftCluster;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.server.raftlog.LogProtoUtils;
 import org.apache.ratis.server.raftlog.RaftLog;
+import org.apache.ratis.server.raftlog.RaftLogConf;
 import org.apache.ratis.server.raftlog.segmented.CacheInvalidationPolicy.CacheInvalidationPolicyDefault;
 import org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogCache.LogSegmentList;
 import org.apache.ratis.server.raftlog.segmented.TestSegmentedRaftLog.SegmentRange;
@@ -49,8 +50,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogTestUtils.MAX_OP_SIZE;
-
 public class TestCacheEviction extends BaseTest {
   private static final CacheInvalidationPolicy policy = new CacheInvalidationPolicyDefault();
 
@@ -58,7 +57,7 @@ public class TestCacheEviction extends BaseTest {
     Assert.assertEquals(numSegments, cached.length);
     final LogSegmentList segments = new LogSegmentList(JavaUtils.getClassSimpleName(TestCacheEviction.class));
     for (int i = 0; i < numSegments; i++) {
-      LogSegment s = LogSegment.newCloseSegment(null, start, start + size - 1, MAX_OP_SIZE, null);
+      LogSegment s = LogSegment.newCloseSegment(null, start, start + size - 1, RaftLogConf.get(), null);
       if (cached[i]) {
         s = Mockito.spy(s);
         Mockito.when(s.hasCache()).thenReturn(true);

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLogCache.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLogCache.java
@@ -18,7 +18,6 @@
 package org.apache.ratis.server.raftlog.segmented;
 
 import static org.apache.ratis.server.metrics.SegmentedRaftLogMetrics.*;
-import static org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogTestUtils.MAX_OP_SIZE;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -32,6 +31,7 @@ import org.apache.ratis.server.metrics.SegmentedRaftLogMetrics;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.LogEntryHeader;
 import org.apache.ratis.server.raftlog.LogProtoUtils;
+import org.apache.ratis.server.raftlog.RaftLogConf;
 import org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogCache.TruncationSegments;
 import org.apache.ratis.server.raftlog.segmented.LogSegment.LogRecord;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
@@ -42,6 +42,7 @@ import org.junit.Test;
 
 public class TestSegmentedRaftLogCache {
   private static final RaftProperties prop = new RaftProperties();
+  private static final RaftLogConf conf = RaftLogConf.get(prop);
 
   private SegmentedRaftLogCache cache;
   private SegmentedRaftLogMetrics raftLogMetrics;
@@ -51,7 +52,7 @@ public class TestSegmentedRaftLogCache {
   public void setup() {
     raftLogMetrics = new SegmentedRaftLogMetrics(RaftServerTestUtil.TEST_MEMBER_ID);
     ratisMetricRegistry = (RatisMetricRegistryImpl) raftLogMetrics.getRegistry();
-    cache = new SegmentedRaftLogCache(null, null, prop, raftLogMetrics);
+    cache = new SegmentedRaftLogCache(null, null, conf, raftLogMetrics);
   }
 
   @After
@@ -60,7 +61,7 @@ public class TestSegmentedRaftLogCache {
   }
 
   private LogSegment prepareLogSegment(long start, long end, boolean isOpen) {
-    LogSegment s = LogSegment.newOpenSegment(null, start, MAX_OP_SIZE, null);
+    LogSegment s = LogSegment.newOpenSegment(null, start, conf, null);
     for (long i = start; i <= end; i++) {
       SimpleOperation m = new SimpleOperation("m" + i);
       LogEntryProto entry = LogProtoUtils.toLogEntryProto(m.getLogEntryContent(), 0, i);


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1879