### PR TITLE
RATIS-1911. Add MembershipManager example.

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/counter/server/CounterStateMachine.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/counter/server/CounterStateMachine.java
@@ -82,7 +82,7 @@ public class CounterStateMachine extends BaseStateMachine {
 
   private final TimeDuration simulatedSlowness;
 
-  CounterStateMachine(TimeDuration simulatedSlowness) {
+  public CounterStateMachine(TimeDuration simulatedSlowness) {
     this.simulatedSlowness = simulatedSlowness;
   }
   CounterStateMachine() {

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/CServer.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/CServer.java
@@ -84,7 +84,7 @@ public class CServer implements Closeable {
     return server.getPeer();
   }
 
-  private static final FileVisitor deleter = new SimpleFileVisitor<Path>() {
+  private static final FileVisitor DELETER = new SimpleFileVisitor<Path>() {
     @Override
     public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
       Files.delete(dir);
@@ -101,7 +101,7 @@ public class CServer implements Closeable {
   @Override
   public void close() throws IOException {
     server.close();
-    Files.walkFileTree(storageDir.toPath(), deleter);
+    Files.walkFileTree(storageDir.toPath(), DELETER);
   }
 
   @Override

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/CServer.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/CServer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.examples.membership.server;
+
+import org.apache.ratis.RaftConfigKeys;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.examples.counter.server.CounterStateMachine;
+import org.apache.ratis.netty.NettyConfigKeys;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.rpc.SupportedRpcType;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.thirdparty.com.google.common.base.MoreObjects;
+import org.apache.ratis.util.TimeDuration;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+
+/**
+ * A simple raft server using {@link CounterStateMachine}.
+ */
+public class CServer implements Closeable {
+  public static final RaftGroupId GROUP_ID = RaftGroupId.randomId();
+  public static final String LOCAL_ADDR = "0.0.0.0";
+
+  private final RaftServer server;
+  private final int port;
+  private final File storageDir;
+
+  public CServer(RaftGroup group, RaftPeerId serverId, int port) throws IOException {
+    this.storageDir = new File("./" + serverId);
+    this.port = port;
+
+    final RaftProperties properties = new RaftProperties();
+    RaftServerConfigKeys.setStorageDir(properties, Collections.singletonList(storageDir));
+    RaftConfigKeys.Rpc.setType(properties, SupportedRpcType.NETTY);
+    NettyConfigKeys.Server.setPort(properties, port);
+
+    // create the counter state machine which holds the counter value.
+    final CounterStateMachine counterStateMachine = new CounterStateMachine(TimeDuration.ZERO);
+
+    // build the Raft server.
+    this.server = RaftServer.newBuilder()
+        .setGroup(group)
+        .setProperties(properties)
+        .setServerId(serverId)
+        .setStateMachine(counterStateMachine)
+        .setOption(RaftStorage.StartupOption.FORMAT)
+        .build();
+  }
+
+  public void start() throws IOException {
+    server.start();
+  }
+
+  public RaftPeer getPeer() {
+    return server.getPeer();
+  }
+
+  private static final FileVisitor deleter = new SimpleFileVisitor<Path>() {
+    @Override
+    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+      Files.delete(dir);
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+      Files.delete(file);
+      return FileVisitResult.CONTINUE;
+    }
+  };
+
+  @Override
+  public void close() throws IOException {
+    server.close();
+    Files.walkFileTree(storageDir.toPath(), deleter);
+  }
+
+  @Override
+  public String toString() {
+    try {
+      return MoreObjects.toStringHelper(this)
+          .add("server", server.getPeer())
+          .add("role", server.getDivision(GROUP_ID).getInfo().getCurrentRole())
+          .toString();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public int getPort() {
+    return port;
+  }
+}

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/CServer.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/CServer.java
@@ -30,17 +30,12 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.thirdparty.com.google.common.base.MoreObjects;
+import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.TimeDuration;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.FileVisitor;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
 
 /**
@@ -84,24 +79,10 @@ public class CServer implements Closeable {
     return server.getPeer();
   }
 
-  private static final FileVisitor DELETER = new SimpleFileVisitor<Path>() {
-    @Override
-    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-      Files.delete(dir);
-      return FileVisitResult.CONTINUE;
-    }
-
-    @Override
-    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-      Files.delete(file);
-      return FileVisitResult.CONTINUE;
-    }
-  };
-
   @Override
   public void close() throws IOException {
     server.close();
-    Files.walkFileTree(storageDir.toPath(), DELETER);
+    FileUtils.deleteFully(storageDir);
   }
 
   @Override

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/Console.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/Console.java
@@ -40,7 +40,7 @@ public class Console {
       + "\tquery                     Query the value of counter.\n"
       + "\tquit                      Quit.";
 
-  private final Scanner sc = new Scanner(System.in);
+  private final Scanner sc = new Scanner(System.in, "UTF-8");
   private final RaftCluster cluster = new RaftCluster();
 
   private void init() {
@@ -111,7 +111,7 @@ public class Console {
     int port = Integer.parseInt(args[index]);
     List<Integer> ports = new ArrayList<>();
     ports.addAll(cluster.ports());
-    if (ports.remove(new Integer(port))) {
+    if (ports.remove(Integer.valueOf(port))) {
       cluster.update(ports);
     } else {
       System.out.println("Invalid port " + port);

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/Console.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/Console.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.examples.membership.server;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Scanner;
+
+/**
+ * Interactive command line console.
+ */
+public class Console {
+  public static final String USAGE_MSG =
+    "Usage: java org.apache.ratis.examples.membership.server.Console [options]\n"
+      + "Options:\n"
+      + "\tupdate [new_peer_ports]   Update membership to C_new. Separate ports with comma. "
+      + "e.g. update 5100,5101\n"
+      + "\tadd [peer_port]           Add peer with peer_port to raft cluster. e.g. add 5103\n"
+      + "\tremove  [peer_port]       Remove peer with peer_port from raft cluster. e.g. remove"
+      + " 5100\n"
+      + "\tshow                      Show all peers of raft cluster.\n"
+      + "\tincr                      Increment the counter value.\n"
+      + "\tquery                     Query the value of counter.\n"
+      + "\tquit                      Quit.";
+
+  private final Scanner sc = new Scanner(System.in);
+  private final RaftCluster cluster = new RaftCluster();
+
+  private void init() {
+    System.out.println("Raft Server Membership Example.");
+    System.out.println("Type ports seperated by comma for initial peers. e.g. 5100,5101,5102");
+
+    String[] portArguments = commandLineInput()[0].split(",");
+    List<Integer> ports = new ArrayList<>();
+    Arrays.stream(portArguments).map(Integer::parseInt).forEach(ports::add);
+    try {
+      cluster.init(ports);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    show();
+    System.out.println(USAGE_MSG);
+  }
+
+  private void execute() {
+    while (true) {
+      try {
+        String[] args = commandLineInput();
+        String command = args[0];
+
+        if (command.equalsIgnoreCase("show")) {
+          show();
+        } else if (command.equalsIgnoreCase("add")) {
+          add(args, 1);
+        } else if (command.equalsIgnoreCase("remove")) {
+          remove(args, 1);
+        } else if (command.equalsIgnoreCase("update")) {
+          update(args, 1);
+        } else if (command.equalsIgnoreCase("incr")) {
+          cluster.counterIncrement();
+        } else if (command.equalsIgnoreCase("query")) {
+          cluster.queryCounter();
+        } else if (command.equalsIgnoreCase("quit")) {
+          break;
+        } else {
+          System.out.println(USAGE_MSG);
+        }
+      } catch (Exception e) {
+        System.out.println("Get error " + e.getMessage());
+      }
+    }
+    try {
+      System.out.println("Closing cluster...");
+      cluster.close();
+      System.out.println("Cluster closed successfully.");
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void show() {
+    cluster.show();
+  }
+
+  private void add(String[] args, int index) throws IOException {
+    int port = Integer.parseInt(args[index]);
+    List<Integer> ports = new ArrayList();
+    ports.add(port);
+    ports.addAll(cluster.ports());
+    cluster.update(ports);
+  }
+
+  private void remove(String[] args, int index) throws IOException {
+    int port = Integer.parseInt(args[index]);
+    List<Integer> ports = new ArrayList<>();
+    ports.addAll(cluster.ports());
+    if (ports.remove(new Integer(port))) {
+      cluster.update(ports);
+    } else {
+      System.out.println("Invalid port " + port);
+    }
+  }
+
+  private void update(String[] args, int index) throws IOException {
+    String[] portStrArray = args[index].split(",");
+    List<Integer> ports = new ArrayList<>();
+    for (String portStr : portStrArray) {
+      ports.add(Integer.parseInt(portStr));
+    }
+    cluster.update(ports);
+  }
+
+  private String[] commandLineInput() {
+    System.out.print(">>> ");
+    return sc.nextLine().split(" ");
+  }
+
+  public static void main(String[] args) throws IOException {
+    Console console = new Console();
+    console.init();
+    console.execute();
+  }
+}

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/RaftCluster.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/RaftCluster.java
@@ -76,7 +76,8 @@ public class RaftCluster {
     for (Integer port : newPorts) {
       CServer server = members.get(port);
       if (server == null) {
-        RaftGroup group = newPeerGroup(port);
+        // New peer always start with an empty group.
+        RaftGroup group = RaftGroup.valueOf(GROUP_ID);
         server = new CServer(group, peerId(port), port);
         peerToStart.add(server);
       }
@@ -166,20 +167,6 @@ public class RaftCluster {
           .setAddress(LOCAL_ADDR + ":" + port)
           .build());
     }
-    members.values().stream().map(CServer::getPeer).forEach(peers::add);
-    return RaftGroup.valueOf(GROUP_ID, peers);
-  }
-
-  /**
-   * Configure the raft group for a new peer.
-   */
-  private RaftGroup newPeerGroup(int port) {
-    RaftPeer currentPeer = RaftPeer.newBuilder()
-        .setId(peerId(port))
-        .setAddress(LOCAL_ADDR + ":" + port)
-        .build();
-    List<RaftPeer> peers = new ArrayList<>();
-    peers.add(currentPeer);
     members.values().stream().map(CServer::getPeer).forEach(peers::add);
     return RaftGroup.valueOf(GROUP_ID, peers);
   }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/RaftCluster.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/RaftCluster.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.examples.membership.server;
+
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.examples.counter.CounterCommand;
+import org.apache.ratis.netty.NettyFactory;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.util.Preconditions;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.ratis.examples.membership.server.CServer.GROUP_ID;
+import static org.apache.ratis.examples.membership.server.CServer.LOCAL_ADDR;
+
+/**
+ * An in process raft cluster. Running all servers in a single process.
+ */
+public class RaftCluster {
+  private Map<Integer, CServer> members = new HashMap<>();
+
+  /**
+   * Start cluster.
+   *
+   * @param initPorts the ports of the initial peers.
+   */
+  public void init(Collection<Integer> initPorts) throws IOException {
+    RaftGroup group = initGroup(initPorts);
+    for (int port : initPorts) {
+      CServer server = new CServer(group, peerId(port), port);
+      server.start();
+      members.put(port, server);
+    }
+  }
+
+  /**
+   * Update membership to C_new.
+   *
+   * @param newPorts the ports of the C_new peers.
+   */
+  public void update(Collection<Integer> newPorts) throws IOException {
+    Preconditions.assertTrue(members.size() > 0, "Cluster is empty.");
+
+    Collection<CServer> oldPeers = members.values();
+    List<CServer> newPeers = new ArrayList<>();
+    List<CServer> peerToStart = new ArrayList<>();
+    List<CServer> peerToStop = new ArrayList<>();
+
+    for (Integer port : newPorts) {
+      CServer server = members.get(port);
+      if (server == null) {
+        RaftGroup group = newPeerGroup(port);
+        server = new CServer(group, peerId(port), port);
+        peerToStart.add(server);
+      }
+      newPeers.add(server);
+    }
+
+    for (CServer peer : oldPeers) {
+      if (!newPeers.contains(peer)) {
+        peerToStop.add(peer);
+      }
+    }
+
+    // Step 1: start new peers.
+    System.out.println("Update membership ...... Step 1: start new peers.");
+    System.out.println(peersInfo(peerToStart, "Peers_to_start"));
+    for (CServer server : peerToStart) {
+      server.start();
+    }
+
+    // Step 2: update membership.
+    System.out.println("Update membership ...... Step 2: update membership from C_old to C_new.");
+    System.out.println(peersInfo(oldPeers, "C_old"));
+    System.out.println(peersInfo(newPeers, "C_new"));
+    if (members.size() > 0) {
+      RaftClient client = createClient();
+      try {
+        RaftClientReply reply = client.admin().setConfiguration(newPeers.stream()
+            .map(CServer::getPeer).collect(Collectors.toList()));
+        if (!reply.isSuccess()) {
+          throw reply.getException();
+        }
+      } finally {
+        client.close();
+      }
+    }
+
+    // Step 3: stop outdated peers.
+    System.out.println("Update membership ...... Step 3: stop outdated peers.");
+    System.out.println(peersInfo(peerToStop, "Peers_to_stop"));
+    for (CServer server : peerToStop) {
+      server.close();
+      members.remove(server.getPort());
+    }
+
+    // Add new peers to members.
+    for (CServer server : peerToStart) {
+      members.put(server.getPort(), server);
+    }
+  }
+
+  public void show() {
+    Collection<CServer> peers = members.values();
+    System.out.println(peersInfo(peers, "Cluster members"));
+  }
+
+  public void counterIncrement() throws IOException {
+    RaftClient client = createClient();
+    try {
+      RaftClientReply reply = client.io().send(CounterCommand.INCREMENT.getMessage());
+      if (!reply.isSuccess()) {
+        throw reply.getException();
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  public void queryCounter() throws IOException {
+    RaftClient client = createClient();
+    try {
+      RaftClientReply reply = client.io().sendReadOnly(CounterCommand.GET.getMessage());
+      String count = reply.getMessage().getContent().toStringUtf8();
+      System.out.println("Current counter value: " + count);
+    } finally {
+      client.close();
+    }
+  }
+
+  /**
+   * Configure the raft group with initial peers.
+   */
+  private RaftGroup initGroup(Collection<Integer> ports) {
+    List<RaftPeer> peers = new ArrayList<>();
+    for (int port : ports) {
+      peers.add(RaftPeer.newBuilder()
+          .setId(peerId(port))
+          .setAddress(LOCAL_ADDR + ":" + port)
+          .build());
+    }
+    members.values().stream().map(CServer::getPeer).forEach(peers::add);
+    return RaftGroup.valueOf(GROUP_ID, peers);
+  }
+
+  /**
+   * Configure the raft group for a new peer.
+   */
+  private RaftGroup newPeerGroup(int port) {
+    RaftPeer currentPeer = RaftPeer.newBuilder()
+        .setId(peerId(port))
+        .setAddress(LOCAL_ADDR + ":" + port)
+        .build();
+    List<RaftPeer> peers = new ArrayList<>();
+    peers.add(currentPeer);
+    members.values().stream().map(CServer::getPeer).forEach(peers::add);
+    return RaftGroup.valueOf(GROUP_ID, peers);
+  }
+
+  public Collection<Integer> ports() {
+    return members.keySet();
+  }
+
+  public void close() throws IOException {
+    for (CServer server : members.values()) {
+      server.close();
+    }
+  }
+
+  private RaftClient createClient() {
+    RaftProperties properties = new RaftProperties();
+    RaftClient.Builder builder = RaftClient.newBuilder().setProperties(properties);
+
+    builder.setRaftGroup(RaftGroup.valueOf(GROUP_ID,
+        members.values().stream().map(s -> s.getPeer()).collect(Collectors.toList())));
+
+    builder.setClientRpc(new NettyFactory(new Parameters()).newRaftClientRpc(ClientId.randomId(), properties));
+
+    return builder.build();
+  }
+
+  private static RaftPeerId peerId(int port) {
+    return RaftPeerId.valueOf("p" + port);
+  }
+
+  private static String peersInfo(Collection<CServer> peers, String prefix) {
+    StringBuilder msgBuilder = new StringBuilder(prefix).append("={");
+    if (peers.size() == 0) {
+      msgBuilder.append("}");
+    } else {
+      peers.forEach(p -> msgBuilder.append("\n\t").append(p));
+      msgBuilder.append("\n}");
+    }
+    return msgBuilder.toString();
+  }
+}

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/RaftCluster.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/RaftCluster.java
@@ -102,15 +102,12 @@ public class RaftCluster {
     System.out.println(peersInfo(oldPeers, "C_old"));
     System.out.println(peersInfo(newPeers, "C_new"));
     if (members.size() > 0) {
-      RaftClient client = createClient();
-      try {
+      try (RaftClient client = createClient()) {
         RaftClientReply reply = client.admin().setConfiguration(newPeers.stream()
             .map(CServer::getPeer).collect(Collectors.toList()));
         if (!reply.isSuccess()) {
           throw reply.getException();
         }
-      } finally {
-        client.close();
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The 《CONSENSUS: BRIDGING THEORY AND PRACTICE》 has explain the JOINT consensus, which is implemented by ratis. But it didn't say how to configure the initial conf for new peers. I didn't find demonstration in ratis either.
 
Initial conf for new peers is easy to make mistakes and cause split brain or cluster unavailable. I think we can add an example to illustrate how to initiate new peers when performing membership change.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1911

## How was this patch tested?

Manual tests. This example is an interactive console.
<img width="1916" alt="image" src="https://github.com/apache/ratis/assets/16864967/9bb910a5-f92f-442d-aef5-6c8fea44790b">
