### PR TITLE
RATIS-1959. Omit download progress in CI builds

### DIFF
--- a/dev-support/checks/build.sh
+++ b/dev-support/checks/build.sh
@@ -19,5 +19,5 @@ cd "$DIR/../.." || exit 1
 source "${DIR}/../find_maven.sh"
 
 export MAVEN_OPTS="-Xmx4096m"
-${MVN} -V -B -Dmaven.javadoc.skip=true -DskipTests clean install "$@"
+${MVN} -V -B -Dmaven.javadoc.skip=true -DskipTests --no-transfer-progress clean install "$@"
 exit $?

--- a/dev-support/checks/checkstyle.sh
+++ b/dev-support/checks/checkstyle.sh
@@ -23,7 +23,7 @@ REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../target/checkstyle"}
 mkdir -p "$REPORT_DIR"
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-MAVEN_OPTIONS='-B -fae -Dcheckstyle.failOnViolation=false'
+MAVEN_OPTIONS='-B -fae --no-transfer-progress -Dcheckstyle.failOnViolation=false'
 
 declare -i rc
 ${MVN} ${MAVEN_OPTIONS} checkstyle:check | tee  "${REPORT_DIR}/output.log"

--- a/dev-support/checks/findbugs.sh
+++ b/dev-support/checks/findbugs.sh
@@ -18,7 +18,7 @@ cd "$DIR/../.." || exit 1
 
 source "${DIR}/../find_maven.sh"
 
-MAVEN_OPTIONS='-B -fae'
+MAVEN_OPTIONS='-B -fae --no-transfer-progress'
 
 if ! type unionBugs >/dev/null 2>&1 || ! type convertXmlToText >/dev/null 2>&1; then
   #shellcheck disable=SC2086

--- a/dev-support/checks/rat.sh
+++ b/dev-support/checks/rat.sh
@@ -23,7 +23,7 @@ mkdir -p "$REPORT_DIR"
 
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-${MVN} -B -fn org.apache.rat:apache-rat-plugin:0.13:check
+${MVN} -B -fn --no-transfer-progress org.apache.rat:apache-rat-plugin:0.13:check
 
 cd "$DIR/../.." || exit 1
 

--- a/dev-support/checks/sonar.sh
+++ b/dev-support/checks/sonar.sh
@@ -23,4 +23,6 @@ if [ ! "$SONAR_TOKEN" ]; then
   exit 1
 fi
 
-${MVN} -B verify -DskipShade -DskipTests org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache-ratis
+${MVN} -B verify -DskipShade -DskipTests --no-transfer-progress \
+  org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar \
+  -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache-ratis

--- a/dev-support/checks/unit.sh
+++ b/dev-support/checks/unit.sh
@@ -41,7 +41,7 @@ for i in $(seq 1 ${ITERATIONS}); do
     mkdir -p "${REPORT_DIR}"
   fi
 
-  ${MVN} -B -fae test "$@" \
+  ${MVN} -B -fae --no-transfer-progress test "$@" \
     | tee "${REPORT_DIR}/output.log"
   irc=$?
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

If dependencies are not available in local repo, Maven logs download progress for each:

```
[INFO] Downloading from apache.snapshots: https://repository.apache.org/snapshots/com/github/spotbugs/spotbugs-maven-plugin/4.2.0/spotbugs-maven-plugin-4.2.0.pom
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs-maven-plugin/4.2.0/spotbugs-maven-plugin-4.2.0.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs-maven-plugin/4.2.0/spotbugs-maven-plugin-4.2.0.pom (33 kB at 1.3 MB/s)
[INFO] Downloading from apache.snapshots: https://repository.apache.org/snapshots/com/github/hazendaz/base-parent/27/base-parent-27.pom
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/github/hazendaz/base-parent/27/base-parent-27.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/github/hazendaz/base-parent/27/base-parent-27.pom (87 kB at 7.9 MB/s)
```

https://github.com/apache/ratis/actions/runs/7074176463/job/19254929774#step:5:49

This may unnecessarily increase log by more than 1000 lines currently ([from ~1800](https://github.com/apache/ratis/actions/runs/7134686428/job/19429987244#step:5:1818) [to ~3000](https://github.com/apache/ratis/actions/runs/7074176463/job/19254929774#step:5:3078)).

CI uses Github Actions cache for Maven dependencies, so this is only noticeable in case of cache miss (usually on POM change or in forks).

https://issues.apache.org/jira/browse/RATIS-1959

## How was this patch tested?

CI build in fork with cache miss:

```
Cache not found for input keys: maven-repo-edc44bba0b03b489af4e8788b210a64e0b74f4870fe3570470bb3a34fc6ece76-build, maven-repo-edc44bba0b03b489af4e8788b210a64e0b74f4870fe3570470bb3a34fc6ece76, maven-repo-
```

https://github.com/adoroszlai/ratis/actions/runs/7149655412/job/19472089995#step:3:12

but build output only ~1800 lines:

https://github.com/adoroszlai/ratis/actions/runs/7149655412/job/19472089995#step:5:1806