### PR TITLE
RATIS-1889 NoSuchMethodError: RaftServerMetricsImpl.addNumPendingRequestsGauge

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequests.java
@@ -112,8 +112,8 @@ class PendingRequests {
       this.resource = new RequestLimits(elementLimit, megabyteLimit);
       this.raftServerMetrics = raftServerMetrics;
 
-      raftServerMetrics.addNumPendingRequestsGauge(resource::getElementCount);
-      raftServerMetrics.addNumPendingRequestsMegaByteSize(resource::getMegaByteSize);
+      raftServerMetrics.addNumPendingRequestsGauge(() -> resource.getElementCount());
+      raftServerMetrics.addNumPendingRequestsMegaByteSize(() -> resource.getMegaByteSize());
     }
 
     Permit tryAcquire(Message message) {


### PR DESCRIPTION
see [jira](https://issues.apache.org/jira/browse/RATIS-1889)

It looks like the master branch doesn't have this issue, but we can cp this commit to a future 2.x release branch to circumvent some potential issues