### PR TITLE
RATIS-589. Eliminate buffer copying in SegmentedRaftLogOutputStream.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/IOUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/IOUtils.java
@@ -126,22 +126,6 @@ public interface IOUtils {
     }
   }
 
-  /**
-   * Write a ByteBuffer to a FileChannel at a given offset,
-   * handling short writes.
-   *
-   * @param fc               The FileChannel to write to
-   * @param buf              The input buffer
-   * @param offset           The offset in the file to start writing at
-   * @throws IOException     On I/O error
-   */
-  static void writeFully(FileChannel fc, ByteBuffer buf, long offset)
-      throws IOException {
-    do {
-      offset += fc.write(buf, offset);
-    } while (buf.remaining() > 0);
-  }
-
   static long preallocate(FileChannel fc, long size, ByteBuffer fill) throws IOException {
     Preconditions.assertSame(0, fill.position(), "fill.position");
     Preconditions.assertSame(fill.capacity(), fill.limit(), "fill.limit");
@@ -153,8 +137,9 @@ public interface IOUtils {
       final int n = remaining < required? remaining: Math.toIntExact(required);
       final ByteBuffer buffer = fill.slice();
       buffer.limit(n);
-      IOUtils.writeFully(fc, buffer, fc.size());
-      allocated += n;
+
+      final int written = fc.write(buffer, fc.size());
+      allocated += written;
     }
     return allocated;
   }

--- a/ratis-common/src/test/java/org/apache/ratis/util/TestPureJavaCrc32C.java
+++ b/ratis-common/src/test/java/org/apache/ratis/util/TestPureJavaCrc32C.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.util;
+
+import org.apache.ratis.BaseTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadLocalRandom;
+
+/** Testing {@link PureJavaCrc32C}. */
+public class TestPureJavaCrc32C extends BaseTest {
+  static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
+
+  @Test
+  public void testByteBuffer() {
+    for(int length = 1; length < 1 << 20; length <<= 2) {
+      runTestByteBuffer(length - 1);
+      runTestByteBuffer(length);
+      runTestByteBuffer(length + 1);
+    }
+  }
+
+  /** Verify if the CRC computed by {@link ByteBuffer}s is the same as the CRC computed by arrays. */
+  static void runTestByteBuffer(int length) {
+    final byte[] array = new byte[length];
+    RANDOM.nextBytes(array);
+    final ByteBuffer buffer = ByteBuffer.wrap(array);
+
+    final PureJavaCrc32C arrayCrc = new PureJavaCrc32C();
+    final PureJavaCrc32C bufferCrc = new PureJavaCrc32C();
+    for (int off = 0; off < array.length; ) {
+      final int len = RANDOM.nextInt(array.length - off) + 1;
+      arrayCrc.update(array, off, len);
+
+      buffer.position(off).limit(off + len);
+      bufferCrc.update(buffer);
+
+      Assert.assertEquals(arrayCrc.getValue(), bufferCrc.getValue());
+      off += len;
+    }
+  }
+}

--- a/ratis-docs/src/site/markdown/configurations.md
+++ b/ratis-docs/src/site/markdown/configurations.md
@@ -342,7 +342,7 @@ Ratis will temporarily stall the new IO Tasks.
 |:----------------|:------------------------------------------------------------|
 | **Description** | size of direct byte buffer for SegmentedRaftLog FileChannel |
 | **Type**        | SizeInBytes                                                 |
-| **Default**     | 64KB                                                        |
+| **Default**     | 8MB                                                         |
 
 | **Property**    | `raft.server.log.force.sync.num`                                                |
 |:----------------|:--------------------------------------------------------------------------------|

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -424,7 +424,7 @@ public interface RaftServerConfigKeys {
     }
 
     String WRITE_BUFFER_SIZE_KEY = PREFIX + ".write.buffer.size";
