### PR TITLE
RATIS-1898. Netty should use EpollEventLoopGroup by default

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyConfigKeys.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyConfigKeys.java
@@ -48,6 +48,9 @@ public interface NettyConfigKeys {
     String PORT_KEY = PREFIX + ".port";
     int PORT_DEFAULT = 0;
 
+    String USE_EPOLL_KEY = PREFIX + ".use-epoll";
+    boolean USE_EPOLL_DEFAULT = true;
+
     static String host(RaftProperties properties) {
       return get(properties::get, HOST_KEY, HOST_DEFAULT, getDefaultLog());
     }
@@ -63,6 +66,13 @@ public interface NettyConfigKeys {
 
     static void setPort(RaftProperties properties, int port) {
       setInt(properties::setInt, PORT_KEY, port);
+    }
+
+    static boolean useEpoll(RaftProperties properties) {
+      return getBoolean(properties::getBoolean, USE_EPOLL_KEY, USE_EPOLL_DEFAULT, getDefaultLog());
+    }
+    static void setUseEpoll(RaftProperties properties, boolean enable) {
+      setBoolean(properties::setBoolean, USE_EPOLL_KEY, enable);
     }
   }
 
@@ -110,6 +120,15 @@ public interface NettyConfigKeys {
         ConfUtils.setTlsConf((key, value) -> parameters.put(key, value, TLS_CONF_CLASS), TLS_CONF_PARAMETER, conf);
       }
 
+      String USE_EPOLL_KEY = PREFIX + ".use-epoll";
+      boolean USE_EPOLL_DEFAULT = true;
+      static boolean useEpoll(RaftProperties properties) {
+        return getBoolean(properties::getBoolean, USE_EPOLL_KEY, USE_EPOLL_DEFAULT, getDefaultLog());
+      }
+      static void setUseEpoll(RaftProperties properties, boolean enable) {
+        setBoolean(properties::setBoolean, USE_EPOLL_KEY, enable);
+      }
+
       String WORKER_GROUP_SIZE_KEY = PREFIX + ".worker-group.size";
       int WORKER_GROUP_SIZE_DEFAULT = Math.max(1, NettyRuntime.availableProcessors() * 2);
       static int workerGroupSize(RaftProperties properties) {
@@ -155,7 +174,7 @@ public interface NettyConfigKeys {
       }
 
       String USE_EPOLL_KEY = PREFIX + ".use-epoll";
-      boolean USE_EPOLL_DEFAULT = false;
+      boolean USE_EPOLL_DEFAULT = true;
       static boolean useEpoll(RaftProperties properties) {
         return getBoolean(properties::getBoolean, USE_EPOLL_KEY, USE_EPOLL_DEFAULT, getDefaultLog());
       }

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyUtils.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyUtils.java
@@ -149,12 +149,12 @@ public interface NettyUtils {
     return sslContext;
   }
 
-  static Class<? extends SocketChannel> getSocketChannel(EventLoopGroup eventLoopGroup) {
+  static Class<? extends SocketChannel> getSocketChannelClass(EventLoopGroup eventLoopGroup) {
     return eventLoopGroup instanceof EpollEventLoopGroup ?
         EpollSocketChannel.class : NioSocketChannel.class;
   }
 
-  static Class<? extends ServerChannel> getServerChannel(EventLoopGroup eventLoopGroup) {
+  static Class<? extends ServerChannel> getServerChannelClass(EventLoopGroup eventLoopGroup) {
     return eventLoopGroup instanceof EpollEventLoopGroup ?
         EpollServerSocketChannel.class : NioServerSocketChannel.class;
   }

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyUtils.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyUtils.java
@@ -23,9 +23,15 @@ import org.apache.ratis.security.TlsConf.KeyManagerConf;
 import org.apache.ratis.security.TlsConf.PrivateKeyConf;
 import org.apache.ratis.security.TlsConf.TrustManagerConf;
 import org.apache.ratis.thirdparty.io.netty.channel.EventLoopGroup;
+import org.apache.ratis.thirdparty.io.netty.channel.ServerChannel;
 import org.apache.ratis.thirdparty.io.netty.channel.epoll.Epoll;
 import org.apache.ratis.thirdparty.io.netty.channel.epoll.EpollEventLoopGroup;
+import org.apache.ratis.thirdparty.io.netty.channel.epoll.EpollServerSocketChannel;
+import org.apache.ratis.thirdparty.io.netty.channel.epoll.EpollSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.channel.nio.NioEventLoopGroup;
+import org.apache.ratis.thirdparty.io.netty.channel.socket.SocketChannel;
+import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioServerSocketChannel;
+import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContext;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
 import org.apache.ratis.util.ConcurrentUtils;
@@ -141,5 +147,15 @@ public interface NettyUtils {
     }
     LOG.debug("buildSslContext for {} from {} returns {}", name, tlsConf, sslContext.getClass().getName());
     return sslContext;
+  }
+
+  static Class<? extends SocketChannel> getSocketChannel(EventLoopGroup eventLoopGroup) {
+    return eventLoopGroup instanceof EpollEventLoopGroup ?
+        EpollSocketChannel.class : NioSocketChannel.class;
+  }
+
+  static Class<? extends ServerChannel> getServerChannel(EventLoopGroup eventLoopGroup) {
+    return eventLoopGroup instanceof EpollEventLoopGroup ?
+        EpollServerSocketChannel.class : NioServerSocketChannel.class;
   }
 }

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
@@ -83,7 +83,8 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
     static EventLoopGroup newWorkerGroup(RaftProperties properties) {
       return NettyUtils.newEventLoopGroup(
           JavaUtils.getClassSimpleName(NettyClientStreamRpc.class) + "-workerGroup",
-          NettyConfigKeys.DataStream.Client.workerGroupSize(properties), false);
+          NettyConfigKeys.DataStream.Client.workerGroupSize(properties),
+          NettyConfigKeys.DataStream.Client.useEpoll(properties));
     }
 
     private final EventLoopGroup workerGroup;

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
@@ -149,7 +149,7 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
     private ChannelFuture connect() {
       return new Bootstrap()
           .group(getWorkerGroup())
-          .channel(NettyUtils.getSocketChannel(getWorkerGroup()))
+          .channel(NettyUtils.getSocketChannelClass(getWorkerGroup()))
           .handler(channelInitializerSupplier.get())
           .option(ChannelOption.SO_KEEPALIVE, true)
           .connect(address)

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
@@ -48,7 +48,6 @@ import org.apache.ratis.thirdparty.io.netty.channel.ChannelOption;
 import org.apache.ratis.thirdparty.io.netty.channel.ChannelPipeline;
 import org.apache.ratis.thirdparty.io.netty.channel.EventLoopGroup;
 import org.apache.ratis.thirdparty.io.netty.channel.socket.SocketChannel;
-import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.codec.ByteToMessageDecoder;
 import org.apache.ratis.thirdparty.io.netty.handler.codec.MessageToMessageEncoder;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContext;
@@ -150,7 +149,7 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
     private ChannelFuture connect() {
       return new Bootstrap()
           .group(getWorkerGroup())
-          .channel(NioSocketChannel.class)
+          .channel(NettyUtils.getSocketChannel(getWorkerGroup()))
           .handler(channelInitializerSupplier.get())
           .option(ChannelOption.SO_KEEPALIVE, true)
           .connect(address)

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
@@ -31,7 +31,6 @@ import org.apache.ratis.server.RaftServerRpcWithProxy;
 import org.apache.ratis.thirdparty.io.netty.bootstrap.ServerBootstrap;
 import org.apache.ratis.thirdparty.io.netty.channel.*;
 import org.apache.ratis.thirdparty.io.netty.channel.socket.SocketChannel;
-import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioServerSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.codec.protobuf.ProtobufDecoder;
 import org.apache.ratis.thirdparty.io.netty.handler.codec.protobuf.ProtobufEncoder;
 import org.apache.ratis.thirdparty.io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
@@ -127,7 +126,7 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
             host == null || host.isEmpty() ? new InetSocketAddress(port) : new InetSocketAddress(host, port);
     this.channel = JavaUtils.memoize(() -> new ServerBootstrap()
         .group(bossGroup, workerGroup)
-        .channel(NioServerSocketChannel.class)
+        .channel(NettyUtils.getServerChannel(bossGroup))
         .handler(new LoggingHandler(LogLevel.INFO))
         .childHandler(initializer)
         .bind(socketAddress));

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
@@ -126,7 +126,7 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
             host == null || host.isEmpty() ? new InetSocketAddress(port) : new InetSocketAddress(host, port);
     this.channel = JavaUtils.memoize(() -> new ServerBootstrap()
         .group(bossGroup, workerGroup)
-        .channel(NettyUtils.getServerChannel(bossGroup))
+        .channel(NettyUtils.getServerChannelClass(bossGroup))
         .handler(new LoggingHandler(LogLevel.INFO))
         .childHandler(initializer)
         .bind(socketAddress));

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
@@ -20,6 +20,7 @@ package org.apache.ratis.netty.server;
 import org.apache.ratis.client.impl.ClientProtoUtils;
 import org.apache.ratis.netty.NettyConfigKeys;
 import org.apache.ratis.netty.NettyRpcProxy;
+import org.apache.ratis.netty.NettyUtils;
 import org.apache.ratis.protocol.GroupInfoReply;
 import org.apache.ratis.protocol.GroupListReply;
 import org.apache.ratis.protocol.RaftClientReply;
@@ -83,8 +84,8 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
 
   private final RaftServer server;
 
-  private final EventLoopGroup bossGroup = new NioEventLoopGroup();
-  private final EventLoopGroup workerGroup = new NioEventLoopGroup();
+  private final EventLoopGroup bossGroup;
+  private final EventLoopGroup workerGroup;
   private final MemoizedSupplier<ChannelFuture> channel;
   private final InetSocketAddress socketAddress;
 
@@ -116,6 +117,10 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
         p.addLast(new InboundHandler());
       }
     };
+
+    final boolean useEpoll = NettyConfigKeys.Server.useEpoll(server.getProperties());
+    this.bossGroup = NettyUtils.newEventLoopGroup(CLASS_NAME + "-bossGroup", 0, useEpoll);
+    this.workerGroup = NettyUtils.newEventLoopGroup(CLASS_NAME + "-workerGroup",0, useEpoll);
 
     final String host = NettyConfigKeys.Server.host(server.getProperties());
     final int port = NettyConfigKeys.Server.port(server.getProperties());

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
@@ -30,7 +30,6 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerRpcWithProxy;
 import org.apache.ratis.thirdparty.io.netty.bootstrap.ServerBootstrap;
 import org.apache.ratis.thirdparty.io.netty.channel.*;
-import org.apache.ratis.thirdparty.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.ratis.thirdparty.io.netty.channel.socket.SocketChannel;
 import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioServerSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.codec.protobuf.ProtobufDecoder;

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -181,7 +181,7 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
             host == null || host.isEmpty() ? new InetSocketAddress(port) : new InetSocketAddress(host, port);
     this.channelFuture = new ServerBootstrap()
         .group(bossGroup, workerGroup)
-        .channel(NettyUtils.getServerChannel(bossGroup))
+        .channel(NettyUtils.getServerChannelClass(bossGroup))
         .handler(new LoggingHandler(LogLevel.INFO))
         .childHandler(newChannelInitializer(sslContext))
         .childOption(ChannelOption.SO_KEEPALIVE, true)

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -45,10 +45,7 @@ import org.apache.ratis.thirdparty.io.netty.channel.ChannelInitializer;
 import org.apache.ratis.thirdparty.io.netty.channel.ChannelOption;
 import org.apache.ratis.thirdparty.io.netty.channel.ChannelPipeline;
 import org.apache.ratis.thirdparty.io.netty.channel.EventLoopGroup;
-import org.apache.ratis.thirdparty.io.netty.channel.epoll.EpollEventLoopGroup;
-import org.apache.ratis.thirdparty.io.netty.channel.epoll.EpollServerSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.channel.socket.SocketChannel;
-import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioServerSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.codec.ByteToMessageDecoder;
 import org.apache.ratis.thirdparty.io.netty.handler.codec.MessageToMessageEncoder;
 import org.apache.ratis.thirdparty.io.netty.handler.logging.LogLevel;
@@ -184,8 +181,7 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
             host == null || host.isEmpty() ? new InetSocketAddress(port) : new InetSocketAddress(host, port);
     this.channelFuture = new ServerBootstrap()
         .group(bossGroup, workerGroup)
-        .channel(bossGroup instanceof EpollEventLoopGroup ?
-            EpollServerSocketChannel.class : NioServerSocketChannel.class)
+        .channel(NettyUtils.getServerChannel(bossGroup))
         .handler(new LoggingHandler(LogLevel.INFO))
         .childHandler(newChannelInitializer(sslContext))
         .childOption(ChannelOption.SO_KEEPALIVE, true)

--- a/ratis-test/src/test/java/org/apache/ratis/netty/TestTlsConfWithNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/netty/TestTlsConfWithNetty.java
@@ -38,6 +38,7 @@ import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.logging.LogLevel;
 import org.apache.ratis.thirdparty.io.netty.handler.logging.LoggingHandler;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContext;
+import org.apache.ratis.util.JavaUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -120,8 +121,12 @@ public class TestTlsConfWithNetty {
   static class NettyTestServer implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(NettyTestServer.class);
 
-    private final EventLoopGroup bossGroup = new NioEventLoopGroup(3);
-    private final EventLoopGroup workerGroup = new NioEventLoopGroup(3);
+    static final String CLASS_NAME = JavaUtils.getClassSimpleName(NettyTestServer.class);
+
+    private final EventLoopGroup bossGroup = NettyUtils.newEventLoopGroup(
+        CLASS_NAME + "-bossGroup", 3, true);
+    private final EventLoopGroup workerGroup = NettyUtils.newEventLoopGroup(
+        CLASS_NAME + "-workerGroup", 3, true);
     private final ChannelFuture channelFuture;
 
     public NettyTestServer(int port, SslContext sslContext) {

--- a/ratis-test/src/test/java/org/apache/ratis/netty/TestTlsConfWithNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/netty/TestTlsConfWithNetty.java
@@ -33,7 +33,6 @@ import org.apache.ratis.thirdparty.io.netty.channel.ChannelPipeline;
 import org.apache.ratis.thirdparty.io.netty.channel.EventLoopGroup;
 import org.apache.ratis.thirdparty.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.ratis.thirdparty.io.netty.channel.socket.SocketChannel;
-import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioServerSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.logging.LogLevel;
 import org.apache.ratis.thirdparty.io.netty.handler.logging.LoggingHandler;
@@ -132,7 +131,7 @@ public class TestTlsConfWithNetty {
     public NettyTestServer(int port, SslContext sslContext) {
       this.channelFuture = new ServerBootstrap()
           .group(bossGroup, workerGroup)
-          .channel(NioServerSocketChannel.class)
+          .channel(NettyUtils.getServerChannel(bossGroup))
           .handler(new LoggingHandler(getClass(), LogLevel.INFO))
           .childHandler(newChannelInitializer(sslContext))
           .bind(port)

--- a/ratis-test/src/test/java/org/apache/ratis/netty/TestTlsConfWithNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/netty/TestTlsConfWithNetty.java
@@ -131,7 +131,7 @@ public class TestTlsConfWithNetty {
     public NettyTestServer(int port, SslContext sslContext) {
       this.channelFuture = new ServerBootstrap()
           .group(bossGroup, workerGroup)
-          .channel(NettyUtils.getServerChannel(bossGroup))
+          .channel(NettyUtils.getServerChannelClass(bossGroup))
           .handler(new LoggingHandler(getClass(), LogLevel.INFO))
           .childHandler(newChannelInitializer(sslContext))
           .bind(port)


### PR DESCRIPTION
## What changes were proposed in this pull request?

From Netty documentation (https://netty.io/wiki/native-transports.html), `EpollEventLoopGroup` generally should have better performance than `NioEventLoopGroup` and therefore should be used by default. The only reason to use `NioEventLoopGroup` is if the underlying OS does not support it (`EpollEventLoopGroup` is only supported in Linux).

From the one of the core developer of Netty (Norman Maurer): https://stackoverflow.com/questions/35568365/netty-epolleventloopgroup-vs-nioeventloopgroup-which-should-i-choose-on-centos

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1898

## How was this patch tested?

Existing tests (`NioEventLoopGroup` to `EpollEventLoopGroup` should not introduce regressions).
