### PR TITLE
RATIS-1909. Fix Decreasing Next Index When GrpcLogAppender Reset Client.

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -143,7 +143,7 @@ public class GrpcLogAppender extends LogAppenderBase {
       if (request != null && request.isHeartbeat()) {
         return;
       }
-      getFollower().decreaseNextIndex(nextIndex);
+      getFollower().computeNextIndex(getNextIndexForError(nextIndex));
     } catch (IOException ie) {
       LOG.warn(this + ": Failed to getClient for " + getFollowerId(), ie);
     }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
@@ -23,6 +23,8 @@ import org.apache.ratis.util.Timestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.function.LongUnaryOperator;
+
 /**
  * Information of a follower, provided the local server is the Leader
  */
@@ -83,6 +85,9 @@ public interface FollowerInfo {
 
   /** Update the nextIndex for this follower. */
   void updateNextIndex(long newNextIndex);
+
+  /** Set the nextIndex for this follower. */
+  void computeNextIndex(LongUnaryOperator op);
 
   /** @return the lastRpcResponseTime . */
   Timestamp getLastRpcResponseTime();

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -27,6 +27,7 @@ import org.apache.ratis.util.Timestamp;
 
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.LongUnaryOperator;
 
 class FollowerInfoImpl implements FollowerInfo {
   private final String name;
@@ -133,6 +134,12 @@ class FollowerInfoImpl implements FollowerInfo {
   public void updateNextIndex(long newNextIndex) {
     nextIndex.updateToMax(newNextIndex,
         message -> debug("updateNextIndex", message));
+  }
+
+  @Override
+  public void computeNextIndex(LongUnaryOperator op) {
+    nextIndex.updateUnconditionally(op,
+        message -> info("computeNextIndex", message));
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Decrease next index obeying that new one is larger than match index in `GrpcLogAppender::resetClient()`.

## What is the link to the Apache JIRA

[RATIS-1909](https://issues.apache.org/jira/browse/RATIS-1909)

## How was this patch tested?

Pass existed tests
