### PR TITLE
RATIS-1888. Handle exception of readIndexAsync in gRPC readIndex impl

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
@@ -176,7 +176,7 @@ public interface GrpcUtil {
           Function<REPLY, REPLY_PROTO> toProto,
           Consumer<Exception> warning) {
     try {
-      supplier.get().whenCompleteAsync((reply, exception) -> {
+      supplier.get().whenComplete((reply, exception) -> {
         if (exception != null) {
           responseObserver.onError(GrpcUtil.wrapException(exception));
         } else {

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
@@ -167,17 +167,18 @@ public interface GrpcUtil {
       StreamObserver<REPLY_PROTO> responseObserver,
       CheckedSupplier<CompletableFuture<REPLY>, IOException> supplier,
       Function<REPLY, REPLY_PROTO> toProto) {
-    asyncCall(responseObserver, supplier, toProto, e -> {});
+    asyncCall(responseObserver, supplier, toProto, throwable -> {});
   }
 
   static <REPLY, REPLY_PROTO> void asyncCall(
           StreamObserver<REPLY_PROTO> responseObserver,
           CheckedSupplier<CompletableFuture<REPLY>, IOException> supplier,
           Function<REPLY, REPLY_PROTO> toProto,
-          Consumer<Exception> warning) {
+          Consumer<Throwable> warning) {
     try {
       supplier.get().whenComplete((reply, exception) -> {
         if (exception != null) {
+          warning.accept(exception);
           responseObserver.onError(GrpcUtil.wrapException(exception));
         } else {
           responseObserver.onNext(toProto.apply(reply));

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
@@ -17,7 +17,7 @@
  */
 package org.apache.ratis.grpc;
 
-import org.apache.ratis.protocol.RaftClientReply;
+import java.util.function.Consumer;
 import org.apache.ratis.protocol.exceptions.ServerNotReadyException;
 import org.apache.ratis.protocol.exceptions.TimeoutIOException;
 import org.apache.ratis.security.TlsConf.TrustManagerConf;
@@ -47,7 +47,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public interface GrpcUtil {
-  static final Logger LOG = LoggerFactory.getLogger(GrpcUtil.class);
+  Logger LOG = LoggerFactory.getLogger(GrpcUtil.class);
 
   Metadata.Key<String> EXCEPTION_TYPE_KEY =
       Metadata.Key.of("exception-type", Metadata.ASCII_STRING_MARSHALLER);
@@ -163,10 +163,18 @@ public interface GrpcUtil {
     return e;
   }
 
-  static <REPLY extends RaftClientReply, REPLY_PROTO> void asyncCall(
+  static <REPLY, REPLY_PROTO> void asyncCall(
       StreamObserver<REPLY_PROTO> responseObserver,
       CheckedSupplier<CompletableFuture<REPLY>, IOException> supplier,
       Function<REPLY, REPLY_PROTO> toProto) {
+    asyncCall(responseObserver, supplier, toProto, e -> {});
+  }
+
+  static <REPLY, REPLY_PROTO> void asyncCall(
+          StreamObserver<REPLY_PROTO> responseObserver,
+          CheckedSupplier<CompletableFuture<REPLY>, IOException> supplier,
+          Function<REPLY, REPLY_PROTO> toProto,
+          Consumer<Exception> warning) {
     try {
       supplier.get().whenCompleteAsync((reply, exception) -> {
         if (exception != null) {
@@ -177,6 +185,7 @@ public interface GrpcUtil {
         }
       });
     } catch (Exception e) {
+      warning.accept(e);
       responseObserver.onError(GrpcUtil.wrapException(e));
     }
   }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.grpc.server;
 
+import java.util.function.Function;
 import org.apache.ratis.grpc.GrpcUtil;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
@@ -212,23 +213,9 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
 
   @Override
   public void readIndex(ReadIndexRequestProto request, StreamObserver<ReadIndexReplyProto> responseObserver) {
-    try {
-      server.readIndexAsync(request).whenComplete((reply, ex) -> {
-        if (ex != null) {
-          responseObserver.onError(GrpcUtil.wrapException(ex));
-        } else if (reply != null) {
-          responseObserver.onNext(reply);
-          responseObserver.onCompleted();
-        } else {
-          responseObserver.onError(GrpcUtil.wrapException(
-                  new IOException("Failed to get readIndex: request=" + request)));
-        }
-      });
-    } catch (Throwable e) {
-      GrpcUtil.warn(LOG,
-          () -> getId() + ": Failed readIndex " + ProtoUtils.toString(request.getServerRequest()), e);
-      responseObserver.onError(GrpcUtil.wrapException(e));
-    }
+    GrpcUtil.asyncCall(responseObserver, () -> server.readIndexAsync(request), Function.identity(),
+            e -> GrpcUtil.warn(LOG,
+                    () -> getId() + ": Failed readIndex " + ProtoUtils.toString(request.getServerRequest()), e));
   }
 
   @Override

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.grpc.server;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 import org.apache.ratis.grpc.GrpcUtil;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -213,9 +214,9 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
 
   @Override
   public void readIndex(ReadIndexRequestProto request, StreamObserver<ReadIndexReplyProto> responseObserver) {
-    GrpcUtil.asyncCall(responseObserver, () -> server.readIndexAsync(request), Function.identity(),
-            e -> GrpcUtil.warn(LOG,
-                    () -> getId() + ": Failed readIndex " + ProtoUtils.toString(request.getServerRequest()), e));
+    final Consumer<Throwable> warning = e -> GrpcUtil.warn(LOG,
+            () -> getId() + ": Failed readIndex " + ProtoUtils.toString(request.getServerRequest()), e);
+    GrpcUtil.asyncCall(responseObserver, () -> server.readIndexAsync(request), Function.identity(), warning);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

@szetszwo I noticed that we once made a `GrpcUtil.asyncCall` (298c1a2de173c0e2284fc08ef2f953a5fee86e2d) so I reuse the code with a few modification to adapt the readIndex type signature.

I check all rpcs defined in Grpc.proto and the readIndex rpc is the only one remaining having this issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1888

## How was this patch tested?

IMO, it's trivial and too detailed to test. But if we have some test infra I'm glad to work one.
