### PR TITLE
RATIS-1895. Replace increaseNextIndex with  updateNextIndex in GrpcLogAppender

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -420,7 +420,7 @@ public class GrpcLogAppender extends LogAppenderBase {
           grpcServerMetrics.onRequestSuccess(getFollowerId().toString(), reply.getIsHearbeat());
           getLeaderState().onFollowerCommitIndex(getFollower(), reply.getFollowerCommit());
           if (getFollower().updateMatchIndex(reply.getMatchIndex())) {
-            getFollower().increaseNextIndex(reply.getMatchIndex() + 1);
+            getFollower().updateNextIndex(reply.getMatchIndex() + 1);
             getLeaderState().onFollowerSuccessAppendEntries(getFollower());
           }
           break;


### PR DESCRIPTION
When testing for 3.0.0 release, we found unexpected error messages introduced by a recent PR https://github.com/apache/ratis/pull/914. 
```java
27951 [grpc-default-executor-6] ERROR o.a.r.grpc.server.GrpcLogAppender - Failed onNext request=AppendEntriesRequest:cid=13,entriesCount=3,lastEntry=(t:2, i:340), reply=1<-2#13:OK-t2,SUCCESS,nextIndex=341,followerCommit=339,matchIndex=340 
java.lang.IllegalStateException: Failed to updateIncreasingly for nextIndex: 343 -> 341
	at org.apache.ratis.util.Preconditions.assertTrue(Preconditions.java:73)
	at org.apache.ratis.server.raftlog.RaftLogIndex.updateIncreasingly(RaftLogIndex.java:68)
	at org.apache.ratis.server.impl.FollowerInfoImpl.increaseNextIndex(FollowerInfoImpl.java:96)
	at org.apache.ratis.grpc.server.GrpcLogAppender$AppendLogResponseHandler.onNextImpl(GrpcLogAppender.java:423)
	at org.apache.ratis.grpc.server.GrpcLogAppender$AppendLogResponseHandler.onNext(GrpcLogAppender.java:402)
	at org.apache.ratis.grpc.server.GrpcLogAppender$AppendLogResponseHandler.onNext(GrpcLogAppender.java:377)
	at org.apache.ratis.thirdparty.io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onMessage(ClientCalls.java:474)
	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInternal(ClientCallImpl.java:662)
	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInContext(ClientCallImpl.java:647)
	at org.apache.ratis.thirdparty.io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at org.apache.ratis.thirdparty.io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```


see https://issues.apache.org/jira/browse/RATIS-1895.