### PR TITLE
RATIS-1918 Introduces parameters that separately control the shutdown of RaftServerProxy by JVMPauseMonitor

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -81,6 +81,16 @@ public interface RaftServerConfigKeys {
     setInt(properties::setInt, SLEEP_DEVIATION_THRESHOLD_KEY, thresholdMs);
   }
 
+  String CLOSE_THRESHOLD_KEY = PREFIX + ".close.threshold";
+  TimeDuration CLOSE_THRESHOLD_DEFAULT = TimeDuration.valueOf(60, TimeUnit.SECONDS);
+  static TimeDuration closeThreshold(RaftProperties properties) {
+    return getTimeDuration(properties.getTimeDuration(CLOSE_THRESHOLD_DEFAULT.getUnit()),
+        CLOSE_THRESHOLD_KEY, CLOSE_THRESHOLD_DEFAULT, getDefaultLog());
+  }
+  static void setCloseThreshold(RaftProperties properties, int thresholdMs) {
+    setInt(properties::setInt, CLOSE_THRESHOLD_KEY, thresholdMs);
+  }
+
   /**
    * When bootstrapping a new peer, If the gap between the match index of the
    * peer and the leader's latest committed index is less than this gap, we

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -222,11 +222,11 @@ class RaftServerProxy implements RaftServer {
         id + "-impl"));
 
     final TimeDuration sleepDeviationThreshold = RaftServerConfigKeys.sleepDeviationThreshold(properties);
-    final TimeDuration rpcSlownessTimeout = RaftServerConfigKeys.Rpc.slownessTimeout(properties);
+    final TimeDuration closeThreshold = RaftServerConfigKeys.closeThreshold(properties);
     final TimeDuration leaderStepDownWaitTime = RaftServerConfigKeys.LeaderElection.leaderStepDownWaitTime(properties);
     this.pauseMonitor = JvmPauseMonitor.newBuilder().setName(id)
         .setSleepDeviationThreshold(sleepDeviationThreshold)
-        .setHandler(extraSleep -> handleJvmPause(extraSleep, rpcSlownessTimeout, leaderStepDownWaitTime))
+        .setHandler(extraSleep -> handleJvmPause(extraSleep, closeThreshold, leaderStepDownWaitTime))
         .build();
     this.threadGroup = threadGroup == null ? new ThreadGroup(this.id.toString()) : threadGroup;
   }


### PR DESCRIPTION
see [jira](https://issues.apache.org/jira/browse/RATIS-1918)