### PR TITLE
RATIS-1885. Incorrect clientWriteRequest timer usage

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -838,6 +838,7 @@ class RaftServerImpl implements RaftServer.Division,
     assertLifeCycleState(LifeCycle.States.RUNNING);
     LOG.debug("{}: receive client request({})", getMemberId(), request);
     final Optional<Timer> timer = Optional.ofNullable(raftServerMetrics.getClientRequestTimer(request.getType()));
+    final Optional<Timer.Context> timerContext = timer.map(Timer::time);
 
     final CompletableFuture<RaftClientReply> replyFuture;
 
@@ -897,7 +898,7 @@ class RaftServerImpl implements RaftServer.Division,
 
     final RaftClientRequest.Type type = request.getType();
     replyFuture.whenComplete((clientReply, exception) -> {
-      timer.map(Timer::time).ifPresent(Timer.Context::stop);
+      timerContext.ifPresent(Timer.Context::stop);
       if (exception != null || clientReply.getException() != null) {
         raftServerMetrics.incFailedRequestCount(type);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Start clientWriteRequest timer as soon as the leader receives the client request.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1885

## How was this patch tested?

Patched on a 2.x Ozone cluster and confirmed the metrics look sane.