### PR TITLE
RATIS-1988. Provide Jacoco report to Sonar

### DIFF
--- a/dev-support/checks/sonar.sh
+++ b/dev-support/checks/sonar.sh
@@ -25,4 +25,5 @@ fi
 
 ${MVN} -B verify -DskipShade -DskipTests --no-transfer-progress \
   org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar \
+  -Dsonar.coverage.jacoco.xmlReportPaths="${DIR}/target/coverage/all.xml" \
   -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache-ratis

--- a/dev-support/checks/sonar.sh
+++ b/dev-support/checks/sonar.sh
@@ -25,5 +25,5 @@ fi
 
 ${MVN} -B verify -DskipShade -DskipTests --no-transfer-progress \
   org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar \
-  -Dsonar.coverage.jacoco.xmlReportPaths="${DIR}/target/coverage/all.xml" \
+  -Dsonar.coverage.jacoco.xmlReportPaths="$(pwd)/target/coverage/all.xml" \
   -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache-ratis


### PR DESCRIPTION
## What changes were proposed in this pull request?

RATIS-1985 added code coverage calculation. SonarCloud expects the report in a different location, so it still shows 0%.

```
[INFO] 'sonar.coverage.jacoco.xmlReportPaths' is not defined. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml
[INFO] No report imported, no coverage information will be imported by JaCoCo XML Report Importer
```

This change sets the property to the location of the aggregate XML report generated by `coverage.sh`.

https://issues.apache.org/jira/browse/RATIS-1988

## How was this patch tested?

Tested in (non-fork) [CI run](https://github.com/apache/ratis/actions/runs/7377131200/job/20070984036#step:8:1298):

```
[INFO] Sensor JaCoCo XML Report Importer [jacoco]
[INFO] Importing 1 report(s). Turn your logs in debug mode in order to see the exhaustive list.
```

SonarCloud now shows 76.3% coverage for [this branch](https://sonarcloud.io/summary/new_code?id=apache-ratis&branch=RATIS-1988).