### PR TITLE
RATIS-1960. Follower may be incorrectly marked as having caught up

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -616,7 +616,7 @@ class LeaderStateImpl implements LeaderState {
   @Override
   public AppendEntriesRequestProto newAppendEntriesRequestProto(FollowerInfo follower,
       List<LogEntryProto> entries, TermIndex previous, long callId) {
-    final boolean initializing = isCaughtUp(follower);
+    final boolean initializing = !isCaughtUp(follower);
     final RaftPeerId targetId = follower.getId();
     return ServerProtoUtils.toAppendEntriesRequestProto(server.getMemberId(), targetId, currentTerm, entries,
         ServerImplUtils.effectiveCommitIndex(raftLog.getLastCommittedIndex(), previous, entries.size()),


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Fix race condition that may cause follower to be incorrectly marked as having caught up with leader.
2. Fix calculation of `initializing` flag for `appendEntries` request sent to follower.

Please see RATIS-1960 for details on both.

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis/actions/runs/7151958459

Passed 10x50 `TestInstallSnapshotNotificationWithGrpc#testInstallSnapshotDuringBootstrap` (this was failing in 6% of runs after fixing only the race condition):
https://github.com/adoroszlai/ratis/actions/runs/7152037092