### PR TITLE
RATIS-1942. GrpcLogAppender has `ILLEGAL TRANSITION: STARTING -> STARTING`

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/LifeCycle.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/LifeCycle.java
@@ -160,16 +160,20 @@ public class LifeCycle {
 
   /** Transition from the current state to the given state. */
   public void transition(final State to) {
-    final State from = current.getAndSet(to);
-    State.validate(name, from, to);
+    current.updateAndGet(from -> {
+      State.validate(name, from, to);
+      return to;
+    });
   }
 
   /** Transition from the current state to the given state if the current state is not equal to the given state. */
   public void transitionIfNotEqual(final State to) {
-    final State from = current.getAndSet(to);
-    if (from != to) {
-      State.validate(name, from, to);
-    }
+    current.updateAndGet(from -> {
+      if (from != to) {
+        State.validate(name, from, to);
+      }
+      return to;
+    });
   }
 
   /**
@@ -226,11 +230,14 @@ public class LifeCycle {
    * @return true iff the current state is equal to the specified from state.
    */
   public boolean compareAndTransition(final State from, final State to) {
-    if (current.compareAndSet(from, to)) {
+    final State previous = current.getAndUpdate(state -> {
+      if (state != from) {
+        return state;
+      }
       State.validate(name, from, to);
-      return true;
-    }
-    return false;
+      return to;
+    });
+    return previous == from;
   }
 
   /** @return the current state. */

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -62,7 +62,7 @@ public class GrpcServerProtocolClient implements Closeable {
   public GrpcServerProtocolClient(RaftPeer target, int flowControlWindow,
       TimeDuration requestTimeout, GrpcTlsConfig tlsConfig, boolean separateHBChannel) {
     raftPeerId = target.getId();
-    LOG.info("Build channel for {}", raftPeerId);
+    LOG.info("Build channel for {}", target);
     useSeparateHBChannel = separateHBChannel;
     channel = buildChannel(target, flowControlWindow, tlsConfig);
     blockingStub = RaftServerProtocolServiceGrpc.newBlockingStub(channel);

--- a/ratis-test/src/test/java/org/apache/ratis/util/TestLifeCycle.java
+++ b/ratis-test/src/test/java/org/apache/ratis/util/TestLifeCycle.java
@@ -17,10 +17,13 @@
  */
 package org.apache.ratis.util;
 
-import org.junit.Assert;
+import org.apache.ratis.util.function.TriConsumer;
 import org.junit.Test;
 
 import static org.apache.ratis.util.LifeCycle.State.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.*;
 
@@ -31,7 +34,7 @@ public class TestLifeCycle {
    * while this test uses successors.
    */
   @Test(timeout = 1000)
-  public void testIsValid() throws Exception {
+  public void testIsValid() {
     final Map<LifeCycle.State, List<LifeCycle.State>> successors
         = new EnumMap<>(LifeCycle.State.class);
     put(NEW,       successors, STARTING, CLOSED);
@@ -44,10 +47,52 @@ public class TestLifeCycle {
     put(CLOSED,    successors);
 
     final List<LifeCycle.State> states = Arrays.asList(LifeCycle.State.values());
-    states.stream().forEach(
+    states.forEach(
         from -> states.forEach(
-            to -> Assert.assertEquals(from + " -> " + to,
+            to -> assertEquals(from + " -> " + to,
                 successors.get(from).contains(to),
                 isValid(from, to))));
   }
+
+  @Test
+  public void validTransitions() {
+    testValidTransition((from, subject, to) -> assertTrue(subject.compareAndTransition(from, to)));
+    testValidTransition((from, subject, to) -> subject.transition(to));
+    testValidTransition((from, subject, to) -> assertEquals(to, subject.transitionAndGet(any -> to)));
+    testValidTransition((from, subject, to) -> subject.transitionIfNotEqual(to));
+    testValidTransition((from, subject, to) -> assertTrue(subject.transitionIfValid(to)));
+  }
+
+  private static void testValidTransition(TriConsumer<LifeCycle.State, LifeCycle, LifeCycle.State> op) {
+    LifeCycle subject = new LifeCycle("subject");
+    for (LifeCycle.State to : new LifeCycle.State[] { STARTING, RUNNING, PAUSING, PAUSED, CLOSING, CLOSED }) {
+      LifeCycle.State from = subject.getCurrentState();
+      op.accept(from, subject, to);
+      assertEquals(to, subject.getCurrentState());
+    }
+  }
+
+  @Test
+  public void invalidTransitions() {
+    testInvalidTransition((from, subject, to) -> subject.compareAndTransition(from, to), true);
+    testInvalidTransition((from, subject, to) -> subject.transition(to), true);
+    testInvalidTransition((from, subject, to) -> subject.transitionIfNotEqual(to), true);
+    testInvalidTransition((from, subject, to) -> assertFalse(subject.transitionIfValid(to)), false);
+    testInvalidTransition((from, subject, to) -> subject.transitionAndGet(any -> to), true);
+  }
+
+  private static void testInvalidTransition(TriConsumer<LifeCycle.State, LifeCycle, LifeCycle.State> op, boolean shouldThrow) {
+    LifeCycle subject = new LifeCycle("subject");
+    for (LifeCycle.State to : new LifeCycle.State[] { RUNNING, EXCEPTION, CLOSING }) {
+      LifeCycle.State from = subject.getCurrentState();
+      try {
+        op.accept(from, subject, to);
+        assertFalse(shouldThrow);
+      } catch (IllegalStateException e) {
+        assertTrue(shouldThrow);
+        assertEquals("Should be in original state", from, subject.getCurrentState());
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Assign local address to new peers being added to the cluster.

https://issues.apache.org/jira/browse/RATIS-1942

## How was this patch tested?

Compared 10x10 runs of `TestRetryCacheWithGrpc` with and without the patch.

without patch: 13/100 failures, 10/13 failure logs had `STARTING -> STARTING`:
https://github.com/adoroszlai/ratis/actions/runs/7199041920

```
$ grep -cr 'STARTING -> STARTING' | sort -g
1/iteration2/ratis-test/org.apache.ratis.grpc.TestRetryCacheWithGrpc-output.txt:1223
2/iteration1/ratis-test/org.apache.ratis.grpc.TestRetryCacheWithGrpc-output.txt:1457
2/iteration3/ratis-test/org.apache.ratis.grpc.TestRetryCacheWithGrpc-output.txt:1284
2/iteration9/ratis-test/org.apache.ratis.grpc.TestRetryCacheWithGrpc-output.txt:1374
3/iteration7/ratis-test/org.apache.ratis.grpc.TestRetryCacheWithGrpc-output.txt:1190
6/iteration10/ratis-test/org.apache.ratis.grpc.TestRetryCacheWithGrpc-output.txt:1215
9/iteration6/ratis-test/org.apache.ratis.grpc.TestRetryCacheWithGrpc-output.txt:1448
9/iteration8/ratis-test/org.apache.ratis.grpc.TestRetryCacheWithGrpc-output.txt:1440
10/iteration1/ratis-test/org.apache.ratis.grpc.TestRetryCacheWithGrpc-output.txt:1507
```

with patch, no `STARTING -> STARTING`:
https://github.com/adoroszlai/ratis/actions/runs/7198991194

CI:
https://github.com/adoroszlai/ratis/actions/runs/7198887876