### PR TITLE
RATIS-1966. Batch frequent warn logs during gRPC exceptional periods

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.util;
+
+import org.slf4j.Logger;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
+
+/** For batching excessive log messages. */
+public final class BatchLogger {
+
+  private BatchLogger() {
+  }
+
+  public static final class UniqueId {
+    private final StackTraceElement traceElement;
+    private final String name;
+
+    private UniqueId(StackTraceElement traceElement, String name) {
+      this.traceElement = traceElement;
+      this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      } else if (!(obj instanceof UniqueId)) {
+        return false;
+      }
+
+      final UniqueId that = (UniqueId) obj;
+      return Objects.equals(this.traceElement, that.traceElement)
+          && Objects.equals(this.name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return traceElement.hashCode() ^ name.hashCode();
+    }
+  }
+
+  public static UniqueId makeUniqueId(String name) {
+    return new UniqueId(JavaUtils.getCallerStackTraceElement(), name);
+  }
+
+  private static final class BatchedLogEntry {
+    private final Consumer<String> log;
+    private final Runnable logOp;
+    private Timestamp startTime = null;
+    private int count = 0;
+
+    private BatchedLogEntry(Consumer<String> log, Runnable logOp) {
+      this.log = log;
+      this.logOp = logOp;
+    }
+
+    private synchronized void execute() {
+      if (count <= 1) {
+        return;
+      }
+      log.accept(String.format("Received %s logs of following between %s and %s:",
+          count, startTime, Timestamp.currentTime()));
+      logOp.run();
+      startTime = null;
+    }
+
+    private synchronized boolean tryStartBatch() {
+      if (startTime == null) {
+        startTime = Timestamp.currentTime();
+        count = 1;
+        return true;
+      }
+      count++;
+      return false;
+    }
+  }
+
+  private static final TimeoutExecutor SCHEDULER = TimeoutExecutor.getInstance();
+  private static final ConcurrentMap<UniqueId, BatchedLogEntry> LOG_CACHE = new ConcurrentHashMap<>();
+
+  public static void warn(Logger log, UniqueId id, Runnable op, TimeDuration batchDuration) {
+    warn(log, id, op, batchDuration, true);
+  }
+
+  public static void warn(Logger log, UniqueId id, Runnable op, TimeDuration batchDuration, boolean shouldBatch) {
+    if (!shouldBatch || batchDuration.isNonPositive()) {
+      op.run();
+      return;
+    }
+
+    final BatchedLogEntry entry = LOG_CACHE.computeIfAbsent(id, key -> new BatchedLogEntry(log::warn, op));
+
+    if (entry.tryStartBatch()) {
+      // print the first warn log on batch start
+      op.run();
+      SCHEDULER.onTimeout(batchDuration,
+          () -> Optional.ofNullable(LOG_CACHE.remove(id)).ifPresent(BatchedLogEntry::execute),
+          log, () -> "print batched exception failed on " + op);
+    }
+  }
+}

--- a/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
@@ -78,8 +78,8 @@ public final class BatchLogger {
       if (count <= 1) {
         return;
       }
-      log.accept(String.format("Received %s logs of following between %s and %s:",
-          count, startTime, Timestamp.currentTime()));
+      log.accept(String.format("Received %s logs of following in the last %s seconds:",
+          count, startTime.elapsedTime()));
       logOp.run();
       startTime = null;
     }

--- a/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.ratis.util;
 
 import org.slf4j.Logger;

