### PR TITLE
RATIS-1864. Support lease based read-only requests

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
@@ -76,6 +76,15 @@ public interface ConfUtils {
     };
   }
 
+  static BiConsumer<String, Double> requireMin(double min) {
+    return (key, value) -> {
+      if (value < min) {
+        throw new IllegalArgumentException(
+            key + " = " + value + " < min = " + min);
+      }
+    };
+  }
+
   static BiConsumer<String, Double> requireMax(double max) {
     return (key, value) -> {
       if (value > max) {

--- a/ratis-common/src/main/java/org/apache/ratis/util/Timestamp.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/Timestamp.java
@@ -51,6 +51,11 @@ public final class Timestamp implements Comparable<Timestamp> {
     return a.compareTo(b) > 0? a: b;
   }
 
+  /** @return the earliest timestamp. */
+  public static Timestamp earliest(Timestamp a, Timestamp b) {
+    return a.compareTo(b) > 0? b: a;
+  }
+
   private final long nanos;
 
   private Timestamp(long nanos) {

--- a/ratis-docs/src/site/markdown/configurations.md
+++ b/ratis-docs/src/site/markdown/configurations.md
@@ -185,6 +185,13 @@ treat the peer as caught-up. Increase this number when write throughput is high.
 
 --------------------------------------------------------------------------------
 
+| **Property**    | `raft.server.read.leader.lease.timeout.ratio` |
+|:----------------|:----------------------------------------------|
+| **Description** | maximum timeout ratio of leader lease         |
+| **Type**        | double, ranging from (0.0,1.0)                |
+| **Default**     | 0.9                                           |
+
+
 ### Write - Configurations related to write requests.
 
 * Limits on pending write requests

--- a/ratis-docs/src/site/markdown/configurations.md
+++ b/ratis-docs/src/site/markdown/configurations.md
@@ -185,6 +185,14 @@ treat the peer as caught-up. Increase this number when write throughput is high.
 
 --------------------------------------------------------------------------------
 
+| **Property**    | `raft.server.read.leader.lease.enabled`                    |
+|:----------------|:-----------------------------------------------------------|
+| **Description** | whether to enable lease in linearizable read-only requests |
+| **Type**        | boolean                                                    |
+| **Default**     | true                                                       |
+
+--------------------------------------------------------------------------------
+
 | **Property**    | `raft.server.read.leader.lease.timeout.ratio` |
 |:----------------|:----------------------------------------------|
 | **Description** | maximum timeout ratio of leader lease         |

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -192,6 +192,18 @@ public interface RaftServerConfigKeys {
       set(properties::setEnum, OPTION_KEY, option);
     }
 
+    String LEADER_LEASE_TIMEOUT_RATIO_KEY = PREFIX + ".leader.lease.timeout.ratio";
+    double LEADER_LEASE_TIMEOUT_RATIO_DEFAULT = 0.9;
+    static double leaderLeaseTimeoutRatio(RaftProperties properties) {
+      return getDouble(properties::getDouble, LEADER_LEASE_TIMEOUT_RATIO_KEY,
+          LEADER_LEASE_TIMEOUT_RATIO_DEFAULT, getDefaultLog(),
+          requireMin(0.0), requireMax(1.0));
+    }
+
+    static void setLeaderLeaseTimeoutRatio(RaftProperties properties, double ratio) {
+      setDouble(properties::setDouble, LEADER_LEASE_TIMEOUT_RATIO_KEY, ratio);
+    }
+
     interface ReadAfterWriteConsistent {
       String PREFIX = RaftServerConfigKeys.PREFIX + ".read-after-write-consistent";
 

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -192,6 +192,16 @@ public interface RaftServerConfigKeys {
       set(properties::setEnum, OPTION_KEY, option);
     }
 
+    String LEADER_LEASE_ENABLED_KEY = PREFIX + ".leader.lease.enabled";
+    boolean LEADER_LEASE_ENABLED_DEFAULT = false;
+    static boolean leaderLeaseEnabled(RaftProperties properties) {
+      return getBoolean(properties::getBoolean, LEADER_LEASE_ENABLED_KEY,
+          LEADER_LEASE_ENABLED_DEFAULT, getDefaultLog());
+    }
+    static void setLeaderLeaseEnabled(RaftProperties properties, boolean enabled) {
+      setBoolean(properties::setBoolean, LEADER_LEASE_ENABLED_KEY, enabled);
+    }
+
     String LEADER_LEASE_TIMEOUT_RATIO_KEY = PREFIX + ".leader.lease.timeout.ratio";
     double LEADER_LEASE_TIMEOUT_RATIO_DEFAULT = 0.9;
     static double leaderLeaseTimeoutRatio(RaftProperties properties) {

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
@@ -101,4 +101,10 @@ public interface FollowerInfo {
 
   /** @return the latest heartbeat send time. */
   Timestamp getLastHeartbeatSendTime();
+
+  /** @return the send time of last responded rpc */
+  Timestamp getLastRespondedAppendEntriesSendTime();
+
+  /** Update lastRpcResponseTime and LastRespondedAppendEntriesSendTime */
+  void updateLastRespondedAppendEntriesSendTime(Timestamp sendTime);
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
@@ -28,18 +28,12 @@ class DivisionPropertiesImpl implements DivisionProperties {
   private final TimeDuration rpcTimeoutMax;
   private final TimeDuration rpcSleepTime;
   private final TimeDuration rpcSlownessTimeout;
-  private final TimeDuration leaderLeaseTimeout;
 
   DivisionPropertiesImpl(RaftProperties properties) {
     this.rpcTimeoutMin = RaftServerConfigKeys.Rpc.timeoutMin(properties);
     this.rpcTimeoutMax = RaftServerConfigKeys.Rpc.timeoutMax(properties);
     Preconditions.assertTrue(rpcTimeoutMax.compareTo(rpcTimeoutMin) >= 0,
         "rpcTimeoutMax = %s < rpcTimeoutMin = %s", rpcTimeoutMax, rpcTimeoutMin);
-
-    final double leaderLeaseTimeoutRatio = RaftServerConfigKeys.Read.leaderLeaseTimeoutRatio(properties);
-    this.leaderLeaseTimeout = this.rpcTimeoutMin.multiply(leaderLeaseTimeoutRatio);
-    Preconditions.assertTrue(rpcTimeoutMin.compareTo(leaderLeaseTimeout) >= 0,
-        "rpcTimeoutMin = %s < leaderLeaseTimeout = %s", rpcTimeoutMin, leaderLeaseTimeout);
 
     this.rpcSleepTime = RaftServerConfigKeys.Rpc.sleepTime(properties);
     this.rpcSlownessTimeout = RaftServerConfigKeys.Rpc.slownessTimeout(properties);
@@ -53,11 +47,6 @@ class DivisionPropertiesImpl implements DivisionProperties {
   @Override
   public TimeDuration maxRpcTimeout() {
     return rpcTimeoutMax;
-  }
-
-  /** @return the ratio of leader lease timeout */
-  public TimeDuration leaderLeaseTimeout() {
-    return leaderLeaseTimeout;
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/DivisionPropertiesImpl.java
@@ -28,12 +28,18 @@ class DivisionPropertiesImpl implements DivisionProperties {
   private final TimeDuration rpcTimeoutMax;
   private final TimeDuration rpcSleepTime;
   private final TimeDuration rpcSlownessTimeout;
+  private final TimeDuration leaderLeaseTimeout;
 
   DivisionPropertiesImpl(RaftProperties properties) {
     this.rpcTimeoutMin = RaftServerConfigKeys.Rpc.timeoutMin(properties);
     this.rpcTimeoutMax = RaftServerConfigKeys.Rpc.timeoutMax(properties);
     Preconditions.assertTrue(rpcTimeoutMax.compareTo(rpcTimeoutMin) >= 0,
         "rpcTimeoutMax = %s < rpcTimeoutMin = %s", rpcTimeoutMax, rpcTimeoutMin);
+
+    final double leaderLeaseTimeoutRatio = RaftServerConfigKeys.Read.leaderLeaseTimeoutRatio(properties);
+    this.leaderLeaseTimeout = this.rpcTimeoutMin.multiply(leaderLeaseTimeoutRatio);
+    Preconditions.assertTrue(rpcTimeoutMin.compareTo(leaderLeaseTimeout) >= 0,
+        "rpcTimeoutMin = %s < leaderLeaseTimeout = %s", rpcTimeoutMin, leaderLeaseTimeout);
 
     this.rpcSleepTime = RaftServerConfigKeys.Rpc.sleepTime(properties);
     this.rpcSlownessTimeout = RaftServerConfigKeys.Rpc.slownessTimeout(properties);
@@ -47,6 +53,11 @@ class DivisionPropertiesImpl implements DivisionProperties {
   @Override
   public TimeDuration maxRpcTimeout() {
     return rpcTimeoutMax;
+  }
+
+  /** @return the ratio of leader lease timeout */
+  public TimeDuration leaderLeaseTimeout() {
+    return leaderLeaseTimeout;
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -39,6 +39,7 @@ class FollowerInfoImpl implements FollowerInfo {
   private final AtomicReference<Timestamp> lastRpcResponseTime;
   private final AtomicReference<Timestamp> lastRpcSendTime;
   private final AtomicReference<Timestamp> lastHeartbeatSendTime;
+  private final AtomicReference<Timestamp> lastRespondedAppendEntriesSendTime;
   private final RaftLogIndex nextIndex;
   private final RaftLogIndex matchIndex = new RaftLogIndex("matchIndex", RaftLog.INVALID_LOG_INDEX);
   private final RaftLogIndex commitIndex = new RaftLogIndex("commitIndex", RaftLog.INVALID_LOG_INDEX);
@@ -57,6 +58,7 @@ class FollowerInfoImpl implements FollowerInfo {
     this.lastRpcResponseTime = new AtomicReference<>(lastRpcTime);
     this.lastRpcSendTime = new AtomicReference<>(lastRpcTime);
     this.lastHeartbeatSendTime = new AtomicReference<>(lastRpcTime);
+    this.lastRespondedAppendEntriesSendTime = new AtomicReference<>(lastRpcTime);
     this.nextIndex = new RaftLogIndex("nextIndex", nextIndex);
     this.caughtUp = caughtUp;
   }
@@ -201,5 +203,15 @@ class FollowerInfoImpl implements FollowerInfo {
   @Override
   public Timestamp getLastHeartbeatSendTime() {
     return lastHeartbeatSendTime.get();
+  }
+
+  @Override
+  public Timestamp getLastRespondedAppendEntriesSendTime() {
+    return lastRespondedAppendEntriesSendTime.get();
+  }
+
+  @Override
+  public void updateLastRespondedAppendEntriesSendTime(Timestamp sendTime) {
+    lastRespondedAppendEntriesSendTime.set(sendTime);
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderLease.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderLease.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server.impl;
+
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.server.leader.FollowerInfo;
+import org.apache.ratis.util.Preconditions;
+import org.apache.ratis.util.Timestamp;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class LeaderLease {
+
+  private final long leaseTimeoutMs;
+  // TODO invalidate leader lease when stepDown / transferLeader
+  private final AtomicReference<Timestamp> lease = new AtomicReference<>(Timestamp.currentTime());
+
+  LeaderLease(RaftProperties properties) {
+    final double leaseRatio = RaftServerConfigKeys.Read.leaderLeaseTimeoutRatio(properties);
+    Preconditions.assertTrue(leaseRatio > 0.0 && leaseRatio <= 1.0,
+        "leader ratio should sit in (0,1], now is " + leaseRatio);
+    this.leaseTimeoutMs = RaftServerConfigKeys.Rpc.timeoutMin(properties)
+        .multiply(leaseRatio)
+        .toIntExact(TimeUnit.MILLISECONDS);
+  }
+
+  boolean isValid() {
+    return lease.get().elapsedTimeMs() < leaseTimeoutMs;
+  }
+
+  /**
+   * try extending the lease based on group heartbeats
+   * @param old nullable
+   */
+  void extend(List<FollowerInfo> current, List<FollowerInfo> old, Predicate<List<RaftPeerId>> hasMajority) {
+    final List<RaftPeerId> activePeers =
+        // check the latest heartbeats of all peers (including those in transitional)
+        Stream.concat(current.stream(), Optional.ofNullable(old).map(List::stream).orElse(Stream.empty()))
+            .filter(f -> f.getLastRespondedAppendEntriesSendTime().elapsedTimeMs() < leaseTimeoutMs)
+            .map(FollowerInfo::getId)
+            .collect(Collectors.toList());
+
+    if (!hasMajority.test(activePeers)) {
+      return;
+    }
+
+    // update the new lease
+    final Timestamp newLease =
+        Timestamp.earliest(getMaxTimestampWithMajorityAck(current), getMaxTimestampWithMajorityAck(old));
+    lease.set(newLease);
+  }
+
+  /**
+   * return maximum timestamp at when the majority of followers are known to be active
+   * return {@link Timestamp#currentTime()} if peers are empty
+   */
+  private Timestamp getMaxTimestampWithMajorityAck(List<FollowerInfo> followers) {
+    if (followers == null || followers.isEmpty()) {
+      return Timestamp.currentTime();
+    }
+
+    final int mid = followers.size() / 2;
+    return followers.stream()
+        .map(FollowerInfo::getLastRespondedAppendEntriesSendTime)
+        .sorted()
+        .limit(mid+1)
+        .skip(mid)
+        .iterator()
+        .next();
+  }
+}

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -348,6 +348,7 @@ class LeaderStateImpl implements LeaderState {
   private final PendingStepDown pendingStepDown;
 
   private final ReadIndexHeartbeats readIndexHeartbeats;
+  private final LeaderLease lease;
 
   LeaderStateImpl(RaftServerImpl server) {
     this.name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
@@ -369,6 +370,7 @@ class LeaderStateImpl implements LeaderState {
     this.messageStreamRequests = new MessageStreamRequests(server.getMemberId());
     this.pendingStepDown = new PendingStepDown(this);
     this.readIndexHeartbeats = new ReadIndexHeartbeats();
+    this.lease = new LeaderLease(properties);
     long maxPendingRequests = RaftServerConfigKeys.Write.elementLimit(properties);
     double followerGapRatioMax = RaftServerConfigKeys.Write.followerGapRatioMax(properties);
 
@@ -1125,6 +1127,23 @@ class LeaderStateImpl implements LeaderState {
   @Override
   public void onAppendEntriesReply(LogAppender appender, RaftProtos.AppendEntriesReplyProto reply) {
     readIndexHeartbeats.onAppendEntriesReply(appender, reply, this::hasMajority);
+  }
+
+  boolean hasLease() {
+    if (checkLeaderLease()) {
+      return true;
+    }
+
+    // try extending the leader lease
+    final RaftConfigurationImpl conf = server.getRaftConf();
+    final CurrentOldFollowerInfos info = followerInfoMap.getFollowerInfos(conf);
+    lease.extend(info.getCurrent(), info.getOld(), peers -> conf.hasMajority(peers, server.getId()));
+
+    return checkLeaderLease();
+  }
+
+  private boolean checkLeaderLease() {
+    return isReady() && (server.getRaftConf().isSingleton() || lease.isValid());
   }
 
   void replyPendingRequest(long logIndex, RaftClientReply reply) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
@@ -26,6 +26,7 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLogIOException;
 import org.apache.ratis.server.util.ServerStringUtils;
 import org.apache.ratis.statemachine.SnapshotInfo;
+import org.apache.ratis.util.Timestamp;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -73,9 +74,11 @@ class LogAppenderDefault extends LogAppenderBase {
         }
 
         resetHeartbeatTrigger();
+        final Timestamp sendTime = Timestamp.currentTime();
         getFollower().updateLastRpcSendTime(request.getEntriesCount() == 0);
         final AppendEntriesReplyProto r = getServerRpc().appendEntries(request);
         getFollower().updateLastRpcResponseTime();
+        getFollower().updateLastRespondedAppendEntriesSendTime(sendTime);
 
         getLeaderState().onFollowerCommitIndex(getFollower(), r.getFollowerCommit());
         return r;

--- a/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
@@ -43,7 +43,6 @@ import org.slf4j.event.Level;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -69,16 +68,21 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
     final RaftProperties p = getProperties();
     p.setClass(MiniRaftCluster.STATEMACHINE_CLASS_KEY,
         CounterStateMachine.class, StateMachine.class);
-
-    p.setEnum(RaftServerConfigKeys.Read.OPTION_KEY, RaftServerConfigKeys.Read.Option.LINEARIZABLE);
   }
 
   @Test
   public void testLinearizableRead() throws Exception {
-    runWithNewCluster(NUM_SERVERS, this::testLinearizableReadImpl);
+    getProperties().setEnum(RaftServerConfigKeys.Read.OPTION_KEY, RaftServerConfigKeys.Read.Option.LINEARIZABLE);
+    runWithNewCluster(NUM_SERVERS, this::testReadOnlyImpl);
   }
 
-  private void testLinearizableReadImpl(CLUSTER cluster) throws Exception {
+  @Test
+  public void testLeaseRead() throws Exception {
+    getProperties().setBoolean(RaftServerConfigKeys.Read.LEADER_LEASE_ENABLED_KEY, true);
+    runWithNewCluster(NUM_SERVERS, this::testReadOnlyImpl);
+  }
+
+  private void testReadOnlyImpl(CLUSTER cluster) throws Exception {
     try {
       RaftTestUtil.waitForLeader(cluster);
       final RaftPeerId leaderId = cluster.getLeader().getId();
@@ -98,10 +102,17 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testLinearizableReadTimeout() throws Exception {
-    runWithNewCluster(NUM_SERVERS, this::testLinearizableReadTimeoutImpl);
+    getProperties().setEnum(RaftServerConfigKeys.Read.OPTION_KEY, RaftServerConfigKeys.Read.Option.LINEARIZABLE);
+    runWithNewCluster(NUM_SERVERS, this::testReadOnlyTimeoutImpl);
   }
 
-  private void testLinearizableReadTimeoutImpl(CLUSTER cluster) throws Exception {
+  @Test
+  public void testLeaseReadTimeout() throws Exception {
+    getProperties().setBoolean(RaftServerConfigKeys.Read.LEADER_LEASE_ENABLED_KEY, true);
+    runWithNewCluster(NUM_SERVERS, this::testReadOnlyTimeoutImpl);
+  }
+
+  private void testReadOnlyTimeoutImpl(CLUSTER cluster) throws Exception {
     try {
       RaftTestUtil.waitForLeader(cluster);
       final RaftPeerId leaderId = cluster.getLeader().getId();
@@ -126,10 +137,17 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testFollowerLinearizableRead() throws Exception {
-    runWithNewCluster(NUM_SERVERS, this::testFollowerLinearizableReadImpl);
+    getProperties().setEnum(RaftServerConfigKeys.Read.OPTION_KEY, RaftServerConfigKeys.Read.Option.LINEARIZABLE);
+    runWithNewCluster(NUM_SERVERS, this::testFollowerReadOnlyImpl);
   }
 
-  private void testFollowerLinearizableReadImpl(CLUSTER cluster) throws Exception {
+  @Test
+  public void testFollowerLeaseRead() throws Exception {
+    getProperties().setBoolean(RaftServerConfigKeys.Read.LEADER_LEASE_ENABLED_KEY, true);
+    runWithNewCluster(NUM_SERVERS, this::testFollowerReadOnlyImpl);
+  }
+
+  private void testFollowerReadOnlyImpl(CLUSTER cluster) throws Exception {
     try {
       RaftTestUtil.waitForLeader(cluster);
 
@@ -155,10 +173,17 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testFollowerLinearizableReadParallel() throws Exception {
-    runWithNewCluster(NUM_SERVERS, this::testFollowerLinearizableReadParallelImpl);
+    getProperties().setEnum(RaftServerConfigKeys.Read.OPTION_KEY, RaftServerConfigKeys.Read.Option.LINEARIZABLE);
+    runWithNewCluster(NUM_SERVERS, this::testFollowerReadOnlyParallelImpl);
   }
 
-  private void testFollowerLinearizableReadParallelImpl(CLUSTER cluster) throws Exception {
+  @Test
+  public void testFollowerLeaseReadParallel() throws Exception {
+    getProperties().setBoolean(RaftServerConfigKeys.Read.LEADER_LEASE_ENABLED_KEY, true);
+    runWithNewCluster(NUM_SERVERS, this::testFollowerReadOnlyParallelImpl);
+  }
+
+  private void testFollowerReadOnlyParallelImpl(CLUSTER cluster) throws Exception {
     try {
       RaftTestUtil.waitForLeader(cluster);
 
@@ -183,10 +208,17 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testFollowerLinearizableReadFailWhenLeaderDown() throws Exception {
-    runWithNewCluster(NUM_SERVERS, this::testFollowerLinearizableReadFailWhenLeaderDownImpl);
+    getProperties().setEnum(RaftServerConfigKeys.Read.OPTION_KEY, RaftServerConfigKeys.Read.Option.LINEARIZABLE);
+    runWithNewCluster(NUM_SERVERS, this::testFollowerReadOnlyFailWhenLeaderDownImpl);
   }
 
-  private void testFollowerLinearizableReadFailWhenLeaderDownImpl(CLUSTER cluster) throws Exception {
+  @Test
+  public void testFollowerLeaseReadWhenLeaderDown() throws Exception {
+    getProperties().setBoolean(RaftServerConfigKeys.Read.LEADER_LEASE_ENABLED_KEY, true);
+    runWithNewCluster(NUM_SERVERS, this::testFollowerReadOnlyFailWhenLeaderDownImpl);
+  }
+
+  private void testFollowerReadOnlyFailWhenLeaderDownImpl(CLUSTER cluster) throws Exception {
     try {
       RaftTestUtil.waitForLeader(cluster);
 
@@ -215,11 +247,18 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
   }
 
   @Test
-  public void testFollowerLinearizableReadRetryWhenLeaderDown() throws Exception {
-    runWithNewCluster(NUM_SERVERS, this::testFollowerLinearizableReadRetryWhenLeaderDown);
+  public void testFollowerReadOnlyRetryWhenLeaderDown() throws Exception {
+    getProperties().setEnum(RaftServerConfigKeys.Read.OPTION_KEY, RaftServerConfigKeys.Read.Option.LINEARIZABLE);
+    runWithNewCluster(NUM_SERVERS, this::testFollowerReadOnlyRetryWhenLeaderDown);
   }
 
-  private void testFollowerLinearizableReadRetryWhenLeaderDown(CLUSTER cluster) throws Exception {
+  @Test
+  public void testFollowerLeaseReadRetryWhenLeaderDown() throws Exception {
+    getProperties().setBoolean(RaftServerConfigKeys.Read.LEADER_LEASE_ENABLED_KEY, true);
+    runWithNewCluster(NUM_SERVERS, this::testFollowerReadOnlyRetryWhenLeaderDown);
+  }
+
+  private void testFollowerReadOnlyRetryWhenLeaderDown(CLUSTER cluster) throws Exception {
     // only retry on readIndexException
     final RetryPolicy retryPolicy = ExceptionDependentRetry
         .newBuilder()

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -652,6 +652,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
   @Test
   public void testLeaderLease() throws Exception {
     // use a strict lease
+    RaftServerConfigKeys.Read.setLeaderLeaseEnabled(getProperties(), true);
     RaftServerConfigKeys.Read.setLeaderLeaseTimeoutRatio(getProperties(), 0.5);
     runWithNewCluster(3, c -> runLeaseTest(c, this::runTestLeaderLease));
   }
@@ -679,6 +680,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
   @Test
   public void testLeaderLeaseDuringReconfiguration() throws Exception {
     // use a strict lease
+    RaftServerConfigKeys.Read.setLeaderLeaseEnabled(getProperties(), true);
     RaftServerConfigKeys.Read.setLeaderLeaseTimeoutRatio(getProperties(), 0.5);
     runWithNewCluster(3, c -> runLeaseTest(c, this::runTestLeaderLeaseDuringReconfiguration));
   }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -43,6 +43,7 @@ import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.Slf4jUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.Timestamp;
+import org.apache.ratis.util.function.CheckedBiConsumer;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -639,6 +640,87 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
           20, HUNDRED_MILLIS, "check new leader", LOG);
     }
   }
+
+  private void runLeaseTest(CLUSTER cluster, CheckedBiConsumer<CLUSTER, Long, Exception> testCase) throws Exception {
+    final double leaseRatio = RaftServerConfigKeys.Read.leaderLeaseTimeoutRatio(getProperties());
+    final long leaseTimeoutMs = RaftServerConfigKeys.Rpc.timeoutMin(getProperties())
+        .multiply(leaseRatio)
+        .toIntExact(TimeUnit.MILLISECONDS);
+    testCase.accept(cluster, leaseTimeoutMs);
+  }
+
+  @Test
+  public void testLeaderLease() throws Exception {
+    // use a strict lease
+    RaftServerConfigKeys.Read.setLeaderLeaseTimeoutRatio(getProperties(), 0.5);
+    runWithNewCluster(3, c -> runLeaseTest(c, this::runTestLeaderLease));
+  }
+
+  void runTestLeaderLease(CLUSTER cluster, long leaseTimeoutMs) throws Exception {
+    final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster);
+    try (final RaftClient client = cluster.createClient(leader.getId())) {
+      client.io().send(new RaftTestUtil.SimpleMessage("message"));
+
+      Assert.assertTrue(leader.getInfo().isLeader());
+      Assert.assertTrue(leader.getInfo().isLeaderReady());
+      RaftServerTestUtil.assertLeaderLease(leader, true);
+
+      isolate(cluster, leader.getId());
+      Thread.sleep(leaseTimeoutMs);
+
+      Assert.assertTrue(leader.getInfo().isLeader());
+      Assert.assertTrue(leader.getInfo().isLeaderReady());
+      RaftServerTestUtil.assertLeaderLease(leader, false);
+    } finally {
+      deIsolate(cluster, leader.getId());
+    }
+  }
+
+  @Test
+  public void testLeaderLeaseDuringReconfiguration() throws Exception {
+    // use a strict lease
+    RaftServerConfigKeys.Read.setLeaderLeaseTimeoutRatio(getProperties(), 0.5);
+    runWithNewCluster(3, c -> runLeaseTest(c, this::runTestLeaderLeaseDuringReconfiguration));
+  }
+
+  void runTestLeaderLeaseDuringReconfiguration(CLUSTER cluster, long leaseTimeoutMs) throws Exception {
+    final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster);
+    try (final RaftClient client = cluster.createClient(leader.getId())) {
+      client.io().send(new RaftTestUtil.SimpleMessage("message"));
+
+      Assert.assertTrue(leader.getInfo().isLeader());
+      Assert.assertTrue(leader.getInfo().isLeaderReady());
+      RaftServerTestUtil.assertLeaderLease(leader, true);
+
+      final List<RaftServer.Division> followers = cluster.getFollowers();
+      final MiniRaftCluster.PeerChanges changes = cluster.addNewPeers(2, true);
+
+      // blocking the original 2 followers
+      BlockRequestHandlingInjection.getInstance().blockReplier(followers.get(0).getId().toString());
+      BlockRequestHandlingInjection.getInstance().blockReplier(followers.get(1).getId().toString());
+
+      // start reconfiguration in another thread, shall fail eventually
+      new Thread(() -> {
+        try {
+          client.admin().setConfiguration(changes.allPeersInNewConf);
+        } catch (IOException e) {
+          System.out.println("as expected: " + e.getMessage());
+        }
+      }).start();
+
+      Thread.sleep(leaseTimeoutMs);
+
+      Assert.assertTrue(leader.getInfo().isLeader());
+      Assert.assertTrue(leader.getInfo().isLeaderReady());
+      RaftServerTestUtil.assertLeaderLease(leader, false);
+
+    } finally {
+      BlockRequestHandlingInjection.getInstance().unblockAll();
+    }
+  }
+
+
+
 
   private static RaftServerImpl createMockServer(boolean alive) {
     final DivisionInfo info = mock(DivisionInfo.class);

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
@@ -147,6 +147,12 @@ public class RaftServerTestUtil {
     return getLeaderState(server).map(LeaderStateImpl::getLogAppenders).orElse(null);
   }
 
+  public static void assertLeaderLease(RaftServer.Division leader, boolean hasLease) {
+    final LeaderStateImpl l = getLeaderState(leader).orElse(null);
+    Assert.assertNotNull(l);
+    Assert.assertEquals(l.hasLease(), hasLease);
+  }
+
   public static void restartLogAppenders(RaftServer.Division server) {
     final LeaderStateImpl leaderState = getLeaderState(server).orElseThrow(
         () -> new IllegalStateException(server + " is not the leader"));


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/RATIS-1864

# What is a Leader Lease
In Raft, the leader is responsible for processing and coordinating client requests, replicating data among other followers, and maintaining the distributed state machine. 
Vanilla Raft requires the leader to obtain majority acknowledgements before serving every read requests. During normal operations, this prerequisite leads to unnecessary rpcs exchanged among the cluster, diminished read throughput and increased latency. 
The leader lease is a concept that allows the leader to maintain its leadership without obtaining majority acknowledgements for a certain period of time (lease duration), during which it can directly serve client read requests. 

The requirement of Lease is first brought up by the Alluxio Community @codings-dan.

# How to extend lease during normal operations
### Prerequisite
- Suppose the CPU clocks are perfectly synchronized among cluster machines.
- Let each AppendEntries request AE(i) contain a send time T(i)
### Initialize
Once a leader is elected and its authority being comfirmed by majorities through successfully replicating its first no-op log, the leader gains the lease. The lease validity starts from T(0).
### Renewal 
As long as the leader continues to send heartbeats and receives acknowledgments from a majority of other nodes, it can renew its lease. Theoretically, if the most recent acknowledged heartbeat was sent at time T(n), the validity of the new lease commences at T(n).
In practice, rather than updating the lease with every heartbeat, we opt for a more efficient approach by lazily updating the leader's lease upon each query. Here's how it works:
At time T(n), when the leader is questioned about its authority, it first collects the send times of the last replied AppendEntries from each of its followers, denoted as TR(1), TR(2), ..., TR(2n), sorted in descending order.
Next, it selects the maximum timestamp at when the majority of followers are known to be active, that is, TR(n). 
If TR(n) falls within the time range [T(n), T(n) + LeaseTimeoutDuration], then the lease can be successfully renewed.
### Revoke
If the lease is expired and the leader cannot renew it, it loses the lease and stops serving read-only requests directly.
# How to handle lease during configuration changes
During the configuration changes, the lease can only be renewed if acknowledgments be received by both the old group and the new group. It is the same to leader election restrictions during reconfiguration.
# What to do when forced step down
1. When the leader is forced down.
2. When a leadership transfer is in-progress.
3. When a reconfiguration's new group excludes the current leader.
When a leader is forced down, its lease should be effectively revoked.
# How to handle CPU drifts
We can lower the ratio allowed for lease timeouts. If the CPU drifts are unbound, better not to use lease read :)
