### PR TITLE
RATIS-1873. Fix retry cache warning condition

### DIFF
--- a/ratis-docs/src/site/markdown/configurations.md
+++ b/ratis-docs/src/site/markdown/configurations.md
@@ -538,6 +538,8 @@ Note that `slowness.timeout` is use in two places:
 | **Description** | expire time of retry cache entry     |
 | **Type**        | TimeDuration                         |
 | **Default**     | 60s                                  |
+Note that we should set an expiration time longer than the total retry waiting duration of clients 
+in order to ensure exactly-once semantic.
 
 | **Property**    | `raft.server.retrycache.statistics.expire-time` |
 |:----------------|:------------------------------------------------|

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -776,6 +776,7 @@ public interface RaftServerConfigKeys {
   interface RetryCache {
     String PREFIX = RaftServerConfigKeys.PREFIX + ".retrycache";
 
+    /** We should set expiry time longer than total client retry to guarantee exactly-once semantic */
     String EXPIRY_TIME_KEY = PREFIX + ".expirytime";
     TimeDuration EXPIRY_TIME_DEFAULT = TimeDuration.valueOf(60, TimeUnit.SECONDS);
     static TimeDuration expiryTime(RaftProperties properties) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1765,7 +1765,7 @@ class RaftServerImpl implements RaftServer.Division,
     // update the retry cache
     final CacheEntry cacheEntry = retryCache.getOrCreateEntry(invocationId);
     Preconditions.assertTrue(cacheEntry != null);
-    if (getInfo().isLeader() && !cacheEntry.isCompletedNormally()) {
+    if (getInfo().isLeader() && cacheEntry.isCompletedNormally()) {
       LOG.warn("{} retry cache entry of leader should be pending: {}", this, cacheEntry);
     }
     if (cacheEntry.isFailed()) {


### PR DESCRIPTION
Made a mistake in previous PR https://github.com/apache/ratis/pull/904. The conditions here are a bit of tricky.

The cache entry is expected to be **not completed normally** when `replyPendingRequest`, since we'll complete this cache entry at the very end of `replyPendingRequest`.

The explanation why this assertion fails in previous PR is incorrect. The real path leading to the error is:
If the request r arrived, committed, but became timeout due to blocking apply (may be stuck in a synchronous snapshotting), a client may choose to retry r. However, if the retry gap exceeds retryCache expiration duration (in our case, yes), the very same request r would be committed, **again**. After the snapshotting finished, these two identical requests being applied would cause the assertion to fail.

Maybe we should recommend users to set a retry cache expiration duration longer than the client retry-waiting duration?


