### PR TITLE
RATIS-1921. Shared worker group in WorkerGroupGetter should be closed

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
@@ -62,6 +62,11 @@ public interface ReferenceCountedObject<T> {
    */
   boolean release();
 
+  /** The same as wrap(value, EMPTY, EMPTY), where EMPTY is an empty method. */
+  static <V> ReferenceCountedObject<V> wrap(V value) {
+    return wrap(value, () -> {}, () -> {});
+  }
+
   /**
    * Wrap the given value as a {@link ReferenceCountedObject}.
    *
@@ -81,8 +86,11 @@ public interface ReferenceCountedObject<T> {
 
       @Override
       public V get() {
-        if (count.get() < 0) {
+        final int previous = count.get();
+        if (previous < 0) {
           throw new IllegalStateException("Failed to get: object has already been completely released.");
+        } else if (previous == 0) {
+          throw new IllegalStateException("Failed to get: object has not yet been retained.");
         }
         return value;
       }

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyConfigKeys.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyConfigKeys.java
@@ -158,7 +158,7 @@ public interface NettyConfigKeys {
       }
 
       String WORKER_GROUP_SHARE_KEY = PREFIX + ".worker-group.share";
-      boolean WORKER_GROUP_SHARE_DEFAULT = false;
+      boolean WORKER_GROUP_SHARE_DEFAULT = true;
       static boolean workerGroupShare(RaftProperties properties) {
         return getBoolean(properties::getBoolean, WORKER_GROUP_SHARE_KEY,
             WORKER_GROUP_SHARE_DEFAULT, getDefaultLog());

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
@@ -56,6 +56,7 @@ import org.apache.ratis.thirdparty.io.netty.util.concurrent.ScheduledFuture;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.MemoizedSupplier;
 import org.apache.ratis.util.NetUtils;
+import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.ReferenceCountedObject;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
@@ -69,7 +70,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -81,52 +81,32 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
 
   private static class WorkerGroupGetter implements Supplier<EventLoopGroup> {
 
-    private static class RefCountedWorkerGroup implements ReferenceCountedObject<EventLoopGroup> {
-      private final AtomicInteger count = new AtomicInteger();
-      private final AtomicReference<EventLoopGroup> value = new AtomicReference<>();
+    private static final AtomicReference<ReferenceCountedObject<EventLoopGroup>> SHARED_WORKER_GROUP =
+        new AtomicReference<>();
 
-      @Override
-      public synchronized EventLoopGroup get() {
-        if (count.get() < 0) {
-          throw new IllegalStateException("Failed to get: object has already been completely released.");
-        }
-        return value.get();
-      }
-
-      @Override
-      public synchronized EventLoopGroup retain() {
-        // n <  0: exception
-        // n >= 0: n++
-        final int previous = count.getAndUpdate(n -> n < 0? n : n + 1);
-        if (previous < 0) {
-          throw new IllegalStateException("Failed to retain: object has already been completely released.");
-        } else if (previous == 0) {
-          // TODO: Find a way to pass RaftProperties
-          // New shared worker group will be created when previously there is
-          // no active connections
-          return value.updateAndGet(g -> g != null ? g: newWorkerGroup(new RaftProperties()));
-        }
-        return value.get();
-      }
-
-      @Override
-      public synchronized boolean release() {
-        // n <= 0: exception
-        // n >= 1: n--
-        final int previous = count.getAndUpdate(n -> n <= 0? -1: n - 1);
-        if (previous <= 0) {
-          throw new IllegalStateException("Failed to release: object has already been completely released.");
-        } else if (previous == 1) {
-          // Shutdown the event loop group when there are no active connection,
-          // subsequent retain will create a new shared worker group.
-          EventLoopGroup previousEventLoopGroup = value.getAndSet(null);
-          previousEventLoopGroup.shutdownGracefully();
-        }
-        return previous == 1;
+    static WorkerGroupGetter newInstance(RaftProperties properties) {
+      final boolean shared = NettyConfigKeys.DataStream.Client.workerGroupShare(properties);
+      if (shared) {
+        final Supplier<ReferenceCountedObject<EventLoopGroup>> supplier = MemoizedSupplier.valueOf(
+            () -> ReferenceCountedObject.wrap(newWorkerGroup((properties))));
+        final ReferenceCountedObject<EventLoopGroup> sharedWorkerGroup = SHARED_WORKER_GROUP.updateAndGet(
+            g -> g != null ? g : supplier.get());
+        return new WorkerGroupGetter(sharedWorkerGroup.get()) {
+          @Override
+          void shutdownGracefully() {
+            final ReferenceCountedObject<EventLoopGroup> returned = SHARED_WORKER_GROUP.updateAndGet(ref -> {
+              Preconditions.assertSame(sharedWorkerGroup, ref, "SHARED_WORKER_GROUP");
+              return ref.release() ? null : ref;
+            });
+            if (returned == null) {
+              workerGroup.shutdownGracefully();
+            }
+          }
+        };
+      } else {
+        return new WorkerGroupGetter(newWorkerGroup(properties));
       }
     }
-
-    private static final RefCountedWorkerGroup SHARED_WORKER_GROUP = new RefCountedWorkerGroup();
 
     static EventLoopGroup newWorkerGroup(RaftProperties properties) {
       return NettyUtils.newEventLoopGroup(
@@ -135,33 +115,19 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
           NettyConfigKeys.DataStream.Client.useEpoll(properties));
     }
 
-    private final EventLoopGroup workerGroup;
-    private final boolean isSharedWorkerGroup;
+    final EventLoopGroup workerGroup;
 
-    WorkerGroupGetter(RaftProperties properties) {
-      isSharedWorkerGroup = NettyConfigKeys.DataStream.Client.workerGroupShare(properties);
-      if (isSharedWorkerGroup) {
-        SHARED_WORKER_GROUP.retain();
-        workerGroup = null;
-      } else {
-        workerGroup = newWorkerGroup(properties);
-      }
+    private WorkerGroupGetter(EventLoopGroup workerGroup) {
+      this.workerGroup = workerGroup;
     }
 
     @Override
-    public EventLoopGroup get() {
-      if (isSharedWorkerGroup) {
-        return SHARED_WORKER_GROUP.get();
-      }
+    public final EventLoopGroup get() {
       return workerGroup;
     }
 
     void shutdownGracefully() {
-      if (isSharedWorkerGroup) {
-        SHARED_WORKER_GROUP.release();
-      } else {
-        workerGroup.shutdownGracefully();
-      }
+      workerGroup.shutdownGracefully();
     }
   }
 
@@ -310,8 +276,7 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
 
     final InetSocketAddress address = NetUtils.createSocketAddr(server.getDataStreamAddress());
     final SslContext sslContext = NettyUtils.buildSslContextForClient(tlsConf);
-    this.connection = new Connection(address,
-        new WorkerGroupGetter(properties),
+    this.connection = new Connection(address, WorkerGroupGetter.newInstance(properties),
         () -> newChannelInitializer(address, sslContext, getClientHandler()));
   }
 

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
@@ -91,7 +91,7 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
             () -> ReferenceCountedObject.wrap(newWorkerGroup((properties))));
         final ReferenceCountedObject<EventLoopGroup> sharedWorkerGroup = SHARED_WORKER_GROUP.updateAndGet(
             g -> g != null ? g : supplier.get());
-        return new WorkerGroupGetter(sharedWorkerGroup.get()) {
+        return new WorkerGroupGetter(sharedWorkerGroup.retain()) {
           @Override
           void shutdownGracefully() {
             final ReferenceCountedObject<EventLoopGroup> returned = SHARED_WORKER_GROUP.updateAndGet(ref -> {

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
@@ -102,7 +102,7 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
               return previous.join().release() ? null : previous;
             });
             if (returned == null) {
-              workerGroup.shutdownGracefully();
+              get().shutdownGracefully();
             }
           }
         };
@@ -118,7 +118,7 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
           NettyConfigKeys.DataStream.Client.useEpoll(properties));
     }
 
-    final EventLoopGroup workerGroup;
+    private final EventLoopGroup workerGroup;
 
     private WorkerGroupGetter(EventLoopGroup workerGroup) {
       this.workerGroup = workerGroup;

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -326,9 +326,11 @@ public class DataStreamManagement {
     for (ByteBuffer buffer : buf.nioBuffers()) {
       final ReferenceCountedObject<ByteBuffer> wrapped = ReferenceCountedObject.wrap(buffer, buf::retain, buf::release);
       try {
-        byteWritten += channel.write(wrapped);
+        byteWritten += channel.write(wrapped.retain());
       } catch (Throwable t) {
         throw new CompletionException(t);
+      } finally {
+        wrapped.release();
       }
     }
 

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -325,8 +325,9 @@ public class DataStreamManagement {
     long byteWritten = 0;
     for (ByteBuffer buffer : buf.nioBuffers()) {
       final ReferenceCountedObject<ByteBuffer> wrapped = ReferenceCountedObject.wrap(buffer, buf::retain, buf::release);
+      wrapped.retain();
       try {
-        byteWritten += channel.write(wrapped.retain());
+        byteWritten += channel.write(wrapped);
       } catch (Throwable t) {
         throw new CompletionException(t);
       } finally {

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestNettyDataStreamChainTopologyWithGrpcCluster.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestNettyDataStreamChainTopologyWithGrpcCluster.java
@@ -17,7 +17,25 @@
  */
 package org.apache.ratis.datastream;
 
+import org.apache.ratis.client.RaftClientConfigKeys;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.netty.NettyConfigKeys;
+import org.apache.ratis.util.SizeInBytes;
+import org.apache.ratis.util.TimeDuration;
+import org.junit.Before;
+
 public class TestNettyDataStreamChainTopologyWithGrpcCluster
     extends DataStreamAsyncClusterTests<MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty>
     implements MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty.FactoryGet {
+
+  @Before
+  public void setup() {
+    final RaftProperties p = getProperties();
+    RaftClientConfigKeys.DataStream.setRequestTimeout(p, TimeDuration.ONE_MINUTE);
+    RaftClientConfigKeys.DataStream.setFlushRequestCountMin(p, 4);
+    RaftClientConfigKeys.DataStream.setFlushRequestBytesMin(p, SizeInBytes.valueOf("10MB"));
+    RaftClientConfigKeys.DataStream.setOutstandingRequestsMax(p, 2 << 16);
+
+    NettyConfigKeys.DataStream.Client.setWorkerGroupSize(p,100);
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestNettyDataStreamStarTopologyWithGrpcCluster.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestNettyDataStreamStarTopologyWithGrpcCluster.java
@@ -19,6 +19,7 @@ package org.apache.ratis.datastream;
 
 import org.apache.ratis.client.RaftClientConfigKeys;
 import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.netty.NettyConfigKeys;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.RoutingTable;
@@ -41,6 +42,8 @@ public class TestNettyDataStreamStarTopologyWithGrpcCluster
     RaftClientConfigKeys.DataStream.setFlushRequestCountMin(p, 4);
     RaftClientConfigKeys.DataStream.setFlushRequestBytesMin(p, SizeInBytes.valueOf("10MB"));
     RaftClientConfigKeys.DataStream.setOutstandingRequestsMax(p, 2 << 16);
+
+    NettyConfigKeys.DataStream.Client.setWorkerGroupSize(p,100);
   }
 
   @Override

--- a/ratis-test/src/test/java/org/apache/ratis/util/TestReferenceCountedObject.java
+++ b/ratis-test/src/test/java/org/apache/ratis/util/TestReferenceCountedObject.java
@@ -47,7 +47,12 @@ public class TestReferenceCountedObject {
         value, retained::getAndIncrement, released::getAndIncrement);
 
     assertValues(retained, 0, released, 0);
-    Assert.assertEquals(value, ref.get());
+    try {
+      ref.get();
+      Assert.fail();
+    } catch (IllegalStateException e) {
+      e.printStackTrace(System.out);
+    }
     assertValues(retained, 0, released, 0);
 
     Assert.assertEquals(value, ref.retain());


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Problem

When benchmarking Ozone streaming pipeline using `ozone freon ockg`, the benchmark would not end although all the keys have been written.  `hdds.ratis.raft.netty.dataStream.client.worker-group.share` is set to true to use the shared worker group optimization.

Using Arthas, it's found that non-daemon threads like "NettyClientStreamRpc-workerGroup–thread1" are still running even after the benchmark has finished. The root cause is that the shared worker group will never be closed, causing the JVM shutdown hook to never be triggered. The benchmark was able to shutdown normally if the share configuration is disabled.

### Background

It seems that shared worker group is a lazily instantiated singleton. The shared worker group will be instantiated when the first `WorkerGroupGetter` is instantiated and passed to a new `Connection`during construction. Due to the nature of singleton, this worker group will be shared across all the Raft clients under the same Ozone client (please correct me if I'm wrong). 

In the case of Ozone streaming write pipeline, every `BlockDatastreamOutput` (whose scope is a single block) will create a new `RaftClient` which corresponds to a single `NettyClientStreamRpc` instance. These `RaftClient`s will share the shared worker group.

### Solution

The current solution uses a "modified" reference counted `EventLoopGroup` using the `ReferenceCountedObject` interface. Previously, I was trying to use the implementation from `ReferenceCountedObject#wrap`. However, when the reference count is 1 and `release()` is invoked, it will completely release the object and throw exceptions for any further operations. This implementation does not seem to suit the use case.

The "modified" reference count instantiates the shared worker group whenever it's retained and the previous reference count is 0. It will also gracefully shutdown the worker group when it's released and the reference count becomes 0.  it's retained whenever a new `WorkerGroupGetter` is instantiated (i.e when connection is created), and released when the connection is closed. 

Technically, the worker group is not a singleton anymore, the shared worker group will be shared with all the connections, but will be removed and shutdown when all connections are removed, subsequent connections will use a new shared worker group. This should guarantee that there will be one worker group shared among the connections, but not necessarily the same instance.

The current solution is still a rough solution for reference what the solution might be,  any advise is greatly appreciated.

Also enabled the `hdds.ratis.raft.netty.dataStream.client.worker-group.share` according to (https://github.com/szetszwo/ozone-benchmark/blob/master/benchmark-conf.xml).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1921

## How was this patch tested?

Existing unit tests (enable worker group sharing by default). Also tested using `ozone freon ockg` again.
