### PR TITLE
RATIS-1963. Restore ZeroCopyMessageMarshaller#popStream

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/ZeroCopyMessageMarshaller.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/ZeroCopyMessageMarshaller.java
@@ -118,7 +118,7 @@ public class ZeroCopyMessageMarshaller<T extends MessageLite> implements Prototy
 
   /** Release the underlying buffers in the given message. */
   public void release(T message) {
-    final InputStream stream = unclosedStreams.remove(message);
+    final InputStream stream = popStream(message);
     if (stream == null) {
       return;
     }
@@ -212,5 +212,14 @@ public class ZeroCopyMessageMarshaller<T extends MessageLite> implements Prototy
       e.setUnfinishedMessage(message);
       throw e;
     }
+  }
+
+  /**
+   * Application can call this function to get the stream for the message, and,
+   * possibly later, must call {@link InputStream#close()} to release buffers.
+   * Alternatively, use {@link #release(T)} to do both in one step.
+   */
+  public InputStream popStream(T message) {
+    return unclosedStreams.remove(message);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

RATIS-1939 refactored `ZeroCopyMessageMarshaller`, replacing `popStream(T)` with `release(T)`.  For compatibility with 3.0.0, I would like to add back `popStream`.

(Note: there is a typo in the commit message, please use PR title when merging, if the change  is accepted.)

https://issues.apache.org/jira/browse/RATIS-1963

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis/actions/runs/7169889152