### PR TITLE
fix: Updated dropwizard3 to a version with the separated jmx module.

### DIFF
--- a/ratis-metrics-dropwizard3/pom.xml
+++ b/ratis-metrics-dropwizard3/pom.xml
@@ -25,7 +25,7 @@
   <name>Apache Ratis Metrics Dropwizard 3 Implementation</name>
 
   <properties>
-    <dropwizard3.version>3.2.5</dropwizard3.version>
+    <dropwizard3.version>4.2.7</dropwizard3.version>
   </properties>
 
   <dependencies>
@@ -71,20 +71,13 @@
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-jvm</artifactId>
+      <artifactId>metrics-jmx</artifactId>
       <version>${dropwizard3.version}</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-ganglia</artifactId>
+      <artifactId>metrics-jvm</artifactId>
       <version>${dropwizard3.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.acplt</groupId>
-          <artifactId>oncrpc</artifactId>
-        </exclusion>
-      </exclusions>
       <optional>true</optional>
     </dependency>
 

--- a/ratis-metrics-dropwizard3/src/main/java/org/apache/ratis/metrics/dropwizard3/Dm3MetricsReporting.java
+++ b/ratis-metrics-dropwizard3/src/main/java/org/apache/ratis/metrics/dropwizard3/Dm3MetricsReporting.java
@@ -17,12 +17,12 @@
  */
 package org.apache.ratis.metrics.dropwizard3;
 
+import com.codahale.metrics.jmx.JmxReporter;
 import org.apache.ratis.metrics.RatisMetricRegistry;
 import org.apache.ratis.util.TimeDuration;
 
 import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.ScheduledReporter;
-import com.codahale.metrics.JmxReporter;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;

--- a/ratis-metrics-dropwizard3/src/main/java/org/apache/ratis/metrics/dropwizard3/Dm3RatisMetricRegistryImpl.java
+++ b/ratis-metrics-dropwizard3/src/main/java/org/apache/ratis/metrics/dropwizard3/Dm3RatisMetricRegistryImpl.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.metrics.dropwizard3;
 
+import com.codahale.metrics.jmx.JmxReporter;
 import org.apache.ratis.metrics.LongCounter;
 import org.apache.ratis.metrics.MetricRegistryInfo;
 import org.apache.ratis.metrics.RatisMetricRegistry;
@@ -28,7 +29,6 @@ import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
-import com.codahale.metrics.JmxReporter;
 
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 

--- a/ratis-metrics-dropwizard3/src/main/java/org/apache/ratis/metrics/dropwizard3/Dm3RatisObjectNameFactory.java
+++ b/ratis-metrics-dropwizard3/src/main/java/org/apache/ratis/metrics/dropwizard3/Dm3RatisObjectNameFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.ratis.metrics.dropwizard3;
 
-import com.codahale.metrics.ObjectNameFactory;
+import com.codahale.metrics.jmx.ObjectNameFactory;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update to dropwizard3 libraries in version 4.2.7 where the JMX module is now located in a separate module as well as a different package.

Removed obsolete dependency to ganglia (as it seems this was only added for managing the exclusion of one dependency)

## How was this patch tested?

I've run all tests of the module, which admittedly only provide a 51% line coverage.

## Why this update?
In the Apache IoTDB project we consume the Ratis artifacts, but we're already using the newer dropwizard modules, however this causes issues with our Ratis modules (mostly the changed package). 

## Why not update to the latest?
I wanted to keep things minimally invasive and 4.2.7 was the first version to have the JMX module relocated.