### PR TITLE
RATIS-1929. Bump ratis-thirdparty version to 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,11 +207,11 @@
     <maven.min.version>3.3.9</maven.min.version>
 
     <!-- Contains all shaded thirdparty dependencies -->
-    <ratis.thirdparty.version>1.0.4</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.5</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
-    <shaded.protobuf.version>3.19.6</shaded.protobuf.version>
-    <shaded.grpc.version>1.51.1</shaded.grpc.version>
+    <shaded.protobuf.version>3.24.4 </shaded.protobuf.version>
+    <shaded.grpc.version>1.58.0</shaded.grpc.version>
 
     <!-- Test properties -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
     <ratis.thirdparty.version>1.0.5</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
-    <shaded.protobuf.version>3.24.4 </shaded.protobuf.version>
+    <shaded.protobuf.version>3.24.4</shaded.protobuf.version>
     <shaded.grpc.version>1.58.0</shaded.grpc.version>
 
     <!-- Test properties -->


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/RATIS-1929