### PR TITLE
RATIS-1925. Support Zero-Copy in GrpcClientProtocolService

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
@@ -279,6 +279,16 @@ public interface GrpcConfigKeys {
     static void setHeartbeatChannel(RaftProperties properties, boolean useSeparate) {
       setBoolean(properties::setBoolean, HEARTBEAT_CHANNEL_KEY, useSeparate);
     }
+
+    String ZERO_COPY_ENABLED = PREFIX + ".zerocopy.enabled";
+    boolean ZERO_COPY_ENABLED_DEFAULT = false;
+    static boolean zeroCopyEnabled(RaftProperties properties) {
+      return getBoolean(properties::getBoolean, ZERO_COPY_ENABLED,
+          ZERO_COPY_ENABLED_DEFAULT, getDefaultLog());
+    }
+    static  void setZeroCopyEnabled(RaftProperties properties, boolean enabled) {
+      setBoolean(properties::setBoolean, ZERO_COPY_ENABLED, enabled);
+    }
   }
 
   String MESSAGE_SIZE_MAX_KEY = PREFIX + ".message.size.max";

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
@@ -280,14 +280,14 @@ public interface GrpcConfigKeys {
       setBoolean(properties::setBoolean, HEARTBEAT_CHANNEL_KEY, useSeparate);
     }
 
-    String ZERO_COPY_ENABLED = PREFIX + ".zerocopy.enabled";
+    String ZERO_COPY_ENABLED_KEY = PREFIX + ".zerocopy.enabled";
     boolean ZERO_COPY_ENABLED_DEFAULT = false;
     static boolean zeroCopyEnabled(RaftProperties properties) {
-      return getBoolean(properties::getBoolean, ZERO_COPY_ENABLED,
+      return getBoolean(properties::getBoolean, ZERO_COPY_ENABLED_KEY,
           ZERO_COPY_ENABLED_DEFAULT, getDefaultLog());
     }
-    static  void setZeroCopyEnabled(RaftProperties properties, boolean enabled) {
-      setBoolean(properties::setBoolean, ZERO_COPY_ENABLED, enabled);
+    static void setZeroCopyEnabled(RaftProperties properties, boolean enabled) {
+      setBoolean(properties::setBoolean, ZERO_COPY_ENABLED_KEY, enabled);
     }
   }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/ZeroCopyMetrics.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/ZeroCopyMetrics.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.grpc.metrics;
+
+import org.apache.ratis.metrics.LongCounter;
+import org.apache.ratis.metrics.MetricRegistryInfo;
+import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.metrics.RatisMetrics;
+
+public class ZeroCopyMetrics extends RatisMetrics {
+  private static final String RATIS_GRPC_METRICS_APP_NAME = "ratis_grpc";
+  private static final String RATIS_GRPC_METRICS_COMP_NAME = "zero_copy";
+  private static final String RATIS_GRPC_METRICS_DESC = "Metrics for Ratis Grpc Zero copy";
+
+  private final LongCounter zeroCopyMessages = getRegistry().counter("num_zero_copy_messages");
+  private final LongCounter nonZeroCopyMessages = getRegistry().counter("num_non_zero_copy_messages");
+
+  public ZeroCopyMetrics() {
+    super(createRegistry());
+  }
+
+  private static RatisMetricRegistry createRegistry() {
+    return create(new MetricRegistryInfo("",
+        RATIS_GRPC_METRICS_APP_NAME,
+        RATIS_GRPC_METRICS_COMP_NAME, RATIS_GRPC_METRICS_DESC));
+  }
+
+
+  public void onZeroCopyMessage() {
+    zeroCopyMessages.inc();
+  }
+
+  public void onNonZeroCopyMessage() {
+    nonZeroCopyMessages.inc();
+  }
+
+}

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
@@ -343,18 +343,13 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
   }
 
   @Override
