### PR TITLE
RATIS-1956. Avoid built-in toString in NettyClientStreamRpc log

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
@@ -189,9 +189,9 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
             @Override
             public void operationComplete(ChannelFuture future) {
               if (!future.isSuccess()) {
-                scheduleReconnect(this + " failed", future.cause());
+                scheduleReconnect(Connection.this + " failed", future.cause());
               } else {
-                LOG.trace("{} succeed.", this);
+                LOG.trace("{} succeed.", Connection.this);
               }
             }
           });
@@ -323,16 +323,16 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
       @Override
       public void channelRead(ChannelHandlerContext ctx, Object msg) {
         if (!(msg instanceof DataStreamReply)) {
-          LOG.error("{}: unexpected message {}", this, msg.getClass());
+          LOG.error("{}: unexpected message {}", name, msg.getClass());
           return;
         }
         final DataStreamReply reply = (DataStreamReply) msg;
-        LOG.debug("{}: read {}", this, reply);
+        LOG.debug("{}: read {}", name, reply);
         final ClientInvocationId clientInvocationId = ClientInvocationId.valueOf(
             reply.getClientId(), reply.getStreamId());
         final NettyClientReplies.ReplyMap replyMap = replies.getReplyMap(clientInvocationId);
         if (replyMap == null) {
-          LOG.error("{}: {} replyMap not found for reply: {}", this, clientInvocationId, reply);
+          LOG.error("{}: {} replyMap not found for reply: {}", name, clientInvocationId, reply);
           return;
         }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some of the logs in `NettyClientStreamRpc` mention the source of the message using `toString` inherited from `Object`.  Replace them with more readable names.

https://issues.apache.org/jira/browse/RATIS-1956

## How was this patch tested?

Before:

```
(NettyClientStreamRpc.java:operationComplete(194)) - org.apache.ratis.netty.client.NettyClientStreamRpc$Connection$1@36383c10 succeed.
(NettyClientStreamRpc.java:channelRead(330)) - org.apache.ratis.netty.client.NettyClientStreamRpc$1@31294ad5: read DataStreamReplyByteBuffer:clientId=client-F61E6E1DAE37,type=STREAM_HEADER,id=1,offset=0,length=0,SUCCESS,bytesWritten=0
```

After:

```
(NettyClientStreamRpc.java:operationComplete(194)) - Connection-localhost/127.0.0.1:33119 succeed.
(NettyClientStreamRpc.java:channelRead(330)) - NettyClientStreamRpc->s0: read DataStreamReplyByteBuffer:clientId=client-263FEF962BB2,type=STREAM_HEADER,id=1,offset=0,length=0,SUCCESS,bytesWritten=0
```

These names are already used for similar messages in `NettyClientStreamRpc`.

CI:
https://github.com/adoroszlai/ratis/actions/runs/7129312221