-    SizeInBytes WRITE_BUFFER_SIZE_DEFAULT =SizeInBytes.valueOf("64KB");
+    SizeInBytes WRITE_BUFFER_SIZE_DEFAULT = SizeInBytes.valueOf("8MB");
     static SizeInBytes writeBufferSize(RaftProperties properties) {
       return getSizeInBytes(properties::getSizeInBytes,
           WRITE_BUFFER_SIZE_KEY, WRITE_BUFFER_SIZE_DEFAULT, getDefaultLog());

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
@@ -107,8 +107,10 @@ class BufferedWriteChannel implements Closeable {
   void writeToChannel(ByteBuffer buffer) throws IOException {
     Preconditions.assertSame(0, writeBufferPosition(), "writeBuffer.position()");
     final int length = buffer.remaining();
-    LOG.debug("Write {} bytes (pos={}, size={}) to channel {}",
-        length, fileChannel.position(), fileChannel.size(), this);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Write {} bytes (pos={}, size={}) to channel {}",
+          length, fileChannel.position(), fileChannel.size(), this);
+    }
     int written = 0;
     for(; written < length; ) {
       written += fileChannel.write(buffer);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
@@ -18,15 +18,17 @@
 package org.apache.ratis.server.raftlog.segmented;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.function.CheckedBiFunction;
+import org.apache.ratis.util.function.CheckedConsumer;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
@@ -34,24 +36,28 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Provides a buffering layer in front of a FileChannel for writing.
- *
+ * <p>
  * This class is NOT threadsafe.
  */
 class BufferedWriteChannel implements Closeable {
-
   @SuppressWarnings("java:S2095") // return Closable
   static BufferedWriteChannel open(File file, boolean append, ByteBuffer buffer) throws IOException {
-    final RandomAccessFile raf = new RandomAccessFile(file, "rw");
-    final FileChannel fc = raf.getChannel();
+    final long size = file.length(); // 0L if the file does not exist.
+    final FileChannel fc;
     if (append) {
-      fc.position(fc.size());
+      fc = FileUtils.newFileChannel(file, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+      Preconditions.assertSame(size, fc.size(), "fc.size");
     } else {
-      fc.truncate(0);
+      fc = FileUtils.newFileChannel(file, StandardOpenOption.WRITE, StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING);
+      Preconditions.assertSame(0, fc.size(), "fc.size");
     }
     Preconditions.assertSame(fc.size(), fc.position(), "fc.position");
-    return new BufferedWriteChannel(fc, buffer);
+    final String name = file + (append? " (append)": "");
+    return new BufferedWriteChannel(name, fc, buffer);
   }
 
+  private final String name;
   private final FileChannel fileChannel;
   private final ByteBuffer writeBuffer;
   private boolean forced = true;
@@ -59,29 +65,55 @@ class BufferedWriteChannel implements Closeable {
       = new AtomicReference<>(CompletableFuture.completedFuture(null));
 
 
-  BufferedWriteChannel(FileChannel fileChannel, ByteBuffer byteBuffer) {
+  BufferedWriteChannel(String name, FileChannel fileChannel, ByteBuffer byteBuffer) {
+    this.name = name;
     this.fileChannel = fileChannel;
     this.writeBuffer = byteBuffer;
   }
 
-  void write(byte[] b) throws IOException {
-    write(b, b.length);
+  int writeBufferPosition() {
+    return writeBuffer.position();
   }
-  void write(byte[] b, int len) throws IOException {
-    int offset = 0;
-    while (offset < len) {
-      int toPut = Math.min(len - offset, writeBuffer.remaining());
-      writeBuffer.put(b, offset, toPut);
-      offset += toPut;
-      if (writeBuffer.remaining() == 0) {
-        flushBuffer();
-      }
+
+  /**
+   * Write to buffer.
+   *
+   * @param writeSize the size to write.
+   * @param writeMethod write exactly the writeSize of bytes to the buffer and advance buffer position.
+   */
+  void writeToBuffer(int writeSize, CheckedConsumer<ByteBuffer, IOException> writeMethod) throws IOException {
+    if (writeSize > writeBuffer.capacity()) {
+      throw new IOException("writeSize = " + writeSize
+          + " > writeBuffer.capacity() = " + writeBuffer.capacity());
     }
+    if (writeSize > writeBuffer.remaining()) {
+      flushBuffer();
+    }
+    final int pos = writeBufferPosition();
+    final int lim = writeBuffer.limit();
+    writeMethod.accept(writeBuffer);
+    final int written = writeBufferPosition() - pos;
+    Preconditions.assertSame(writeSize, written, "written");
+    Preconditions.assertSame(lim, writeBuffer.limit(), "writeBuffer.limit()");
+  }
+
+  /** Write the content of the given buffer to {@link #fileChannel}. */
+  void writeToChannel(ByteBuffer buffer) throws IOException {
+    if (buffer != writeBuffer) {
+      Preconditions.assertSame(0, writeBufferPosition(), "writeBuffer.position()");
+    }
+    final int length = buffer.remaining();
+    int written = 0;
+    for(; written < length; ) {
+      written += fileChannel.write(buffer);
+    }
+    Preconditions.assertSame(length, written, "written");
+    forced = false;
   }
 
   void preallocateIfNecessary(long size, CheckedBiFunction<FileChannel, Long, Long, IOException> preallocate)
       throws IOException {
-    final long outstanding = writeBuffer.position() + size;
+    final long outstanding = writeBufferPosition() + size;
     if (fileChannel.position() + outstanding > fileChannel.size()) {
       preallocate.apply(fileChannel, outstanding);
     }
@@ -115,26 +147,19 @@ class BufferedWriteChannel implements Closeable {
     try {
       fileChannel.force(false);
     } catch (IOException e) {
-      LogSegment.LOG.error("Failed to flush channel", e);
-      throw new CompletionException(e);
+      throw new CompletionException("Failed to force channel " + this, e);
     }
     return null;
   }
 
-  /**
-   * Write any data in the buffer to the file.
-   *
-   * @throws IOException if the write fails.
-   */
+  /** Flush the data from the {@link #writeBuffer} to {@link #fileChannel}. */
   private void flushBuffer() throws IOException {
-    if (writeBuffer.position() == 0) {
+    if (writeBufferPosition() == 0) {
       return; // nothing to flush
     }
 
     writeBuffer.flip();
-    do {
-      fileChannel.write(writeBuffer);
-    } while (writeBuffer.hasRemaining());
+    writeToChannel(writeBuffer);
     writeBuffer.clear();
     forced = false;
   }
@@ -156,5 +181,10 @@ class BufferedWriteChannel implements Closeable {
     } finally {
       fileChannel.close();
     }
+  }
+
+  @Override
+  public String toString() {
+    return name;
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
@@ -107,6 +107,8 @@ class BufferedWriteChannel implements Closeable {
   void writeToChannel(ByteBuffer buffer) throws IOException {
     Preconditions.assertSame(0, writeBufferPosition(), "writeBuffer.position()");
     final int length = buffer.remaining();
+    LOG.debug("Write {} bytes (pos={}, size={}) to channel {}",
+        length, fileChannel.position(), fileChannel.size(), this);
     int written = 0;
     for(; written < length; ) {
       written += fileChannel.write(buffer);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
@@ -18,8 +18,6 @@
 package org.apache.ratis.server.raftlog.segmented;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.ratis.util.FileUtils;
-import org.apache.ratis.util.IOUtils;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.function.CheckedBiFunction;
 import org.apache.ratis.util.function.CheckedConsumer;
@@ -32,7 +30,6 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.file.StandardOpenOption;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogFormat.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogFormat.java
@@ -24,23 +24,29 @@ import java.nio.charset.StandardCharsets;
 
 public interface SegmentedRaftLogFormat {
   class Internal {
-    private static final byte[] HEADER_BYTES = "RaftLog1".getBytes(StandardCharsets.UTF_8);
-    private static final ByteBuffer HEADER_BYTEBUFFER = ByteBuffer.wrap(HEADER_BYTES).asReadOnlyBuffer();
+    private static final ByteBuffer HEADER;
     private static final byte TERMINATOR_BYTE = 0;
+
+    static {
+      final byte[] bytes = "RaftLog1".getBytes(StandardCharsets.UTF_8);
+      final ByteBuffer header = ByteBuffer.allocateDirect(bytes.length);
+      header.put(bytes);
+      HEADER = header.asReadOnlyBuffer();
+    }
   }
 
   static int getHeaderLength() {
-    return Internal.HEADER_BYTES.length;
+    return Internal.HEADER.remaining();
   }
 
   static ByteBuffer getHeaderBytebuffer() {
-    return Internal.HEADER_BYTEBUFFER.duplicate();
+    return Internal.HEADER.duplicate();
   }
 
   static int matchHeader(byte[] bytes, int offset, int length) {
     Preconditions.assertTrue(length <= getHeaderLength());
     for(int i = 0; i < length; i++) {
-      if (bytes[offset + i] != Internal.HEADER_BYTES[i]) {
+      if (bytes[offset + i] != Internal.HEADER.get(i)) {
         return i;
       }
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogFormat.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogFormat.java
@@ -18,25 +18,23 @@
 package org.apache.ratis.server.raftlog.segmented;
 
 import org.apache.ratis.util.Preconditions;
-import org.apache.ratis.util.function.CheckedFunction;
 
-import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 public interface SegmentedRaftLogFormat {
   class Internal {
     private static final byte[] HEADER_BYTES = "RaftLog1".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] HEADER_BYTES_CLONE = HEADER_BYTES.clone();
+    private static final ByteBuffer HEADER_BYTEBUFFER = ByteBuffer.wrap(HEADER_BYTES).asReadOnlyBuffer();
     private static final byte TERMINATOR_BYTE = 0;
-
-    private static void assertHeader() {
-      Preconditions.assertTrue(Arrays.equals(HEADER_BYTES, HEADER_BYTES_CLONE));
-    }
   }
 
   static int getHeaderLength() {
     return Internal.HEADER_BYTES.length;
+  }
+
+  static ByteBuffer getHeaderBytebuffer() {
+    return Internal.HEADER_BYTEBUFFER.duplicate();
   }
 
   static int matchHeader(byte[] bytes, int offset, int length) {
@@ -47,12 +45,6 @@ public interface SegmentedRaftLogFormat {
       }
     }
     return length;
-  }
-
-  static <T> T applyHeaderTo(CheckedFunction<byte[], T, IOException> function) throws IOException {
-    final T t = function.apply(Internal.HEADER_BYTES);
-    Internal.assertHeader(); // assert that the header is unmodified by the function.
-    return t;
   }
 
   static byte getTerminator() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogFormat.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogFormat.java
@@ -30,7 +30,7 @@ public interface SegmentedRaftLogFormat {
     static {
       final byte[] bytes = "RaftLog1".getBytes(StandardCharsets.UTF_8);
       final ByteBuffer header = ByteBuffer.allocateDirect(bytes.length);
-      header.put(bytes);
+      header.put(bytes).flip();
       HEADER = header.asReadOnlyBuffer();
     }
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogReader.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogReader.java
@@ -242,7 +242,8 @@ class SegmentedRaftLogReader implements Closeable {
         }
         for (idx = 0; idx < numRead; idx++) {
           if (!SegmentedRaftLogFormat.isTerminator(temp[idx])) {
-            throw new IOException("Read extra bytes after the terminator!");
+            throw new IOException("Read extra bytes after the terminator at position "
+                + (limiter.getPos() - numRead + idx) + " in " + file);
           }
         }
       } finally {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogReader.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogReader.java
@@ -182,7 +182,7 @@ class SegmentedRaftLogReader implements Closeable {
     throw new CorruptedFileException(file, "Log header mismatched: expected header length="
         + SegmentedRaftLogFormat.getHeaderLength() + ", read length=" + readLength + ", match length=" + matchLength
         + ", header in file=" + StringUtils.bytes2HexString(temp, 0, readLength)
-        + ", expected header=" + SegmentedRaftLogFormat.applyHeaderTo(StringUtils::bytes2HexString));
+        + ", expected header=" + StringUtils.bytes2HexString(SegmentedRaftLogFormat.getHeaderBytebuffer()));
   }
 
   /**

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -732,7 +732,8 @@ class SegmentedRaftLogWorker {
   }
 
   private void allocateSegmentedRaftLogOutputStream(File file, boolean append) throws IOException {
-    Preconditions.assertTrue(out == null && writeBuffer.position() == 0);
+    Preconditions.assertNull(out, "out");
+    Preconditions.assertSame(0, writeBuffer.position(), "writeBuffer.position()");
     out = new SegmentedRaftLogOutputStream(file, append, segmentMaxSize,
         preallocatedSize, writeBuffer);
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -50,7 +50,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -149,7 +148,6 @@ class SegmentedRaftLogWorker {
   private final StateMachine stateMachine;
   private final SegmentedRaftLogMetrics raftLogMetrics;
   private final ByteBuffer writeBuffer;
-  private final AtomicReference<byte[]> sharedBuffer;
 
   /**
    * The number of entries that have been written into the SegmentedRaftLogOutputStream but
@@ -210,7 +208,12 @@ class SegmentedRaftLogWorker {
     this.writeBuffer = ByteBuffer.allocateDirect(bufferSize);
     final int logEntryLimit = RaftServerConfigKeys.Log.Appender.bufferByteLimit(properties).getSizeInt();
     // 4 bytes (serialized size) + logEntryLimit + 4 bytes (checksum)
-    this.sharedBuffer = new AtomicReference<>(new byte[logEntryLimit + 8]);
+    if (bufferSize < logEntryLimit + 8) {
+      throw new IllegalArgumentException(RaftServerConfigKeys.Log.WRITE_BUFFER_SIZE_KEY
+          + " (= " + bufferSize
+          + ") is less than " + RaftServerConfigKeys.Log.Appender.BUFFER_BYTE_LIMIT_KEY
+          + " + 8 (= " + (logEntryLimit + 8) + ")");
+    }
     this.unsafeFlush = RaftServerConfigKeys.Log.unsafeFlushEnabled(properties);
     this.asyncFlush = RaftServerConfigKeys.Log.asyncFlushEnabled(properties);
     if (asyncFlush && unsafeFlush) {
@@ -235,7 +238,6 @@ class SegmentedRaftLogWorker {
 
   void close() {
     this.running = false;
-    sharedBuffer.set(null);
     Optional.ofNullable(flushExecutor).ifPresent(ExecutorService::shutdown);
     ConcurrentUtils.shutdownAndWait(TimeDuration.ONE_SECOND.multiply(3),
         workerThreadExecutor, timeout -> LOG.warn("{}: shutdown timeout in " + timeout, name));
@@ -732,6 +734,6 @@ class SegmentedRaftLogWorker {
   private void allocateSegmentedRaftLogOutputStream(File file, boolean append) throws IOException {
     Preconditions.assertTrue(out == null && writeBuffer.position() == 0);
     out = new SegmentedRaftLogOutputStream(file, append, segmentMaxSize,
-        preallocatedSize, writeBuffer, sharedBuffer::get);
+        preallocatedSize, writeBuffer);
   }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestBufferedWriteChannel.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestBufferedWriteChannel.java
@@ -18,15 +18,18 @@
 package org.apache.ratis.server.raftlog.segmented;
 
 import org.apache.ratis.BaseTest;
+import org.apache.ratis.util.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Test {@link BufferedWriteChannel}
@@ -71,7 +74,6 @@ public class TestBufferedWriteChannel extends BaseTest {
       final int remaining = src.remaining();
       LOG.info("write {} bytes", remaining);
       position += remaining;
-      src.position(src.limit());
       return remaining;
     }
 
@@ -132,55 +134,128 @@ public class TestBufferedWriteChannel extends BaseTest {
     }
   }
 
-  @Test
-  public void testFlush() throws Exception {
-    final byte[] bytes = new byte[10];
-    final ByteBuffer buffer = ByteBuffer.wrap(bytes);
-    final FakeFileChannel fake = new FakeFileChannel();
-    final BufferedWriteChannel out = new BufferedWriteChannel(fake, buffer);
+  static ByteBuffer allocateByteBuffer(int size) {
+    final ByteBuffer buffer = ByteBuffer.allocate(size);
+    for(int i = 0; i < size; i++) {
+      buffer.put(i, (byte)i);
+    }
+    return buffer.asReadOnlyBuffer();
+  }
 
-    // write exactly buffer size, then flush.
+
+  @Test
+  public void testWriteToChannel() throws Exception {
+    for(int n = 1; n < 1 << 20; n <<=2) {
+      runTestWriteToChannel(n - 1);
+      runTestWriteToChannel(n);
+      runTestWriteToChannel(n + 1);
+    }
+  }
+
+  void runTestWriteToChannel(int bufferSize) throws Exception {
+    final ByteBuffer buffer = allocateByteBuffer(2 * bufferSize);
+    final FakeFileChannel fake = new FakeFileChannel();
+    final BufferedWriteChannel out = new BufferedWriteChannel("test", fake, ByteBuffer.allocate(0));
+
     fake.assertValues(0, 0);
-    out.write(bytes);
-    int pos = bytes.length;
-    fake.assertValues(pos,  0);
-    out.flush();
-    int force = pos;
-    fake.assertValues(pos, force);
+    final AtomicInteger pos = new AtomicInteger();
+    final AtomicInteger force = new AtomicInteger();
+
+    {
+      // write exactly buffer size, then flush.
+      writeToChannel(out, fake, pos, force, buffer, bufferSize);
+      flush(out, fake, pos, force);
+    }
 
     {
       // write less than buffer size, then flush.
-      int n = bytes.length/2;
-      out.write(new byte[n]);
-      fake.assertValues(pos, force);
-      out.flush();
-      pos += n;
-      force = pos;
-      fake.assertValues(pos, force);
+      writeToChannel(out, fake, pos, force, buffer, bufferSize/2);
+      flush(out, fake, pos, force);
     }
 
     {
       // write less than buffer size twice, then flush.
-      int n = bytes.length*2/3;
-      out.write(new byte[n]);
-      fake.assertValues(pos, force);
-      out.write(new byte[n]);
-      fake.assertValues(pos + bytes.length, force);
-      out.flush();
-      pos += 2*n;
-      force = pos;
-      fake.assertValues(pos, force);
+      final int n = bufferSize*2/3;
+      writeToChannel(out, fake, pos, force, buffer, n);
+      writeToChannel(out, fake, pos, force, buffer, n);
+      flush(out, fake, pos, force);
     }
 
     {
       // write more than buffer size, then flush.
-      int n = bytes.length*3/2;
-      out.write(new byte[n]);
-      fake.assertValues(pos + bytes.length, force);
-      out.flush();
-      pos += n;
-      force = pos;
-      fake.assertValues(pos, force);
+      writeToChannel(out, fake, pos, force, buffer, bufferSize*3/2);
+      flush(out, fake, pos, force);
+    }
+  }
+
+  static void writeToChannel(BufferedWriteChannel out, FakeFileChannel fake, AtomicInteger pos, AtomicInteger force,
+      ByteBuffer buffer, int n) throws IOException {
+    buffer.position(0).limit(n);
+    out.writeToChannel(buffer);
+    pos.addAndGet(n);
+    fake.assertValues(pos.get(), force.get());
+  }
+
+  static void flush(BufferedWriteChannel out, FakeFileChannel fake,
+      AtomicInteger pos, AtomicInteger force) throws IOException {
+    final int existing = out.writeBufferPosition();
+    out.flush();
+    Assert.assertEquals(0, out.writeBufferPosition());
+    pos.addAndGet(existing);
+    force.set(pos.get());
+    fake.assertValues(pos.get(), force.get());
+  }
+
+  static void writeToBuffer(BufferedWriteChannel out, FakeFileChannel fake, AtomicInteger pos, AtomicInteger force,
+      int bufferCapacity, ByteBuffer buffer, int n) throws IOException {
+    final int existing = out.writeBufferPosition();
+    buffer.position(0).limit(n);
+    out.writeToBuffer(n, b -> b.put(buffer));
+    if (existing + n > bufferCapacity) {
+      pos.addAndGet(existing);
+      Assert.assertEquals(n, out.writeBufferPosition());
+    } else {
+      Assert.assertEquals(existing + n, out.writeBufferPosition());
+    }
+    fake.assertValues(pos.get(), force.get());
+  }
+
+  @Test
+  public void testWriteToBuffer() throws Exception {
+    for(int n = 1; n < 1 << 20; n <<=2) {
+      runTestWriteToBuffer(n - 1);
+      runTestWriteToBuffer(n);
+      runTestWriteToBuffer(n + 1);
+    }
+  }
+
+  void runTestWriteToBuffer(int bufferSize) throws Exception {
+    final ByteBuffer buffer = allocateByteBuffer(2 * bufferSize);
+    final FakeFileChannel fake = new FakeFileChannel();
+    final BufferedWriteChannel out = new BufferedWriteChannel("test", fake, ByteBuffer.allocate(bufferSize));
+
+    fake.assertValues(0, 0);
+    final AtomicInteger pos = new AtomicInteger();
+    final AtomicInteger force = new AtomicInteger();
+
+    {
+      // write exactly buffer size, then flush.
+      writeToBuffer(out, fake, pos, force, bufferSize, buffer, bufferSize);
+      flush(out, fake, pos, force);
+    }
+
+    {
+      // write less than buffer size, then flush.
+      writeToBuffer(out, fake, pos, force, bufferSize, buffer, bufferSize/2);
+      flush(out, fake, pos, force);
+    }
+
+    {
+      // write less than buffer size twice, then flush.
+      final int n = bufferSize*2/3;
+      writeToBuffer(out, fake, pos, force, bufferSize, buffer, n);
+      writeToBuffer(out, fake, pos, force, bufferSize, buffer, n);
+      flush(out, fake, pos, force);
     }
   }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestBufferedWriteChannel.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestBufferedWriteChannel.java
@@ -79,7 +79,7 @@ public class TestBufferedWriteChannel extends BaseTest {
 
     @Override
     public long position() {
-      throw new UnsupportedOperationException();
+      return position;
     }
 
     @Override

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -699,25 +699,6 @@ public class TestSegmentedRaftLog extends BaseTest {
   }
 
   @Test
-  public void testSegmentedRaftLogFormatInternalHeader() throws Exception {
-    testFailureCase("testSegmentedRaftLogFormatInternalHeader",
-        () -> SegmentedRaftLogFormat.applyHeaderTo(header -> {
-          LOG.info("header  = " + new String(header, StandardCharsets.UTF_8));
-          header[0]++; // try changing the internal header
-          LOG.info("header' = " + new String(header, StandardCharsets.UTF_8));
-          return null;
-        }), IllegalStateException.class);
-
-    // reset the header
-    SegmentedRaftLogFormat.applyHeaderTo(header -> {
-      LOG.info("header'  = " + new String(header, StandardCharsets.UTF_8));
-      header[0] -= 1; // try changing the internal header
-      LOG.info("header'' = " + new String(header, StandardCharsets.UTF_8));
-      return null;
-    });
-  }
-
-  @Test
   public void testAsyncFlushPerf1() throws Exception {
     List<SegmentRange> ranges = prepareRanges(0, 50, 20000, 0);
     List<LogEntryProto> entries = prepareLogEntries(ranges, null);


### PR DESCRIPTION
See RATIS-589