### PR TITLE
RATIS-1991. Optimize the reconfig judgment logic in the ReconfigurationBase class.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/conf/ReconfigurationBase.java
+++ b/ratis-common/src/main/java/org/apache/ratis/conf/ReconfigurationBase.java
@@ -172,7 +172,7 @@ public abstract class ReconfigurationBase implements Reconfigurable {
     }
     final String effective = reconfigureProperty(property, newValue);
     LOG.info("{}: changed property {} to {} (effective {})", name, property, newValue, effective);
-    if (newValue != null) {
+    if (effective != null) {
       properties.set(property, effective);
     } else {
       properties.unset(property);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change the judgment logic: 
It is necessary to determine whether the `effective` is null, rather than `newValue`.

Because the parameter of the `properties.set` method is `effective`.

```java
final String effective = reconfigureProperty(property, newValue);
LOG.info("{}: changed property {} to {} (effective {})", name, property, newValue, effective);
if (newValue != null) {
  properties.set(property, effective);
} else {
  properties.unset(property);
}
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1991

## How was this patch tested?
No testing required.