### PR TITLE
RATIS-1899. Use EpollEventLoopGroup for Netty Proxies

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/RaftClientConfigKeys.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/RaftClientConfigKeys.java
@@ -62,6 +62,15 @@ public interface RaftClientConfigKeys {
         TimeDuration timeoutDuration) {
       setTimeDuration(properties::setTimeDuration, WATCH_REQUEST_TIMEOUT_KEY, timeoutDuration);
     }
+
+    String USE_EPOLL_KEY = PREFIX + ".use-epoll";
+    boolean USE_EPOLL_DEFAULT = true;
+    static boolean useEpoll(RaftProperties properties) {
+      return getBoolean(properties::getBoolean, USE_EPOLL_KEY, USE_EPOLL_DEFAULT, getDefaultLog());
+    }
+    static void setUseEpoll(RaftProperties properties, boolean enable) {
+      setBoolean(properties::setBoolean, USE_EPOLL_KEY, enable);
+    }
   }
 
   interface Async {

--- a/ratis-client/src/main/java/org/apache/ratis/client/RaftClientConfigKeys.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/RaftClientConfigKeys.java
@@ -62,15 +62,6 @@ public interface RaftClientConfigKeys {
         TimeDuration timeoutDuration) {
       setTimeDuration(properties::setTimeDuration, WATCH_REQUEST_TIMEOUT_KEY, timeoutDuration);
     }
-
-    String USE_EPOLL_KEY = PREFIX + ".use-epoll";
-    boolean USE_EPOLL_DEFAULT = true;
-    static boolean useEpoll(RaftProperties properties) {
-      return getBoolean(properties::getBoolean, USE_EPOLL_KEY, USE_EPOLL_DEFAULT, getDefaultLog());
-    }
-    static void setUseEpoll(RaftProperties properties, boolean enable) {
-      setBoolean(properties::setBoolean, USE_EPOLL_KEY, enable);
-    }
   }
 
   interface Async {

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyClient.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyClient.java
@@ -23,7 +23,6 @@ import org.apache.ratis.thirdparty.io.netty.channel.ChannelFuture;
 import org.apache.ratis.thirdparty.io.netty.channel.ChannelInitializer;
 import org.apache.ratis.thirdparty.io.netty.channel.EventLoopGroup;
 import org.apache.ratis.thirdparty.io.netty.channel.socket.SocketChannel;
-import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.logging.LogLevel;
 import org.apache.ratis.thirdparty.io.netty.handler.logging.LoggingHandler;
 import org.apache.ratis.util.JavaUtils;
@@ -47,7 +46,7 @@ public class NettyClient implements Closeable {
     lifeCycle.startAndTransition(
         () -> channel = new Bootstrap()
             .group(group)
-            .channel(NioSocketChannel.class)
+            .channel(NettyUtils.getSocketChannelClass(group))
             .handler(new LoggingHandler(LogLevel.INFO))
             .handler(initializer)
             .connect(address)

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyConfigKeys.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyConfigKeys.java
@@ -76,6 +76,24 @@ public interface NettyConfigKeys {
     }
   }
 
+  interface Client {
+    Logger LOG = LoggerFactory.getLogger(Client.class);
+    static Consumer<String> getDefaultLog() {
+      return LOG::debug;
+    }
+
+    String PREFIX = NettyConfigKeys.PREFIX + ".client";
+
+    String USE_EPOLL_KEY = PREFIX + ".use-epoll";
+    boolean USE_EPOLL_DEFAULT = true;
+    static boolean useEpoll(RaftProperties properties) {
+      return getBoolean(properties::getBoolean, USE_EPOLL_KEY, USE_EPOLL_DEFAULT, getDefaultLog());
+    }
+    static void setUseEpoll(RaftProperties properties, boolean enable) {
+      setBoolean(properties::setBoolean, USE_EPOLL_KEY, enable);
+    }
+  }
+
   interface DataStream {
     Logger LOG = LoggerFactory.getLogger(DataStream.class);
     static Consumer<String> getDefaultLog() {

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyRpcProxy.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyRpcProxy.java
@@ -52,7 +52,7 @@ public class NettyRpcProxy implements Closeable {
 
     public PeerMap(String name, RaftProperties properties) {
       this(name, properties, NettyUtils.newEventLoopGroup(name, 0,
-          RaftClientConfigKeys.Rpc.useEpoll(properties)));
+          NettyConfigKeys.Client.useEpoll(properties)));
     }
 
     private PeerMap(String name, RaftProperties properties, EventLoopGroup group) {

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyRpcProxy.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyRpcProxy.java
@@ -22,7 +22,6 @@ import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.exceptions.TimeoutIOException;
 import org.apache.ratis.thirdparty.io.netty.channel.*;
-import org.apache.ratis.thirdparty.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.ratis.thirdparty.io.netty.channel.socket.SocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.codec.protobuf.ProtobufDecoder;
 import org.apache.ratis.thirdparty.io.netty.handler.codec.protobuf.ProtobufEncoder;
@@ -52,7 +51,8 @@ public class NettyRpcProxy implements Closeable {
     private final EventLoopGroup group;
 
     public PeerMap(String name, RaftProperties properties) {
-      this(name, properties, new NioEventLoopGroup());
+      this(name, properties, NettyUtils.newEventLoopGroup(name, 0,
+          RaftClientConfigKeys.Rpc.useEpoll(properties)));
     }
 
     private PeerMap(String name, RaftProperties properties, EventLoopGroup group) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similar to RATIS-1898, to use EpollEventLoopGroup for Netty proxies.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1899

## How was this patch tested?

Existing tests.