-  public void notifyIndexApplied(RaftGroupId groupId, long appliedIndex) {
-    try {
-      zeroCopyCleaner.onIndexChanged(groupId, appliedIndex, raftServer.getDivision(groupId).getInfo()
-          .getFollowerNextIndices());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+  public void notifyCacheEvict(RaftGroupId groupId, long start, long end) {
+    zeroCopyCleaner.release(groupId, start, end);
   }
 
   @Override
   public void notifyServerClosed(RaftGroupId groupId) {
-    zeroCopyCleaner.onServerClosed(groupId);
+    zeroCopyCleaner.releaseAll(groupId);
   }
 
   @Override

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
@@ -21,6 +21,7 @@ import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.GrpcConfigKeys;
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.grpc.GrpcUtil;
+import org.apache.ratis.grpc.metrics.ZeroCopyMetrics;
 import org.apache.ratis.grpc.metrics.intercept.server.MetricServerInterceptor;
 import org.apache.ratis.grpc.util.RaftLogZeroCopyCleaner;
 import org.apache.ratis.protocol.RaftGroupId;
@@ -155,9 +156,9 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
   private final GrpcClientProtocolService clientProtocolService;
 
   private final MetricServerInterceptor serverInterceptor;
-  private final boolean zeroCopyEnabled;
   private final RaftLogZeroCopyCleaner zeroCopyCleaner;
   private final RaftServer raftServer;
+  private final ZeroCopyMetrics zeroCopyMetrics;
 
   public MetricServerInterceptor getServerInterceptor() {
     return serverInterceptor;
@@ -206,11 +207,11 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
         GrpcConfigKeys.Server.asyncRequestThreadPoolSize(properties),
         getId() + "-request-");
 
-    this.zeroCopyEnabled = zeroCopyEnabled;
+    this.zeroCopyMetrics = new ZeroCopyMetrics();
     this.zeroCopyCleaner = RaftLogZeroCopyCleaner.create(zeroCopyEnabled);
     this.raftServer = raftServer;
     this.clientProtocolService = new GrpcClientProtocolService(idSupplier, raftServer, executor,
-        zeroCopyEnabled, zeroCopyCleaner);
+        zeroCopyEnabled, zeroCopyCleaner, zeroCopyMetrics);
 
     this.serverInterceptor = new MetricServerInterceptor(
         idSupplier,

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
@@ -157,7 +157,6 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
 
   private final MetricServerInterceptor serverInterceptor;
   private final RaftLogZeroCopyCleaner zeroCopyCleaner;
-  private final RaftServer raftServer;
   private final ZeroCopyMetrics zeroCopyMetrics;
 
   public MetricServerInterceptor getServerInterceptor() {
@@ -209,7 +208,6 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
 
     this.zeroCopyMetrics = new ZeroCopyMetrics();
     this.zeroCopyCleaner = RaftLogZeroCopyCleaner.create(zeroCopyEnabled);
-    this.raftServer = raftServer;
     this.clientProtocolService = new GrpcClientProtocolService(idSupplier, raftServer, executor,
         zeroCopyEnabled, zeroCopyCleaner, zeroCopyMetrics);
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/RaftLogZeroCopyCleaner.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/RaftLogZeroCopyCleaner.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.grpc.util;
+
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.thirdparty.io.grpc.KnownLength;
+import org.apache.ratis.thirdparty.io.grpc.internal.GrpcUtil;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * When using {@link ZeroCopyMessageMarshaller} in services that receive Raft logs, e.g. GrpcClientProtocolService
+ * or GrpcServerProtocolService, the original message buffers can't be released immediately after onNext() because
+ * the protobuf log messages is kept in Ratis log cache (or StateMachine cache) waiting for being applied to state
+ * machine or replicated to followers.
+ *
+ * <p>
+ * This component manages the buffers to close, sorts them by the associating log index and release them safely by
+ * observing events like index applied.
+ *
+ * @see {@link org.apache.ratis.grpc.server.GrpcClientProtocolService}
+ * @see {@link org.apache.ratis.grpc.server.GrpcServerProtocolService}
+ */
+public abstract class RaftLogZeroCopyCleaner {
+  public abstract void watch(RaftClientReply clientReply, Closeable handle);
+  public abstract void onIndexChanged(RaftGroupId groupId, long appliedIndex, long[] followerIndices);
+  public abstract void onServerClosed(RaftGroupId groupId);
+
+  public static RaftLogZeroCopyCleaner create(boolean zeroCopyEnabled) {
+    return zeroCopyEnabled ? new RaftLogZeroCopyCleanerImpl() : new NoopRaftLogZeroCopyCleaner();
+  }
+
+  public static void close(Closeable closeable) {
+    GrpcUtil.closeQuietly(closeable);
+  }
+
+  private static class NoopRaftLogZeroCopyCleaner extends RaftLogZeroCopyCleaner {
+    @Override
+    public void onIndexChanged(RaftGroupId groupId, long appliedIndex, long[] followerIndices) {
+    }
+
+    @Override
+    public void onServerClosed(RaftGroupId groupId) {
+    }
+
+    @Override
+    public void watch(RaftClientReply clientReply, Closeable handle) {
+    }
+  }
+
+  private static class RaftLogZeroCopyCleanerImpl extends RaftLogZeroCopyCleaner {
+    private final Map<RaftGroupId, NavigableMap<Long, ReferenceCountedClosable>> groups = new ConcurrentHashMap<>();
+
+    public RaftLogZeroCopyCleanerImpl() {
+    }
+
+    @Override
+    public void onIndexChanged(RaftGroupId groupId, long appliedIndex, long[] followerNextIndices) {
+      if (followerNextIndices != null) {
+        long minFollowerNextIndex = Arrays.stream(followerNextIndices).min().orElse(Long.MAX_VALUE);
+        long minIndex = Math.min(appliedIndex, minFollowerNextIndex - 1);
+        release(groupId, 0, minIndex);
+      } else {
+        release(groupId, 0, appliedIndex);
+      }
+    }
+
+    @Override
+    public void onServerClosed(RaftGroupId groupId) {
+      NavigableMap<Long, ReferenceCountedClosable> removed = groups.remove(groupId);
+      removed.values().forEach(x -> release(x));
+    }
+
+    @Override
+    public void watch(RaftClientReply clientReply, Closeable handle) {
+      if (handle == null) {
+        return;
+      }
+      ReferenceCountedClosable ref = new ReferenceCountedClosable(1, handle);
+      NavigableMap<Long, ReferenceCountedClosable> group = group(clientReply.getRaftGroupId());
+      synchronized (group) {
+        ReferenceCountedClosable overwritten = group.put(clientReply.getLogIndex(), ref);
+        release(overwritten);
+      }
+    }
+
+    private NavigableMap<Long, ReferenceCountedClosable> group(RaftGroupId groupId) {
+      return groups.computeIfAbsent(groupId, (k) -> new TreeMap<>());
+    }
+
+    private void release(RaftGroupId groupId, long startIndex, long endIndex) {
+      if (startIndex > endIndex) {
+        return ;
+      }
+      NavigableMap<Long, ReferenceCountedClosable> group = group(groupId);
+      synchronized (group) {
+        NavigableMap<Long, ReferenceCountedClosable> range = group.subMap(startIndex, true, endIndex, true);
+        List<Long> removedIndices = new LinkedList<>();
+        for (Map.Entry<Long, ReferenceCountedClosable> entry : range.entrySet()) {
+          Long idx = entry.getKey();
+          ReferenceCountedClosable closable = entry.getValue();
+          release(closable);
+          removedIndices.add(idx);
+        }
+        removedIndices.forEach(group::remove);
+      }
+    }
+
+    private void release(ReferenceCountedClosable closable) {
+      if (closable == null) {
+        return;
+      }
+      if (closable.refCount.decrementAndGet() <= 0) {
+        close(closable.handle);
+      }
+    }
+
+  }
+
+  private static class ReferenceCountedClosable {
+    final AtomicInteger refCount;
+    final Closeable handle;
+    final int size;
+
+    private ReferenceCountedClosable(int refCount, Closeable handle) {
+      this.refCount = new AtomicInteger(refCount);
+      this.handle = handle;
+      this.size = estimateSize(handle);
+    }
+
+    private int estimateSize(Closeable handle) {
+      if (handle instanceof KnownLength) {
+        try {
+          return ((KnownLength) handle).available();
+        } catch (IOException e) {
+          return 0;
+        }
+      }
+      return 0;
+    }
+  }
+
+}

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/RaftLogZeroCopyCleaner.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/RaftLogZeroCopyCleaner.java
@@ -98,7 +98,9 @@ public abstract class RaftLogZeroCopyCleaner {
     @Override
     public void onServerClosed(RaftGroupId groupId) {
       NavigableMap<Long, ReferenceCountedClosable> removed = groups.remove(groupId);
-      removed.values().forEach(x -> release(x));
+      if (removed != null) {
+        removed.values().forEach(x -> release(x));
+      }
     }
 
     @Override

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/RaftLogZeroCopyCleaner.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/RaftLogZeroCopyCleaner.java
@@ -155,7 +155,7 @@ public abstract class RaftLogZeroCopyCleaner {
       this.size = estimateSize(handle);
     }
 
-    private int estimateSize(Closeable handle) {
+    private static int estimateSize(Closeable handle) {
       if (handle instanceof KnownLength) {
         try {
           return ((KnownLength) handle).available();

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/RaftLogZeroCopyCleaner.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/RaftLogZeroCopyCleaner.java
@@ -114,7 +114,8 @@ public abstract class RaftLogZeroCopyCleaner {
       });
     }
 
-    private void runInGroupSequentially(RaftGroupId groupId, Consumer<NavigableMap<Long, ReferenceCountedClosable>> block) {
+    private void runInGroupSequentially(RaftGroupId groupId,
+        Consumer<NavigableMap<Long, ReferenceCountedClosable>> block) {
       NavigableMap<Long, ReferenceCountedClosable> group = groups.computeIfAbsent(groupId, (k) -> new TreeMap<>());
       synchronized (group) {
         block.accept(group);
@@ -151,10 +152,10 @@ public abstract class RaftLogZeroCopyCleaner {
 
   }
 
-  private static class ReferenceCountedClosable {
-    final AtomicInteger refCount;
-    final Closeable handle;
-    final int size;
+  private static final class ReferenceCountedClosable {
+    private final AtomicInteger refCount;
+    private final Closeable handle;
+    private final int size;
 
     private ReferenceCountedClosable(int refCount, Closeable handle) {
       this.refCount = new AtomicInteger(refCount);

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/ZeroCopyMessageMarshaller.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/ZeroCopyMessageMarshaller.java
@@ -129,10 +129,6 @@ public class ZeroCopyMessageMarshaller<T extends MessageLite> implements Prototy
     }
   }
 
-  public InputStream popStream(T message) {
-    return unclosedStreams.get(message);
-  }
-
   private List<ByteString> getByteStrings(InputStream detached, int exactSize) throws IOException {
     Preconditions.assertTrue(detached instanceof HasByteBuffer);
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/ZeroCopyMessageMarshaller.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/ZeroCopyMessageMarshaller.java
@@ -129,6 +129,10 @@ public class ZeroCopyMessageMarshaller<T extends MessageLite> implements Prototy
     }
   }
 
+  public InputStream popStream(T message) {
+    return unclosedStreams.get(message);
+  }
+
   private List<ByteString> getByteStrings(InputStream detached, int exactSize) throws IOException {
     Preconditions.assertTrue(detached instanceof HasByteBuffer);
 

--- a/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
+++ b/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
@@ -22,6 +22,8 @@ import org.apache.ratis.RaftTestUtil;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.server.GrpcService;
+import org.apache.ratis.grpc.util.RaftLogZeroCopyCleaner;
+import org.apache.ratis.grpc.util.ZeroCopyMessageMarshaller;
 import org.apache.ratis.protocol.RaftGroup;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -29,6 +31,8 @@ import org.apache.ratis.rpc.SupportedRpcType;
 import org.apache.ratis.server.impl.DelayLocalExecutionInjection;
 import org.apache.ratis.server.impl.MiniRaftCluster;
 import org.apache.ratis.util.NetUtils;
+import org.apache.ratis.util.Slf4jUtils;
+import org.slf4j.event.Level;
 
 import java.util.Optional;
 
@@ -36,6 +40,9 @@ import java.util.Optional;
  * A {@link MiniRaftCluster} with {{@link SupportedRpcType#GRPC}} and data stream disabled.
  */
 public class MiniRaftClusterWithGrpc extends MiniRaftCluster.RpcBase {
+  static {
+    Slf4jUtils.setLogLevel(RaftLogZeroCopyCleaner.LOG, Level.DEBUG);
+  }
   public static final Factory<MiniRaftClusterWithGrpc> FACTORY
       = new Factory<MiniRaftClusterWithGrpc>() {
     @Override

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerRpc.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerRpc.java
@@ -56,7 +56,7 @@ public interface RaftServerRpc extends RaftServerProtocol, RpcType.Get, RaftPeer
   default void notifyNotLeader(RaftGroupId groupId) {
   }
 
-  default void notifyIndexApplied(RaftGroupId groupId, long appliedIndex) {
+  default void notifyCacheEvict(RaftGroupId groupId, long start, long end) {
   }
 
   default void notifyServerClosed(RaftGroupId groupId) {

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerRpc.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerRpc.java
@@ -56,6 +56,12 @@ public interface RaftServerRpc extends RaftServerProtocol, RpcType.Get, RaftPeer
   default void notifyNotLeader(RaftGroupId groupId) {
   }
 
+  default void notifyIndexApplied(RaftGroupId groupId, long appliedIndex) {
+  }
+
+  default void notifyServerClosed(RaftGroupId groupId) {
+  }
+
   default RaftServerAsynchronousProtocol async() {
     throw new UnsupportedOperationException(getClass().getName()
         + " does not support " + JavaUtils.getClassSimpleName(RaftServerAsynchronousProtocol.class));

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -265,7 +265,7 @@ class RaftServerImpl implements RaftServer.Division,
     this.sleepDeviationThreshold = RaftServerConfigKeys.sleepDeviationThreshold(properties);
     this.proxy = proxy;
 
-    this.state = new ServerState(id, group, stateMachine, this, option, properties, this::onIndexApplied);
+    this.state = new ServerState(id, group, stateMachine, this, option, properties, this::onCacheEvict);
     this.retryCache = new RetryCacheImpl(properties);
     this.dataStreamMap = new DataStreamMapImpl(id);
     this.readOption = RaftServerConfigKeys.Read.option(properties);
@@ -1875,8 +1875,8 @@ class RaftServerImpl implements RaftServer.Division,
     return null;
   }
 
-  private void onIndexApplied(long index) {
-    getServerRpc().notifyIndexApplied(getMemberId().getGroupId(), index);
+  private void onCacheEvict(long start, long end) {
+    getServerRpc().notifyCacheEvict(getMemberId().getGroupId(), start, end);
   }
 
   /**

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -37,8 +37,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -121,7 +121,8 @@ public final class LogSegment implements Comparable<Long> {
   static LogSegment newLogSegment(RaftStorage storage, LogSegmentStartEnd startEnd, SizeInBytes maxOpSize,
       SegmentedRaftLogMetrics metrics, BiConsumer<Long, Long> cacheEvictConsumer) {
     return startEnd.isOpen()? newOpenSegment(storage, startEnd.getStartIndex(), maxOpSize, metrics, cacheEvictConsumer)
-        : newCloseSegment(storage, startEnd.getStartIndex(), startEnd.getEndIndex(), maxOpSize, metrics, cacheEvictConsumer);
+        : newCloseSegment(storage, startEnd.getStartIndex(), startEnd.getEndIndex(), maxOpSize, metrics,
+        cacheEvictConsumer);
   }
 
   public static int readSegmentFile(File file, LogSegmentStartEnd startEnd, SizeInBytes maxOpSize,

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -158,6 +158,7 @@ public final class LogSegment implements Comparable<Long> {
     return count;
   }
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
   static LogSegment loadSegment(RaftStorage storage, File file, LogSegmentStartEnd startEnd, SizeInBytes maxOpSize,
       boolean keepEntryInCache, Consumer<LogEntryProto> logConsumer, SegmentedRaftLogMetrics raftLogMetrics,
       BiConsumer<Long, Long> cacheEvictConsumer)

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -212,7 +212,8 @@ public final class SegmentedRaftLog extends RaftLogBase {
     this.storage = b.storage;
     this.stateMachine = b.stateMachine;
     this.segmentMaxSize = RaftServerConfigKeys.Log.segmentSizeMax(b.properties).getSize();
-    this.cache = new SegmentedRaftLogCache(b.memberId, storage, b.properties, getRaftLogMetrics(), b.cacheEvictConsumer);
+    this.cache = new SegmentedRaftLogCache(b.memberId, storage, b.properties, getRaftLogMetrics(),
+        b.cacheEvictConsumer);
     this.cacheEviction = new AwaitToRun(b.memberId + "-cacheEviction", this::checkAndEvictCache).start();
     this.fileLogWorker = new SegmentedRaftLogWorker(b.memberId, stateMachine,
         b.submitUpdateCommitEvent, b.server, storage, b.properties, getRaftLogMetrics());

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
@@ -200,6 +200,7 @@ public class RaftServerTestUtil {
         .setGetTransactionContext(server::getTransactionContext)
         .setSubmitUpdateCommitEvent(server::submitUpdateCommitEvent)
         .setStorage(storage)
+        .setCacheEvictConsumer((l1, l2) -> {})
         .setProperties(properties)
         .build();
   }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RetryCacheTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RetryCacheTestUtil.java
@@ -88,6 +88,7 @@ public class RetryCacheTestUtil {
         .setGetTransactionContext(server::getTransactionContext)
         .setSubmitUpdateCommitEvent(server::submitUpdateCommitEvent)
         .setStorage(storage)
+        .setCacheEvictConsumer((l1, l2) -> {})
         .setProperties(properties)
         .build();
   }

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/impl/SimpleStateMachine4Testing.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/impl/SimpleStateMachine4Testing.java
@@ -202,10 +202,11 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
     // Application should not cache the original log entry to use infinitely,
     // because with zero copy, the buffer that backs the protobuf entry might be gone.
     // Here, we keep a copied version for testing purpose.
-    final LogEntryProto previous = indexMap.put(entry.getIndex(), copy(entry));
+    LogEntryProto copied = copy(entry);
+    final LogEntryProto previous = indexMap.put(entry.getIndex(), copied);
     Preconditions.assertNull(previous, "previous");
     final String s = entry.getStateMachineLogEntry().getLogData().toStringUtf8();
-    dataMap.put(s, entry);
+    dataMap.put(s, copied);
     LOG.info("{}: put {}, {} -> {}", getId(), entry.getIndex(),
         s.length() <= 10? s: s.substring(0, 10) + "...",
         LogProtoUtils.toLogEntryString(entry));

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/impl/SimpleStateMachine4Testing.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/impl/SimpleStateMachine4Testing.java
@@ -42,6 +42,7 @@ import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.statemachine.TransactionContext;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.ratis.util.Daemon;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.LifeCycle;
@@ -198,13 +199,25 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
   }
 
   private void put(LogEntryProto entry) {
-    final LogEntryProto previous = indexMap.put(entry.getIndex(), entry);
+    // Application should not cache the original log entry to use infinitely,
+    // because with zero copy, the buffer that backs the protobuf entry might be gone.
+    // Here, we keep a copied version for testing purpose.
+    final LogEntryProto previous = indexMap.put(entry.getIndex(), copy(entry));
     Preconditions.assertNull(previous, "previous");
     final String s = entry.getStateMachineLogEntry().getLogData().toStringUtf8();
     dataMap.put(s, entry);
     LOG.info("{}: put {}, {} -> {}", getId(), entry.getIndex(),
         s.length() <= 10? s: s.substring(0, 10) + "...",
         LogProtoUtils.toLogEntryString(entry));
+  }
+
+  private LogEntryProto copy(LogEntryProto entry) {
+    try {
+      return LogEntryProto.parseFrom(entry.toByteArray());
+    } catch (
+        InvalidProtocolBufferException e) {
+      throw new IllegalStateException("Error copying entry.", e);
+    }
   }
 
   @Override

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestGroupInfoWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestGroupInfoWithGrpc.java
@@ -24,6 +24,9 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
 @RunWith(Parameterized.class)
 public class TestGroupInfoWithGrpc
     extends GroupInfoBaseTest<MiniRaftClusterWithGrpc>
@@ -34,6 +37,6 @@ public class TestGroupInfoWithGrpc
 
   @Parameterized.Parameters
   public static Collection<Boolean[]> data() {
-    return Arrays.asList((new Boolean[][] {{Boolean.FALSE}, {Boolean.TRUE}}));
+    return Arrays.asList((new Boolean[][] {{FALSE}, {TRUE}}));
   }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestGroupInfoWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestGroupInfoWithGrpc.java
@@ -18,8 +18,22 @@
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.server.impl.GroupInfoBaseTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
 public class TestGroupInfoWithGrpc
     extends GroupInfoBaseTest<MiniRaftClusterWithGrpc>
     implements MiniRaftClusterWithGrpc.FactoryGet {
+  public TestGroupInfoWithGrpc(Boolean zeroCopyEnabled) {
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Boolean[]> data() {
+    return Arrays.asList((new Boolean[][] {{Boolean.FALSE}, {Boolean.TRUE}}));
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestInstallSnapshotNotificationWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestInstallSnapshotNotificationWithGrpc.java
@@ -18,8 +18,23 @@
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.InstallSnapshotNotificationTests;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
 public class TestInstallSnapshotNotificationWithGrpc
     extends InstallSnapshotNotificationTests<MiniRaftClusterWithGrpc>
     implements MiniRaftClusterWithGrpc.FactoryGet {
+
+  @Parameterized.Parameters
+  public static Collection<Boolean[]> data() {
+    return Arrays.asList((new Boolean[][] {{Boolean.FALSE}, {Boolean.TRUE}}));
+  }
+
+  public TestInstallSnapshotNotificationWithGrpc(Boolean zeroCopyEnabled) {
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLeaderElectionWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLeaderElectionWithGrpc.java
@@ -20,10 +20,25 @@ package org.apache.ratis.grpc;
 import org.apache.ratis.server.impl.BlockRequestHandlingInjection;
 import org.apache.ratis.server.impl.LeaderElectionTests;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
 public class TestLeaderElectionWithGrpc
     extends LeaderElectionTests<MiniRaftClusterWithGrpc>
     implements MiniRaftClusterWithGrpc.FactoryGet {
+
+  @Parameterized.Parameters
+  public static Collection<Boolean[]> data() {
+    return Arrays.asList((new Boolean[][] {{Boolean.FALSE}, {Boolean.TRUE}}));
+  }
+
+  public TestLeaderElectionWithGrpc(Boolean zeroCopyEnabled) {
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
+  }
 
   @Override
   @Test

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLeaderInstallSnapshot.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLeaderInstallSnapshot.java
@@ -24,17 +24,21 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
 @RunWith(Parameterized.class)
 public class TestLeaderInstallSnapshot
 extends InstallSnapshotFromLeaderTests<MiniRaftClusterWithGrpc>
 implements MiniRaftClusterWithGrpc.FactoryGet {
 
-    public TestLeaderInstallSnapshot(Boolean separateHeartbeat) {
+    public TestLeaderInstallSnapshot(Boolean separateHeartbeat, Boolean zeroCopyEnabled) {
         GrpcConfigKeys.Server.setHeartbeatChannel(getProperties(), separateHeartbeat);
+        GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
     }
 
     @Parameterized.Parameters
     public static Collection<Boolean[]> data() {
-        return Arrays.asList((new Boolean[][] {{Boolean.FALSE}, {Boolean.TRUE}}));
+        return Arrays.asList((new Boolean[][] {{FALSE, FALSE}, {FALSE, TRUE}, {TRUE, FALSE}, {TRUE, TRUE},}));
     }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
@@ -45,6 +45,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static org.apache.ratis.RaftTestUtil.waitForLeader;
 
 @RunWith(Parameterized.class)
@@ -62,8 +64,7 @@ public class TestLogAppenderWithGrpc
 
   @Parameterized.Parameters
   public static Collection<Boolean[]> data() {
-    return Arrays.asList((new Boolean[][] {{Boolean.FALSE, Boolean.FALSE}, {Boolean.FALSE, Boolean.TRUE},
-        {Boolean.TRUE, Boolean.FALSE}, {Boolean.TRUE, Boolean.TRUE},}));
+    return Arrays.asList((new Boolean[][] {{FALSE, FALSE}, {FALSE, TRUE}, {TRUE, FALSE}, {TRUE, TRUE},}));
   }
 
   @Test

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
@@ -55,13 +55,15 @@ public class TestLogAppenderWithGrpc
     Slf4jUtils.setLogLevel(FollowerInfo.LOG, Level.DEBUG);
   }
 
-  public TestLogAppenderWithGrpc(Boolean separateHeartbeat) {
+  public TestLogAppenderWithGrpc(Boolean separateHeartbeat, Boolean zeroCopyEnabled) {
     GrpcConfigKeys.Server.setHeartbeatChannel(getProperties(), separateHeartbeat);
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
   }
 
   @Parameterized.Parameters
   public static Collection<Boolean[]> data() {
-    return Arrays.asList((new Boolean[][] {{Boolean.FALSE}, {Boolean.TRUE}}));
+    return Arrays.asList((new Boolean[][] {{Boolean.FALSE, Boolean.FALSE}, {Boolean.FALSE, Boolean.TRUE},
+        {Boolean.TRUE, Boolean.FALSE}, {Boolean.TRUE, Boolean.TRUE},}));
   }
 
   @Test

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestMessageStreamApiWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestMessageStreamApiWithGrpc.java
@@ -18,7 +18,24 @@
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.MessageStreamApiTests;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+@RunWith(Parameterized.class)
 public class TestMessageStreamApiWithGrpc extends MessageStreamApiTests<MiniRaftClusterWithGrpc>
     implements MiniRaftClusterWithGrpc.FactoryGet {
+  public TestMessageStreamApiWithGrpc(Boolean zeroCopyEnabled) {
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Boolean[]> data() {
+    return Arrays.asList((new Boolean[][] {{FALSE}, {TRUE}}));
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftAsyncWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftAsyncWithGrpc.java
@@ -18,7 +18,24 @@
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.RaftAsyncTests;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+@RunWith(Parameterized.class)
 public class TestRaftAsyncWithGrpc extends RaftAsyncTests<MiniRaftClusterWithGrpc>
     implements MiniRaftClusterWithGrpc.FactoryGet {
+  public TestRaftAsyncWithGrpc(Boolean zeroCopyEnabled) {
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Boolean[]> data() {
+    return Arrays.asList((new Boolean[][] {{FALSE}, {TRUE}}));
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftExceptionWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftExceptionWithGrpc.java
@@ -18,8 +18,25 @@
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.RaftExceptionBaseTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+@RunWith(Parameterized.class)
 public class TestRaftExceptionWithGrpc
     extends RaftExceptionBaseTest<MiniRaftClusterWithGrpc>
     implements MiniRaftClusterWithGrpc.FactoryGet {
+  public TestRaftExceptionWithGrpc(Boolean zeroCopyEnabled) {
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Boolean[]> data() {
+    return Arrays.asList((new Boolean[][] {{FALSE}, {TRUE}}));
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftOutputStreamWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftOutputStreamWithGrpc.java
@@ -18,10 +18,29 @@
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.OutputStreamBaseTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+@RunWith(Parameterized.class)
 public class TestRaftOutputStreamWithGrpc
     extends OutputStreamBaseTest<MiniRaftClusterWithGrpc>
     implements MiniRaftClusterWithGrpc.FactoryGet {
+
+  public TestRaftOutputStreamWithGrpc(Boolean zeroCopyEnabled) {
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Boolean[]> data() {
+    return Arrays.asList((new Boolean[][] {{FALSE}, {TRUE}}));
+  }
+
   @Override
   public int getGlobalTimeoutSeconds() {
     return 100;

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftReconfigurationWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftReconfigurationWithGrpc.java
@@ -18,8 +18,26 @@
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.server.impl.RaftReconfigurationBaseTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+@RunWith(Parameterized.class)
 public class TestRaftReconfigurationWithGrpc
     extends RaftReconfigurationBaseTest<MiniRaftClusterWithGrpc>
     implements MiniRaftClusterWithGrpc.FactoryGet {
+
+  public TestRaftReconfigurationWithGrpc(Boolean zeroCopyEnabled) {
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Boolean[]> data() {
+    return Arrays.asList((new Boolean[][] {{FALSE}, {TRUE}}));
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftServerWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftServerWithGrpc.java
@@ -86,13 +86,15 @@ public class TestRaftServerWithGrpc extends BaseTest implements MiniRaftClusterW
     Slf4jUtils.setLogLevel(GrpcClientProtocolClient.LOG, Level.TRACE);
   }
 
-  public TestRaftServerWithGrpc(Boolean separateHeartbeat) {
+  public TestRaftServerWithGrpc(Boolean separateHeartbeat, Boolean zeroCopyEnabled) {
     GrpcConfigKeys.Server.setHeartbeatChannel(getProperties(), separateHeartbeat);
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
   }
 
   @Parameterized.Parameters
   public static Collection<Boolean[]> data() {
-    return Arrays.asList((new Boolean[][] {{Boolean.FALSE}, {Boolean.TRUE}}));
+    return Arrays.asList((new Boolean[][] {{Boolean.FALSE, Boolean.FALSE}, {Boolean.FALSE, Boolean.TRUE},
+        {Boolean.TRUE, Boolean.FALSE}, {Boolean.TRUE, Boolean.TRUE},}));
   }
 
   @Before

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftStateMachineExceptionWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftStateMachineExceptionWithGrpc.java
@@ -18,9 +18,25 @@
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.server.impl.RaftStateMachineExceptionTests;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+@RunWith(Parameterized.class)
 public class TestRaftStateMachineExceptionWithGrpc
     extends RaftStateMachineExceptionTests<MiniRaftClusterWithGrpc>
     implements MiniRaftClusterWithGrpc.FactoryGet {
+  public TestRaftStateMachineExceptionWithGrpc(Boolean zeroCopyEnabled) {
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
+  }
 
+  @Parameterized.Parameters
+  public static Collection<Boolean[]> data() {
+    return Arrays.asList((new Boolean[][] {{FALSE}, {TRUE}}));
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
@@ -52,13 +52,15 @@ public class TestRaftWithGrpc
         SimpleStateMachine4Testing.class, StateMachine.class);
   }
 
-  public TestRaftWithGrpc(Boolean separateHeartbeat) {
+  public TestRaftWithGrpc(Boolean separateHeartbeat, Boolean zeroCopyEnabled) {
     GrpcConfigKeys.Server.setHeartbeatChannel(getProperties(), separateHeartbeat);
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
   }
 
   @Parameterized.Parameters
   public static Collection<Boolean[]> data() {
-    return Arrays.asList((new Boolean[][] {{Boolean.FALSE}, {Boolean.TRUE}}));
+    return Arrays.asList((new Boolean[][] {{Boolean.FALSE, Boolean.FALSE}, {Boolean.FALSE, Boolean.TRUE},
+        {Boolean.TRUE, Boolean.FALSE}, {Boolean.TRUE, Boolean.TRUE},}));
   }
 
   @Override

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
@@ -40,6 +40,8 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static org.apache.ratis.RaftTestUtil.waitForLeader;
 
 @RunWith(Parameterized.class)
@@ -59,8 +61,7 @@ public class TestRaftWithGrpc
 
   @Parameterized.Parameters
   public static Collection<Boolean[]> data() {
-    return Arrays.asList((new Boolean[][] {{Boolean.FALSE, Boolean.FALSE}, {Boolean.FALSE, Boolean.TRUE},
-        {Boolean.TRUE, Boolean.FALSE}, {Boolean.TRUE, Boolean.TRUE},}));
+    return Arrays.asList((new Boolean[][] {{FALSE, FALSE}, {FALSE, TRUE}, {TRUE, FALSE}, {TRUE, TRUE},}));
   }
 
   @Override

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestReadOnlyRequestWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestReadOnlyRequestWithGrpc.java
@@ -18,8 +18,26 @@
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.ReadOnlyRequestTests;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+@RunWith(Parameterized.class)
 public class TestReadOnlyRequestWithGrpc
   extends ReadOnlyRequestTests<MiniRaftClusterWithGrpc>
   implements MiniRaftClusterWithGrpc.FactoryGet {
+
+  public TestReadOnlyRequestWithGrpc(Boolean zeroCopyEnabled) {
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Boolean[]> data() {
+    return Arrays.asList((new Boolean[][] {{FALSE}, {TRUE}}));
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestServerPauseResumeWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestServerPauseResumeWithGrpc.java
@@ -18,9 +18,25 @@
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.server.impl.ServerPauseResumeTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+@RunWith(Parameterized.class)
 public class TestServerPauseResumeWithGrpc
     extends ServerPauseResumeTest<MiniRaftClusterWithGrpc>
     implements MiniRaftClusterWithGrpc.FactoryGet {
+  public TestServerPauseResumeWithGrpc(Boolean zeroCopyEnabled) {
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
+  }
 
+  @Parameterized.Parameters
+  public static Collection<Boolean[]> data() {
+    return Arrays.asList((new Boolean[][] {{FALSE}, {TRUE}}));
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestServerRestartWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestServerRestartWithGrpc.java
@@ -18,8 +18,25 @@
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.server.ServerRestartTests;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+@RunWith(Parameterized.class)
 public class TestServerRestartWithGrpc
     extends ServerRestartTests<MiniRaftClusterWithGrpc>
     implements MiniRaftClusterWithGrpc.FactoryGet {
+  public TestServerRestartWithGrpc(Boolean zeroCopyEnabled) {
+    GrpcConfigKeys.Server.setZeroCopyEnabled(getProperties(), zeroCopyEnabled);
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Boolean[]> data() {
+    return Arrays.asList((new Boolean[][] {{FALSE}, {TRUE}}));
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestCacheEviction.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestCacheEviction.java
@@ -58,7 +58,7 @@ public class TestCacheEviction extends BaseTest {
     Assert.assertEquals(numSegments, cached.length);
     final LogSegmentList segments = new LogSegmentList(JavaUtils.getClassSimpleName(TestCacheEviction.class));
     for (int i = 0; i < numSegments; i++) {
-      LogSegment s = LogSegment.newCloseSegment(null, start, start + size - 1, MAX_OP_SIZE, null);
+      LogSegment s = LogSegment.newCloseSegment(null, start, start + size - 1, MAX_OP_SIZE, null, (l1, l2) -> {});
       if (cached[i]) {
         s = Mockito.spy(s);
         Mockito.when(s.hasCache()).thenReturn(true);

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestLogSegment.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestLogSegment.java
@@ -172,7 +172,7 @@ public class TestLogSegment extends BaseTest {
     final File openSegmentFile = prepareLog(true, 0, 100, 0, isLastEntryPartiallyWritten);
     RaftStorage storage = RaftStorageTestUtils.newRaftStorage(storageDir);
     final LogSegment openSegment = LogSegment.loadSegment(storage, openSegmentFile,
-        LogSegmentStartEnd.valueOf(0), MAX_OP_SIZE, loadInitial, null, null);
+        LogSegmentStartEnd.valueOf(0), MAX_OP_SIZE, loadInitial, null, null, (l1, l2) -> {});
     final int delta = isLastEntryPartiallyWritten? 1: 0;
     checkLogSegment(openSegment, 0, 99 - delta, true, openSegmentFile.length(), 0);
     storage.close();
@@ -182,7 +182,7 @@ public class TestLogSegment extends BaseTest {
     // load a closed segment (1000-1099)
     final File closedSegmentFile = prepareLog(false, 1000, 100, 1, false);
     LogSegment closedSegment = LogSegment.loadSegment(storage, closedSegmentFile,
-        LogSegmentStartEnd.valueOf(1000, 1099L), MAX_OP_SIZE, loadInitial, null, null);
+        LogSegmentStartEnd.valueOf(1000, 1099L), MAX_OP_SIZE, loadInitial, null, null, (l1, l2) -> {});
     checkLogSegment(closedSegment, 1000, 1099, false,
         closedSegment.getTotalFileSize(), 1);
     Assert.assertEquals(loadInitial ? 0 : 1, closedSegment.getLoadingTimes());
@@ -191,7 +191,7 @@ public class TestLogSegment extends BaseTest {
   @Test
   public void testAppendEntries() throws Exception {
     final long start = 1000;
-    LogSegment segment = LogSegment.newOpenSegment(null, start, MAX_OP_SIZE, null);
+    LogSegment segment = LogSegment.newOpenSegment(null, start, MAX_OP_SIZE, null, (l1, l2) -> {});
     long size = SegmentedRaftLogFormat.getHeaderLength();
     final long max = 8 * 1024 * 1024;
     checkLogSegment(segment, start, start - 1, true, size, 0);
@@ -217,7 +217,7 @@ public class TestLogSegment extends BaseTest {
     final File openSegmentFile = prepareLog(true, 0, 100, 0, true);
     RaftStorage storage = RaftStorageTestUtils.newRaftStorage(storageDir);
     final LogSegment openSegment = LogSegment.loadSegment(storage, openSegmentFile,
-        LogSegmentStartEnd.valueOf(0), MAX_OP_SIZE, true, null, raftLogMetrics);
+        LogSegmentStartEnd.valueOf(0), MAX_OP_SIZE, true, null, raftLogMetrics, (l1, l2) -> {});
     checkLogSegment(openSegment, 0, 98, true, openSegmentFile.length(), 0);
     storage.close();
 
@@ -230,7 +230,7 @@ public class TestLogSegment extends BaseTest {
 
   @Test
   public void testAppendWithGap() throws Exception {
-    LogSegment segment = LogSegment.newOpenSegment(null, 1000, MAX_OP_SIZE, null);
+    LogSegment segment = LogSegment.newOpenSegment(null, 1000, MAX_OP_SIZE, null, (l1, l2) -> {});
     SimpleOperation op = new SimpleOperation("m");
     final StateMachineLogEntryProto m = op.getLogEntryContent();
     try {
@@ -257,7 +257,7 @@ public class TestLogSegment extends BaseTest {
   public void testTruncate() throws Exception {
     final long term = 1;
     final long start = 1000;
-    LogSegment segment = LogSegment.newOpenSegment(null, start, MAX_OP_SIZE, null);
+    LogSegment segment = LogSegment.newOpenSegment(null, start, MAX_OP_SIZE, null, (l1, l2) -> {});
     for (int i = 0; i < 100; i++) {
       LogEntryProto entry = LogProtoUtils.toLogEntryProto(
           new SimpleOperation("m" + i).getLogEntryContent(), term, i + start);

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -140,6 +140,7 @@ public class TestSegmentedRaftLog extends BaseTest {
         .setMemberId(memberId)
         .setStorage(storage)
         .setProperties(properties)
+        .setCacheEvictConsumer((l1, l2) -> {})
         .build();
   }
 
@@ -150,6 +151,7 @@ public class TestSegmentedRaftLog extends BaseTest {
         .setStorage(storage)
         .setSnapshotIndexSupplier(getSnapshotIndexFromStateMachine)
         .setProperties(properties)
+        .setCacheEvictConsumer((l1, l2) -> {})
         .build();
   }
 
@@ -588,6 +590,7 @@ public class TestSegmentedRaftLog extends BaseTest {
         .setStateMachine(sm)
         .setStorage(storage)
         .setProperties(properties)
+        .setCacheEvictConsumer((l1, l2) -> {})
         .build()) {
       raftLog.open(RaftLog.INVALID_LOG_INDEX, null);
 
@@ -658,6 +661,7 @@ public class TestSegmentedRaftLog extends BaseTest {
         .setStateMachine(sm)
         .setStorage(storage)
         .setProperties(properties)
+        .setCacheEvictConsumer((l1, l2) -> {})
         .build()) {
       raftLog.open(RaftLog.INVALID_LOG_INDEX, null);
       // SegmentedRaftLogWorker should catch TimeoutIOException

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLogCache.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLogCache.java
@@ -51,7 +51,7 @@ public class TestSegmentedRaftLogCache {
   public void setup() {
     raftLogMetrics = new SegmentedRaftLogMetrics(RaftServerTestUtil.TEST_MEMBER_ID);
     ratisMetricRegistry = (RatisMetricRegistryImpl) raftLogMetrics.getRegistry();
-    cache = new SegmentedRaftLogCache(null, null, prop, raftLogMetrics);
+    cache = new SegmentedRaftLogCache(null, null, prop, raftLogMetrics, (l1, l2) -> {});
   }
 
   @After
@@ -60,7 +60,7 @@ public class TestSegmentedRaftLogCache {
   }
 
   private LogSegment prepareLogSegment(long start, long end, boolean isOpen) {
-    LogSegment s = LogSegment.newOpenSegment(null, start, MAX_OP_SIZE, null);
+    LogSegment s = LogSegment.newOpenSegment(null, start, MAX_OP_SIZE, null, (l1, l2) -> {});
     for (long i = start; i <= end; i++) {
       SimpleOperation m = new SimpleOperation("m" + i);
       LogEntryProto entry = LogProtoUtils.toLogEntryProto(m.getLogEntryContent(), 0, i);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support Zero-Copy in GrpcClientProtocolService. 
Zero copy applied to `ordered` and `unordered` API.

Incoming streams are managed by a component called `RaftLogZeroCopyCleaner`. It sorts the streams by associating the log index and observes the raft log cache eviction events to release the streams accordingly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1925

## How was this patch tested?

Added integration test for zero-copy. 
