### PR TITLE
RATIS-1968. Remove unreached else block of trySendDelayed

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
@@ -63,6 +63,7 @@ public final class OrderedAsync {
     private final long seqNum;
     private final AtomicReference<Function<SlidingWindowEntry, RaftClientRequest>> requestConstructor;
     private volatile boolean isFirst = false;
+    private volatile long firstSeqNum = 0;
 
     PendingOrderedRequest(long callId, long seqNum,
         Function<SlidingWindowEntry, RaftClientRequest> requestConstructor) {
@@ -81,6 +82,10 @@ public final class OrderedAsync {
     @Override
     public void setFirstRequest() {
       isFirst = true;
+    }
+
+    public long getCallId() {
+      return callId;
     }
 
     @Override
@@ -133,7 +138,7 @@ public final class OrderedAsync {
   }
 
   private void resetSlidingWindow(RaftClientRequest request) {
-    getSlidingWindow(request).resetFirstSeqNum();
+    getSlidingWindow(request).resetFirstSeqNum(request.getCallId());
   }
 
   private SlidingWindow.Client<PendingOrderedRequest, RaftClientReply> getSlidingWindow(RaftClientRequest request) {

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
@@ -63,7 +63,6 @@ public final class OrderedAsync {
     private final long seqNum;
     private final AtomicReference<Function<SlidingWindowEntry, RaftClientRequest>> requestConstructor;
     private volatile boolean isFirst = false;
-    private volatile long firstSeqNum = 0;
 
     PendingOrderedRequest(long callId, long seqNum,
         Function<SlidingWindowEntry, RaftClientRequest> requestConstructor) {

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedStreamAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedStreamAsync.java
@@ -73,6 +73,10 @@ public class OrderedStreamAsync {
       return seqNum;
     }
 
+    public long getCallId() {
+      return -1;
+    }
+
     @Override
     public void setReply(DataStreamReply dataStreamReply) {
       replyFuture.complete(dataStreamReply);

--- a/ratis-common/src/main/java/org/apache/ratis/util/SlidingWindow.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/SlidingWindow.java
@@ -17,7 +17,6 @@
  */
 package org.apache.ratis.util;
 
-import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +25,6 @@ import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;

--- a/ratis-common/src/main/java/org/apache/ratis/util/SlidingWindow.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/SlidingWindow.java
@@ -367,6 +367,16 @@ public interface SlidingWindow {
         // after first received, all other requests can be submitted (out-of-order)
         delayedRequests.getAllAndClear().forEach(
             seqNum -> sendMethod.accept(requests.getNonRepliedRequest(seqNum, "trySendDelayed")));
+      } else {
+        // Otherwise, submit the first only if it is a delayed request
+        final Iterator<REQUEST> i = requests.iterator();
+        if (i.hasNext()) {
+          final REQUEST r = i.next();
+          final Long delayed = delayedRequests.remove(r.getSeqNum());
+          if (delayed != null) {
+            sendOrDelayRequest(r, sendMethod);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In "https://github.com/apache/ratis/blob/9bd82aa2aa125a749b9357f208dd66533f43374c/ratis-common/src/main/java/org/apache/ratis/util/SlidingWindow.java#L363", the else block should not be reached, since only the first request is send out, all other request are still in the "delayedRequests", we can not receive out-of-order replies if "firstReplied" is not set.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1968

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

No tests.