--- a/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
@@ -19,25 +19,30 @@
 package org.apache.ratis.util;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 /** For batching excessive log messages. */
 public final class BatchLogger {
+  private static final Logger LOG = LoggerFactory.getLogger(BatchLogger.class);
 
   private BatchLogger() {
   }
 
-  public static final class UniqueId {
-    private final StackTraceElement traceElement;
+  public interface Key {}
+
+  private static final class UniqueId {
+    private final Key key;
     private final String name;
 
-    private UniqueId(StackTraceElement traceElement, String name) {
-      this.traceElement = traceElement;
+    private UniqueId(Key key, String name) {
+      this.key = Objects.requireNonNull(key, "key == null");
       this.name = name;
     }
 
@@ -50,73 +55,63 @@ public final class BatchLogger {
       }
 
       final UniqueId that = (UniqueId) obj;
-      return Objects.equals(this.traceElement, that.traceElement)
+      return Objects.equals(this.key, that.key)
           && Objects.equals(this.name, that.name);
     }
 
     @Override
     public int hashCode() {
-      return traceElement.hashCode() ^ name.hashCode();
+      return key.hashCode() ^ name.hashCode();
     }
-  }
-
-  public static UniqueId makeUniqueId(String name) {
-    return new UniqueId(JavaUtils.getCallerStackTraceElement(), name);
   }
 
   private static final class BatchedLogEntry {
-    private final Consumer<String> log;
-    private final Runnable logOp;
-    private Timestamp startTime = null;
+    private Consumer<String> logOp;
+    private Timestamp startTime = Timestamp.currentTime();
     private int count = 0;
-
-    private BatchedLogEntry(Consumer<String> log, Runnable logOp) {
-      this.log = log;
-      this.logOp = logOp;
-    }
 
     private synchronized void execute() {
       if (count <= 1) {
         return;
       }
-      log.accept(String.format("Received %s logs of following in the last %s seconds:",
-          count, startTime.elapsedTime()));
-      logOp.run();
+      logOp.accept(String.format(" (Repeated %d times in the last %s)",
+          count, startTime.elapsedTime().toString(TimeUnit.SECONDS, 3)));
       startTime = null;
     }
 
-    private synchronized boolean tryStartBatch() {
-      if (startTime == null) {
-        startTime = Timestamp.currentTime();
-        count = 1;
-        return true;
+    private synchronized boolean tryStartBatch(Consumer<String> op) {
+      if (startTime == null) { // already executed
+        op.accept("");
+        return false;
       }
+      logOp = op;
       count++;
-      return false;
+      return count == 1;
     }
   }
 
   private static final TimeoutExecutor SCHEDULER = TimeoutExecutor.getInstance();
   private static final ConcurrentMap<UniqueId, BatchedLogEntry> LOG_CACHE = new ConcurrentHashMap<>();
 
-  public static void warn(Logger log, UniqueId id, Runnable op, TimeDuration batchDuration) {
-    warn(log, id, op, batchDuration, true);
+  public static void warn(Key key, String name, Consumer<String> op, TimeDuration batchDuration) {
+    warn(key, name, op, batchDuration, true);
   }
 
-  public static void warn(Logger log, UniqueId id, Runnable op, TimeDuration batchDuration, boolean shouldBatch) {
+  public static void warn(Key key, String name, Consumer<String> op, TimeDuration batchDuration, boolean shouldBatch) {
     if (!shouldBatch || batchDuration.isNonPositive()) {
-      op.run();
+      op.accept("");
       return;
     }
 
-    final BatchedLogEntry entry = LOG_CACHE.computeIfAbsent(id, key -> new BatchedLogEntry(log::warn, op));
+    final UniqueId id = new UniqueId(key, name);
+    final BatchedLogEntry entry = LOG_CACHE.computeIfAbsent(id, k -> new BatchedLogEntry());
 
-    if (entry.tryStartBatch()) {
+    if (entry.tryStartBatch(op)) {
       // print the first warn log on batch start
-      op.run();
+      op.accept("");
       SCHEDULER.onTimeout(batchDuration,
           () -> Optional.ofNullable(LOG_CACHE.remove(id)).ifPresent(BatchedLogEntry::execute),
-          log, () -> "print batched exception failed on " + op);
+          LOG, () -> "print batched exception failed on " + op);
     }
   }
 }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
@@ -288,9 +288,9 @@ public interface GrpcConfigKeys {
           LOG_MESSAGE_BATCH_DURATION_KEY, LOG_MESSAGE_BATCH_DURATION_DEFAULT, getDefaultLog());
     }
     static void setLogMessageBatchDuration(RaftProperties properties,
-                                           TimeDuration exceptionalWarnLogBatchDuration) {
+                                           TimeDuration logMessageBatchDuration) {
       setTimeDuration(properties::setTimeDuration,
-          LOG_MESSAGE_BATCH_DURATION_KEY, exceptionalWarnLogBatchDuration);
+          LOG_MESSAGE_BATCH_DURATION_KEY, logMessageBatchDuration);
     }
   }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
@@ -25,6 +25,7 @@ import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static org.apache.ratis.conf.ConfUtils.get;
@@ -278,6 +279,18 @@ public interface GrpcConfigKeys {
     }
     static void setHeartbeatChannel(RaftProperties properties, boolean useSeparate) {
       setBoolean(properties::setBoolean, HEARTBEAT_CHANNEL_KEY, useSeparate);
+    }
+
+    String LOG_MESSAGE_BATCH_DURATION_KEY = PREFIX + ".log-message.batch.duration";
+    TimeDuration LOG_MESSAGE_BATCH_DURATION_DEFAULT = TimeDuration.valueOf(5, TimeUnit.SECONDS);
+    static TimeDuration logMessageBatchDuration(RaftProperties properties) {
+      return getTimeDuration(properties.getTimeDuration(LOG_MESSAGE_BATCH_DURATION_DEFAULT.getUnit()),
+          LOG_MESSAGE_BATCH_DURATION_KEY, LOG_MESSAGE_BATCH_DURATION_DEFAULT, getDefaultLog());
+    }
+    static void setLogMessageBatchDuration(RaftProperties properties,
+                                           TimeDuration exceptionalWarnLogBatchDuration) {
+      setTimeDuration(properties::setTimeDuration,
+          LOG_MESSAGE_BATCH_DURATION_KEY, exceptionalWarnLogBatchDuration);
     }
   }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1966. 

See the effects:
<img width="838" alt="image" src="https://github.com/apache/ratis/assets/48054931/cd7bbba1-0f4f-4b9b-8d78-43ed8689bffa">


BEFORE：
![image](https://github.com/apache/ratis/assets/48054931/927b145f-0512-4e49-ba76-d855c933ef59)
AFTER
<img width="679" alt="image" src="https://github.com/apache/ratis/assets/48054931/c142634d-a9e0-43d9-a84e-ec2a202d0993">
