### PR TITLE
RATIS-1951. Upgrade sonar check to Java 17

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -205,6 +205,8 @@ jobs:
     if: (github.repository == 'apache/ratis' || github.repository == 'apache/incubator-ratis') && github.event_name != 'pull_request'
     steps:
         - uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
         - name: Cache for maven dependencies
           uses: actions/cache@v3
           with:
@@ -213,11 +215,11 @@ jobs:
             restore-keys: |
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
-        - name: Setup java 11
+        - name: Setup java 17
           uses: actions/setup-java@v3
           with:
             distribution: 'temurin'
-            java-version: 11
+            java-version: 17
         - run: ./dev-support/checks/sonar.sh
           env:
             SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix SonarCloud issues:

> The version of Java (11.0.21) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.

> Shallow clone detected during the analysis. Some files will miss SCM information. This will affect features like auto-assignment of issues. Please configure your build to disable shallow clone.

https://issues.apache.org/jira/browse/RATIS-1951

## How was this patch tested?

Since `sonar` check only runs for commits in the main repo, it will be tested after merge.  But similar change was [already done](https://github.com/apache/ozone/commit/08131b9addc719551a8e4d8c1846f8c8f11bd62c) for Ozone.