### PR TITLE
RATIS-1913. Assert that the primary peers in DataStreamClient and RoutingTable are equal

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -44,6 +44,7 @@ import org.apache.ratis.protocol.*;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.MemoizedSupplier;
+import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.SlidingWindow;
 
 import java.io.IOException;
@@ -230,6 +231,14 @@ public class DataStreamClientImpl implements DataStreamClient {
 
   @Override
   public DataStreamOutputRpc stream(ByteBuffer headerMessage, RoutingTable routingTable) {
+    if (routingTable != null) {
+      // Validate that the primary peer is equal to the primary peer passed
+      // by the RoutingTable
+      Preconditions.assertTrue(
+          dataStreamServer.getId().equals(routingTable.getPrimary()),
+          "The primary peer in the routing table is not the same " +
+              "with the one specified in the client");
+    }
     final Message message =
         Optional.ofNullable(headerMessage).map(ByteString::copyFrom).map(Message::valueOf).orElse(null);
     RaftClientRequest request = RaftClientRequest.newBuilder()

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -231,7 +231,7 @@ public class DataStreamClientImpl implements DataStreamClient {
 
   @Override
   public DataStreamOutputRpc stream(ByteBuffer headerMessage, RoutingTable routingTable) {
-    if (routingTable != null) {
+    if (routingTable != null && routingTable.getPrimary() != null) {
       // Validate that the primary peer is equal to the primary peer passed
       // by the RoutingTable
       Preconditions.assertTrue(

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -231,13 +231,11 @@ public class DataStreamClientImpl implements DataStreamClient {
 
   @Override
   public DataStreamOutputRpc stream(ByteBuffer headerMessage, RoutingTable routingTable) {
-    if (routingTable != null && routingTable.getPrimary() != null) {
-      // Validate that the primary peer is equal to the primary peer passed
-      // by the RoutingTable
-      Preconditions.assertTrue(
-          dataStreamServer.getId().equals(routingTable.getPrimary()),
-          "The primary peer in the routing table is not the same " +
-              "with the one specified in the client");
+    if (routingTable != null) {
+      // Validate that the primary peer is equal to the primary peer passed by the RoutingTable
+      Preconditions.assertTrue(dataStreamServer.getId().equals(routingTable.getPrimary()),
+          () -> "Primary peer mismatched: the routing table has " + routingTable.getPrimary()
+              + " but the client has " + dataStreamServer.getId());
     }
     final Message message =
         Optional.ofNullable(headerMessage).map(ByteString::copyFrom).map(Message::valueOf).orElse(null);

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RoutingTable.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RoutingTable.java
@@ -81,9 +81,11 @@ public interface RoutingTable {
     }
 
     public RoutingTable build() {
-      return Optional.ofNullable(ref.getAndSet(null))
-          .map(RoutingTable::newRoutingTable)
-          .orElseThrow(() -> new IllegalStateException("RoutingTable Already built"));
+      final Map<RaftPeerId, Set<RaftPeerId>> map = ref.getAndSet(null);
+      if (map == null) {
+        throw new IllegalStateException("RoutingTable is already built.");
+      }
+      return RoutingTable.newRoutingTable(map);
     }
 
     static RaftPeerId validate(Map<RaftPeerId, Set<RaftPeerId>> map) {

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RoutingTable.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RoutingTable.java
@@ -87,10 +87,7 @@ public interface RoutingTable {
     }
 
     static RaftPeerId validate(Map<RaftPeerId, Set<RaftPeerId>> map) {
-      if (map != null && !map.isEmpty()) {
-        return new Builder.Validation(map).run();
-      }
-      return null;
+      return new Builder.Validation(map).run();
     }
 
     /** Validate if a map represents a valid routing table. */
@@ -164,7 +161,10 @@ public interface RoutingTable {
 
   /** @return a new {@link RoutingTable} represented by the given map. */
   static RoutingTable newRoutingTable(Map<RaftPeerId, Set<RaftPeerId>> map){
-    RaftPeerId primary = Builder.validate(map);
+    if (map == null || map.isEmpty()) {
+      return null;
+    }
+    final RaftPeerId primary = Builder.validate(map);
 
     final Supplier<RoutingTableProto> proto = JavaUtils.memoize(
         () -> RoutingTableProto.newBuilder().addAllRoutes(ProtoUtils.toRouteProtos(map)).build());

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamSslWithRpcTypeGrpcAndDataStreamTypeNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamSslWithRpcTypeGrpcAndDataStreamTypeNetty.java
@@ -62,6 +62,11 @@ public class TestDataStreamSslWithRpcTypeGrpcAndDataStreamTypeNetty
 
   @Ignore
   @Override
+  public void testStreamWithInvalidRoutingTable() {
+  }
+
+  @Ignore
+  @Override
   public void testMultipleStreamsMultipleServers() {
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

While implementing [HDDS-9392](https://issues.apache.org/jira/browse/HDDS-9392), I incorrectly updated the first node in `RoutingTable` so that it does not point to the same node in `DataStreamClientImpl#dataStreamServer`. This causes some issues that took a while to debug due to the lack of assertion.

To prevent this in the future, let's setup an assertion in `DataStreamClientImpl#stream` to throw exception if the first node in `RoutingTable` is not equal to `DataStreamClientImpl#dataStreamServer`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1913

## How was this patch tested?

Unit test.
