### PR TITLE
RATIS-1924. Increase the default of raft.server.log.segment.size.max.

### DIFF
--- a/ratis-docs/src/site/markdown/configurations.md
+++ b/ratis-docs/src/site/markdown/configurations.md
@@ -318,7 +318,7 @@ Ratis will temporarily stall the new IO Tasks.
 |:----------------|:--------------------------------------------|
 | **Description** | max file size for a single Raft Log Segment |
 | **Type**        | SizeInBytes                                 |
-| **Default**     | 8MB                                         |
+| **Default**     | 32MB                                        |
 
 | **Property**    | `raft.server.log.segment.cache.num.max`                                     |
 |:----------------|:----------------------------------------------------------------------------|

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -381,7 +381,7 @@ public interface RaftServerConfigKeys {
     }
 
     String SEGMENT_SIZE_MAX_KEY = PREFIX + ".segment.size.max";
-    SizeInBytes SEGMENT_SIZE_MAX_DEFAULT = SizeInBytes.valueOf("8MB");
+    SizeInBytes SEGMENT_SIZE_MAX_DEFAULT = SizeInBytes.valueOf("32MB");
     static SizeInBytes segmentSizeMax(RaftProperties properties) {
       return getSizeInBytes(properties::getSizeInBytes,
           SEGMENT_SIZE_MAX_KEY, SEGMENT_SIZE_MAX_DEFAULT, getDefaultLog());


### PR DESCRIPTION
See RATIS-1924