### PR TITLE
RATIS-1992. Update website with Ratis 3.0.1 release

### DIFF
--- a/categories.html
+++ b/categories.html
@@ -115,7 +115,7 @@
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/community.html
+++ b/community.html
@@ -151,7 +151,7 @@ issues mailing list.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/downloads.html
+++ b/downloads.html
@@ -114,9 +114,31 @@ The binaries are also uploaded to the maven central for convenience. (See the ge
     </tr>
   </thead>
 
-    <tr>
+    
+    
+     <tr>
+       <td>3.0.1</td>
+       <td>2024 Jan 9</td>
+       <td>
+         <a href="https://www.apache.org/dyn/closer.cgi/ratis/3.0.1/apache-ratis-3.0.1-src.tar.gz">source</a>
+         (<a href="https://downloads.apache.org/ratis/3.0.1/apache-ratis-3.0.1-src.tar.gz.mds">checksum</a>
+         <a href="https://downloads.apache.org/ratis/3.0.1/apache-ratis-3.0.1-src.tar.gz.asc">signature</a>)
+        </td>
+        <td>
+          <a href="https://www.apache.org/dyn/closer.cgi/ratis/3.0.1/apache-ratis-3.0.1-bin.tar.gz">binary</a>
+          (<a href="https://downloads.apache.org/ratis/3.0.1/apache-ratis-3.0.1-bin.tar.gz.mds">checksum</a>
+          <a href="https://downloads.apache.org/ratis/3.0.1/apache-ratis-3.0.1-bin.tar.gz.asc">signature</a>)
+         </td>
+         <td>
+           <a href="post/3.0.1.html">Announcement</a>
+         </td>
+     </tr>
+    
+    
+    
+     <tr>
        <td>3.0.0</td>
-       <td>2023 Nov 17</td>
+       <td>2023 Nov 21</td>
        <td>
          <a href="https://www.apache.org/dyn/closer.cgi/ratis/3.0.0/apache-ratis-3.0.0-src.tar.gz">source</a>
          (<a href="https://downloads.apache.org/ratis/3.0.0/apache-ratis-3.0.0-src.tar.gz.mds">checksum</a>
@@ -131,6 +153,7 @@ The binaries are also uploaded to the maven central for convenience. (See the ge
            <a href="post/3.0.0.html">Announcement</a>
          </td>
      </tr>
+    
     
     
      <tr>
@@ -192,46 +215,6 @@ The binaries are also uploaded to the maven central for convenience. (See the ge
      </tr>
     
     
-    
-     <tr>
-       <td>2.4.0</td>
-       <td>2022 Oct 18</td>
-       <td>
-         <a href="https://www.apache.org/dyn/closer.cgi/ratis/2.4.0/apache-ratis-2.4.0-src.tar.gz">source</a>
-         (<a href="https://downloads.apache.org/ratis/2.4.0/apache-ratis-2.4.0-src.tar.gz.mds">checksum</a>
-         <a href="https://downloads.apache.org/ratis/2.4.0/apache-ratis-2.4.0-src.tar.gz.asc">signature</a>)
-        </td>
-        <td>
-          <a href="https://www.apache.org/dyn/closer.cgi/ratis/2.4.0/apache-ratis-2.4.0-bin.tar.gz">binary</a>
-          (<a href="https://downloads.apache.org/ratis/2.4.0/apache-ratis-2.4.0-bin.tar.gz.mds">checksum</a>
-          <a href="https://downloads.apache.org/ratis/2.4.0/apache-ratis-2.4.0-bin.tar.gz.asc">signature</a>)
-         </td>
-         <td>
-           <a href="post/2.4.0.html">Announcement</a>
-         </td>
-     </tr>
-    
-    
-    
-     <tr>
-       <td>2.3.0</td>
-       <td>2022 May 19</td>
-       <td>
-         <a href="https://www.apache.org/dyn/closer.cgi/ratis/2.3.0/apache-ratis-2.3.0-src.tar.gz">source</a>
-         (<a href="https://downloads.apache.org/ratis/2.3.0/apache-ratis-2.3.0-src.tar.gz.mds">checksum</a>
-         <a href="https://downloads.apache.org/ratis/2.3.0/apache-ratis-2.3.0-src.tar.gz.asc">signature</a>)
-        </td>
-        <td>
-          <a href="https://www.apache.org/dyn/closer.cgi/ratis/2.3.0/apache-ratis-2.3.0-bin.tar.gz">binary</a>
-          (<a href="https://downloads.apache.org/ratis/2.3.0/apache-ratis-2.3.0-bin.tar.gz.mds">checksum</a>
-          <a href="https://downloads.apache.org/ratis/2.3.0/apache-ratis-2.3.0-bin.tar.gz.asc">signature</a>)
-         </td>
-         <td>
-           <a href="post/2.3.0.html">Announcement</a>
-         </td>
-     </tr>
-    
-    
   </table>
 </p>
 
@@ -269,7 +252,7 @@ archive</a> site.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/getting_started.html
+++ b/getting_started.html
@@ -143,7 +143,7 @@
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/index.html
+++ b/index.html
@@ -153,6 +153,7 @@
               </p>
           </div>
 
+
           <div class="col-md-6 col-sm-6 feature-item">
               <span class="glyphicon glyphicon-dashboard" aria-hidden="true"></span>
               <h4>Pluggable metrics</h4>
@@ -182,7 +183,7 @@
             <h2>Latest news</h2>
             
             <div class="panel-heading clearfix"><a class="pull-left" href="/post.html">Posts</a>
-                <small class="pull-right">2023 Nov 21 </small>
+                <small class="pull-right">2024 Jan 9 </small>
             </div>
             
         </div>
@@ -342,7 +343,7 @@ Only the source code from the released artifacts are checked by the Project Mana
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/index.xml
+++ b/index.xml
@@ -6,19 +6,32 @@
     <description>Recent content on Apache Ratis</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Tue, 21 Nov 2023 00:00:00 +0000</lastBuildDate><atom:link href="https://ratis.apache.org/index.xml" rel="self" type="application/rss+xml" />
-
-  <item>
+    <lastBuildDate>Tue, 09 Jan 2024 00:00:00 +0000</lastBuildDate><atom:link href="https://ratis.apache.org/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Release 3.0.1 is available</title>
+      <link>https://ratis.apache.org/post/3.0.1.html</link>
+      <pubDate>Tue, 09 Jan 2024 00:00:00 +0000</pubDate>
+      
+      <guid>https://ratis.apache.org/post/3.0.1.html</guid>
+      <description>Download
+This is a bugfix release. See the changes between 3.0.0 and 3.0.1 releases.
+It has been tested with Apache Ozone and Apache IoTDB, where Apache Ratis is used to replicate raw data and to provide high availability.</description>
+    </item>
+    
+    <item>
       <title>Release 3.0.0 is available</title>
       <link>https://ratis.apache.org/post/3.0.0.html</link>
-      <pubDate>Fri, 17 Nov 2023 00:00:00 +0000</pubDate>
-
+      <pubDate>Tue, 21 Nov 2023 00:00:00 +0000</pubDate>
+      
       <guid>https://ratis.apache.org/post/3.0.0.html</guid>
       <description>Download
-This is a major new version that contains 100 improvements and bug fixes. It introduces new features like pluggable metrics and lease read, etc.
-It has been tested with Apache Ozone, Apache IoTDB where Apache Ratis is used to replicate raw data and to provide high availability.</description>
+This is a major new version that contains 100 improvements and bug fixes. It introduces new features like pluggable metrics and lease read, etc. See the changes between 2.5.1 and 3.0.0 releases as below:
+Change list of ratis 3.0.0 In total, there are roughly 100 commits diffing from 2.5.1
+Incompatible Changes   RaftStorage Auto-Format
+  RATIS-1677. Do not auto format RaftStorage in RECOVER. (#718)
+  RATIS-1694. Fix the compatibility issue of RATIS-1677.</description>
     </item>
-
+    
     <item>
       <title>Release 2.5.1 is available</title>
       <link>https://ratis.apache.org/post/2.5.1.html</link>

--- a/logservice.html
+++ b/logservice.html
@@ -292,7 +292,7 @@ of this document.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/index.html
+++ b/logservice/index.html
@@ -121,7 +121,7 @@ daemons provided for the LogService, but these are solely to be used for testing
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/lifecycle.html
+++ b/logservice/lifecycle.html
@@ -172,7 +172,7 @@ an archival of a log is an export of the entire log to a specific location.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/security.html
+++ b/logservice/security.html
@@ -181,7 +181,7 @@ of this document.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/testing.html
+++ b/logservice/testing.html
@@ -184,7 +184,7 @@ scenarios. Please find more on each using the below references.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/testing/docker.html
+++ b/logservice/testing/docker.html
@@ -138,7 +138,7 @@ described above, use <code>docker exec -it &lt;name&gt; /bin/sh</code> to attach
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/testing/index.html
+++ b/logservice/testing/index.html
@@ -118,7 +118,7 @@ scenarios. Please find more on each using the below references.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/testing/vagrant.html
+++ b/logservice/testing/vagrant.html
@@ -116,7 +116,7 @@
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post.html
+++ b/post.html
@@ -104,16 +104,226 @@
   <div>
     <h1 id="title">Posts Archive</h1>
         <ul id="list">
-
-            <h1><a href="/post/3.0.0.html">Release 3.0.0 is available</a></h1>
-            <p><small>2023 Nov 17 </small></p>
+            
+            <h1><a href="/post/3.0.1.html">Release 3.0.1 is available</a></h1>
+            <p><small>2024 Jan 9 </small></p>
 
             <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
 <p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
-<p>This is a major new version that contains 100 improvements and bug fixes. It introduces new features like pluggable metrics and lease read, etc. See the <a href="/post/3.0.0.html">changes between 2.5.1 and 3.0.0</a> releases.</p>
-<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a>, <a href="https://iotdb.apache.org">Apache IoTDB</a>
+<p>This is a bugfix release.  See the <a href="https://github.com/apache/ratis/compare/ratis-3.0.0...ratis-3.0.1">changes between 3.0.0 and 3.0.1</a> releases.</p>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> and <a href="https://iotdb.apache.org">Apache IoTDB</a>,
 where Apache Ratis is used to replicate raw data and to provide high availability.</p>
+
+
+            
+            <h1><a href="/post/3.0.0.html">Release 3.0.0 is available</a></h1>
+            <p><small>2023 Nov 21 </small></p>
+
+            <!-- raw HTML omitted -->
+<!-- raw HTML omitted -->
+<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
+<p>This is a major new version that contains 100 improvements and bug fixes. It introduces new features like pluggable metrics and lease read, etc.
+See the changes between 2.5.1 and 3.0.0 releases as below:</p>
+<p>Change list of ratis 3.0.0
+In total, there are roughly 100 commits diffing from 2.5.1</p>
+<h1 id="incompatible-changes">Incompatible Changes</h1>
+<ul>
+<li>
+<p>RaftStorage Auto-Format</p>
+</li>
+<li>
+<p>RATIS-1677. Do not auto format RaftStorage in RECOVER. (#718)</p>
+</li>
+<li>
+<p>RATIS-1694. Fix the compatibility issue of RATIS-1677. (#731)</p>
+</li>
+<li>
+<p>RATIS-1871. Auto format RaftStorage when there is only one
+directory configured. (#903)</p>
+</li>
+<li>
+<p>Pluggable Ratis-Metrics (RATIS-1688)</p>
+</li>
+<li>
+<p>RATIS-1689. Remove the use of the thirdparty Gauge. (#728)</p>
+</li>
+<li>
+<p>RATIS-1692. Remove the use of the thirdparty Counter. (#732)</p>
+</li>
+<li>
+<p>RATIS-1693. Remove the use of the thirdparty Timer. (#734)</p>
+</li>
+<li>
+<p>RATIS-1703. Move MetricsReporting and JvmMetrics to impl. (#741)</p>
+</li>
+<li>
+<p>RATIS-1704. Fix SuppressWarnings(&ldquo;VisibilityModifier&rdquo;) in
+RatisMetrics. (#742)</p>
+</li>
+<li>
+<p>RATIS-1710. Refactor metrics api and implementation to separated
+modules. (#749)</p>
+</li>
+<li>
+<p>RATIS-1712. Add a dropwizard 3 implementation of ratis-metrics-api. (#751)</p>
+</li>
+<li>
+<p>RATIS-1391. Update library dropwizard.metrics version to 4.x (#632)</p>
+</li>
+<li>
+<p>RATIS-1601. Use the shaded dropwizard metrics and remove the
+dependency (#671)</p>
+</li>
+<li>
+<p>Streaming Protocol Change</p>
+</li>
+<li>
+<p>RATIS-1569. Move the asyncRpcApi.sendForward(..) call to the
+client side. (#635)</p>
+</li>
+</ul>
+<h1 id="new-features">New Features</h1>
+<ul>
+<li>Leader Lease (RATIS-1864)</li>
+<li>RATIS-1865. Add leader lease bound ratio configuration (#897)</li>
+<li>RATIS-1866. Maintain leader lease after AppendEntries (#898)</li>
+<li>RATIS-1894. Implement ReadOnly based on leader lease (#925)</li>
+<li>RATIS-1882. Support read-after-write consistency (#913)</li>
+<li>StateMachine API</li>
+<li>RATIS-1874. Add notifyLeaderReady function in IStateMachine (#906)</li>
+<li>RATIS-1897. Make TransactionContext available in DataApi.write(..). (#930)</li>
+<li>New Configuration Properties</li>
+<li>RATIS-1862. Add the parameter whether to take Snapshot when
+stopping to adapt to different services (#896)</li>
+<li>RATIS-1930. Add a conf for enable/disable majority-add. (#961)</li>
+<li>RATIS-1918. Introduces parameters that separately control the
+shutdown of RaftServerProxy by JVMPauseMonitor. (#950)</li>
+<li>RATIS-1636. Support re-config ratis properties (#800)</li>
+<li>RATIS-1860. Add ratis-shell cmd to generate a new raft-meta.conf. (#901)</li>
+</ul>
+<h1 id="improvements--bug-fixes">Improvements &amp; Bug Fixes</h1>
+<h2 id="streaming--netty">Streaming &amp; Netty</h2>
+<ul>
+<li>RATIS-1550. Rewrite stream client reply queue. (#740)</li>
+<li>RATIS-1847. Stream has memory leak. (#884)</li>
+<li>RATIS-1850. When the stream server side receives a disconnection,
+memory is cleared (#887)</li>
+<li>RATIS-1853. When the stream server channelInactive, all requests in
+the channel. (#889)</li>
+<li>RATIS-1880. Optimize Stream client&amp;server side channel pipeline Create (#910)</li>
+<li>RATIS-1898. Netty should use EpollEventLoopGroup by default (#931)</li>
+<li>RATIS-1899. Use EpollEventLoopGroup for Netty Proxies (#932)</li>
+<li>RATIS-1913. Assert that the primary peers in DataStreamClient and
+RoutingTable are equal (#945)</li>
+<li>RATIS-1921. Shared worker group in WorkerGroupGetter should be closed. (#955)</li>
+<li>RATIS-1923. Netty: atomic operations require side-effect-free
+functions. (#956)</li>
+</ul>
+<h2 id="read-index">Read Index</h2>
+<ul>
+<li>RATIS-1856. Notify apply index change of all RaftLog entries (#893)</li>
+<li>RATIS-1895. IllegalStateException: Failed to updateIncreasingly for
+nextIndex. (#926)</li>
+<li>RATIS-1861. NullPointerException in readAsync when Ratis leader is
+changing (#895)</li>
+<li>RATIS-1888. Handle exception of readIndexAsync in gRPC readIndex impl (#920)</li>
+<li>RATIS-1927. Use double check to eliminate data race in ReadRequests. (#958)</li>
+</ul>
+<h2 id="raftserver">RaftServer</h2>
+<ul>
+<li>RATIS-1924. Increase the default of raft.server.log.segment.size.max. (#957)</li>
+<li>RATIS-1892. Unify the lifetime of the RaftServerProxy thread pool (#923)</li>
+<li>RATIS-1889. NoSuchMethodError:
+RaftServerMetricsImpl.addNumPendingRequestsGauge #922 (#922)</li>
+<li>RATIS-761. Handle writeStateMachineData failure in leader. (#927)</li>
+<li>RATIS-1902. The snapshot index is set incorrectly in
+InstallSnapshotReplyProto. (#933)</li>
+<li>RATIS-1912. Fix infinity election when perform membership change. (#954)</li>
+<li>RATIS-1858. Follower keeps logging first election timeout. (#894)</li>
+</ul>
+<h2 id="appendentries--grpclogappender">AppendEntries &amp; GrpcLogAppender</h2>
+<ul>
+<li>RATIS-1804. Change the default number of outstanding append entries. (#838)</li>
+<li>RATIS-1883. Next Index should be always larger than Match Index in
+GrpcLogAppender (#914)</li>
+<li>RATIS-1886. AppendLog sleep fixed time cause significant drop in
+write throughput. (#929)</li>
+<li>RATIS-1909. Fix Decreasing Next Index When GrpcLogAppender Reset
+Client. (#939)</li>
+<li>RATIS-1920. NPE in AppendLogResponseHandler. (#952)</li>
+<li>RATIS-1928. Join the LogAppenders when closing the server. (#959)</li>
+<li>RATIS-1705. Fix metrics leak (#744)</li>
+</ul>
+<h2 id="raftlog--raftlog-cache">RaftLog &amp; RaftLog Cache</h2>
+<ul>
+<li>RATIS-1887. Gap between segement log (#919)</li>
+<li>RATIS-1890. SegmentedRaftLogCache#shouldEvict should only iterate
+over closed segments once (#921)</li>
+<li>RATIS-1893. In SegmentedRaftLogCache, start a daemon thread to
+checkAndEvictCache. (#924)</li>
+<li>RATIS-1884. Fix retry cache warning condition (#915)</li>
+<li>RATIS-872. Invalidate replied calls in retry cache. (#942)</li>
+<li>RATIS-1916. OrderAsync does not call handReply. (#948)</li>
+</ul>
+<h2 id="common-utilities">Common Utilities</h2>
+<ul>
+<li>RATIS-1932. Create zero-copy Marshaller. (#962)</li>
+<li>RATIS-1910. Deduplicate RaftGroupId and ClientId. (#940)</li>
+<li>RATIS-1867. To uniformly manage the timeout parameters for detecting
+gc. (#899)</li>
+</ul>
+<h1 id="code-cleanup--refactoring">Code Cleanup &amp; Refactoring</h1>
+<ul>
+<li>RATIS-1870. Refactor hasMajority code during configuration changes. (#902)</li>
+<li>RATIS-1848. Simplify PeerMap inheritance (#885)</li>
+<li>RATIS-1849. Remove unused getRaftClient (#886)</li>
+<li>RATIS-1854. Remove useless error logs when closing the ratisclient
+writing thread (#890)</li>
+<li>RATIS-1904. Refactor RaftServerImpl.submitClientRequestAsync(..). (#935)</li>
+</ul>
+<h1 id="code-improvement">Code Improvement</h1>
+<ul>
+<li>RATIS-1852. Fix trivial SonarLint complains (#888)</li>
+<li>RATIS-1855. Fix some sonar code smell and bugs in ratis-server (#892)</li>
+<li>RATIS-1903. Fix parameter number warning in RaftClientRequest. (#934)</li>
+<li>RATIS-1905. Fix some sonar lint complains (#936)</li>
+<li>RATIS-1915. Do not use FileInputStream/FileOutputStream in
+ratis-common. (#947)</li>
+<li>RATIS-1917. Print Epoll.unavailabilityCause() only once. (#949)</li>
+<li>RATIS-1919. Fix some sonar code smell and bugs in
+ratis-client/common/grpc (#951)</li>
+</ul>
+<h1 id="documentations--examples">Documentations &amp; Examples</h1>
+<ul>
+<li>RATIS-1842. Fix typo of &ldquo;configuraions.md&rdquo; name in ratis-docs project (#880)</li>
+<li>RATIS-1843. Add existing markdown documents to site.xml in the
+ratis-docs project (#881)</li>
+<li>RATIS-1901. Update Counter example to benchmark performance. (#953)</li>
+<li>RATIS-1908. Keep configurations doc updated (#938)</li>
+<li>RATIS-1911. Add MembershipManager example. (#941)</li>
+</ul>
+<h1 id="tests">Tests</h1>
+<ul>
+<li>RATIS-1828. Enable TestServerRestartWithNetty (#869)</li>
+<li>RATIS-1830. Intermittent failure in TestRetryPolicy (#871)</li>
+<li>RATIS-1832. Intermittent failure in TestStreamObserverWithTimeout (#873)</li>
+<li>RATIS-1833. Intermittent failure in
+TestRaftStateMachineExceptionWithSimulatedRpc (#874)</li>
+<li>RATIS-1599. Fix test failure from RATIS-1569. (#659)</li>
+</ul>
+<h1 id="build--maven">Build &amp; Maven</h1>
+<ul>
+<li>RATIS-1829. Support magic links to PR and JIRA in IDEA (#870)</li>
+<li>RATIS-1878. checkstyle fails with UnsupportedClassVersionError. (#909)</li>
+<li>RATIS-1906. Bump copyright year to 2023 (#937)</li>
+<li>RATIS-1914. Bouncy Castle For Java LDAP injection vulnerability. (#944)</li>
+<li>RATIS-1929. Bump ratis-thirdparty version to 1.0.5 (#960)</li>
+</ul>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a>, <a href="https://iotdb.apache.org">Apache IoTDB</a>, <a href="https://www.alluxio.io/">Alluxio</a>
+where Apache Ratis is used to replicate raw data and to provide high availability.</p>
+
+
             
             <h1><a href="/post/2.5.1.html">Release 2.5.1 is available</a></h1>
             <p><small>2023 May 5 </small></p>
@@ -212,30 +422,6 @@ See the <a href="https://github.com/apache/ratis/compare/ratis-1.0.0...ratis-2.0
 
 
             
-            <h1><a href="/post/1.0.0.html">GA Release 1.0.0 is available</a></h1>
-            <p><small>2020 Jul 20 </small></p>
-
-            <!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
-<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
-<p>It contains around 119 improvements and bug fixes based on various Apache Ozone use cases.
-See the <a href="https://github.com/apache/ratis/compare/ratis-0.5.0-rc0...ratis-1.0.0">changes between 0.5.0 and 1.0.0</a> releases.</p>
-<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data and to provide high availability.</p>
-
-
-            
-            <h1><a href="/post/0.5.0.html">Release 0.5.0 is available</a></h1>
-            <p><small>2020 Feb 4 </small></p>
-
-            <!-- raw HTML omitted -->
-<!-- raw HTML omitted -->
-<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
-<p>It contains more than 94 improvements and bug fixes based on various Apache Ozone use cases.
-See the <a href="https://github.com/apache/ratis/compare/0.4.0-rc4...ratis-0.5.0-rc0">changes between 0.4.0 and 0.5.0</a> releases.</p>
-<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data.</p>
-
-
-            
         </ul>
   </div>
 
@@ -266,7 +452,7 @@ See the <a href="https://github.com/apache/ratis/compare/0.4.0-rc4...ratis-0.5.0
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/0.1.0-alpha.html
+++ b/post/0.1.0-alpha.html
@@ -116,7 +116,7 @@
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/0.2.0.html
+++ b/post/0.2.0.html
@@ -113,7 +113,7 @@
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/0.3.0.html
+++ b/post/0.3.0.html
@@ -113,7 +113,7 @@ See the <a href="https://github.com/apache/ratis/compare/ratis-0.2.0...ratis-0.3
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/0.4.0.html
+++ b/post/0.4.0.html
@@ -113,7 +113,7 @@ See the <a href="https://github.com/apache/ratis/compare/ratis-0.3.0...0.4.0-rc4
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/0.5.0.html
+++ b/post/0.5.0.html
@@ -113,7 +113,7 @@ See the <a href="https://github.com/apache/ratis/compare/0.4.0-rc4...ratis-0.5.0
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/1.0.0.html
+++ b/post/1.0.0.html
@@ -113,7 +113,7 @@ See the <a href="https://github.com/apache/ratis/compare/ratis-0.5.0-rc0...ratis
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/2.0.0.html
+++ b/post/2.0.0.html
@@ -113,7 +113,7 @@ See the <a href="https://github.com/apache/ratis/compare/ratis-1.0.0...ratis-2.0
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/2.1.0.html
+++ b/post/2.1.0.html
@@ -113,7 +113,7 @@ See the <a href="https://github.com/apache/ratis/compare/ratis-2.0.0...ratis-2.1
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/2.3.0.html
+++ b/post/2.3.0.html
@@ -113,7 +113,7 @@ See the <a href="https://github.com/apache/ratis/compare/ratis-2.2.0...ratis-2.3
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/2.4.0.html
+++ b/post/2.4.0.html
@@ -113,7 +113,7 @@ See the <a href="https://github.com/apache/ratis/compare/ratis-2.3.0...ratis-2.4
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/2.4.1.html
+++ b/post/2.4.1.html
@@ -114,7 +114,7 @@ where Apache Ratis is used to replicate raw data and to provide high availabilit
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/2.5.0.html
+++ b/post/2.5.0.html
@@ -113,7 +113,7 @@ See the <a href="https://github.com/apache/ratis/compare/ratis-2.4.1...ratis-2.5
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/2.5.1.html
+++ b/post/2.5.1.html
@@ -113,7 +113,7 @@ where Apache Ratis is used to replicate raw data and to provide high availabilit
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/3.0.0.html
+++ b/post/3.0.0.html
@@ -103,92 +103,205 @@
 <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
 <p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
-<p>This is a major new version that contains 100 improvements and bug fixes. It introduces new features like pluggable metrics and lease read, etc., based on various Apache Ozone、Apache IoTDB and Alluxio use cases.
-<h1>Change list of ratis 3.0.0</h1>
-<p>In total, there are roughly 100 commits diffing from 2.5.1</p>
-
-<h2>Incompatible Changes</h2>
-
-<ul><li><p>RaftStorage Auto-Format</p><ul><li>RATIS-1677. Do not auto format RaftStorage in RECOVER. (#718)</li><li>RATIS-1694. Fix the compatibility issue of RATIS-1677. (#731)</li><li><p>RATIS-1871. Auto format RaftStorage when there is only one
-directory configured. (#903)</p></li></ul></li><li><p>Pluggable Ratis-Metrics (RATIS-1688)</p><ul><li>RATIS-1689. Remove the use of the thirdparty Gauge. (#728)</li><li>RATIS-1692. Remove the use of the thirdparty Counter. (#732)</li><li>RATIS-1693. Remove the use of the thirdparty Timer. (#734)</li><li>RATIS-1703. Move MetricsReporting and JvmMetrics to impl. (#741)</li><li>RATIS-1704. Fix SuppressWarnings(&quot;VisibilityModifier&quot;) in
-RatisMetrics. (#742)</li><li>RATIS-1710. Refactor metrics api and implementation to separated
-modules. (#749)</li><li>RATIS-1712. Add a dropwizard 3 implementation of ratis-metrics-api. (#751)</li><li>RATIS-1391. Update library dropwizard.metrics version to 4.x (#632)</li><li><p>RATIS-1601. Use the shaded dropwizard metrics and remove the
-dependency (#671)</p></li></ul></li><li><p>Streaming Protocol Change</p><ul><li>RATIS-1569. Move the asyncRpcApi.sendForward(..) call to the
-client side. (#635)</li></ul></li></ul>
-
-<h2>New Features</h2>
-
-<ul><li>Leader Lease (RATIS-1864)<ul><li>RATIS-1865. Add leader lease bound ratio configuration (#897)</li><li>RATIS-1866. Maintain leader lease after AppendEntries (#898)</li><li>RATIS-1894. Implement ReadOnly based on leader lease (#925)</li></ul></li><li>RATIS-1882. Support read-after-write consistency (#913)</li><li>StateMachine API<ul><li>RATIS-1874. Add notifyLeaderReady function in IStateMachine (#906)</li><li>RATIS-1897. Make TransactionContext available in DataApi.write(..). (#930)</li></ul></li><li>New Configuration Properties<ul><li>RATIS-1862. Add the parameter whether to take Snapshot when
-stopping to adapt to different services (#896)</li><li>RATIS-1930. Add a conf for enable/disable majority-add. (#961)</li><li>RATIS-1918. Introduces parameters that separately control the
-shutdown of RaftServerProxy by JVMPauseMonitor. (#950)</li></ul></li><li>RATIS-1636. Support re-config ratis properties (#800)</li><li>RATIS-1860. Add ratis-shell cmd to generate a new raft-meta.conf. (#901)</li></ul>
-
-<h2>Improvements &amp; Bug Fixes</h2>
-
-<h3>Streaming &amp; Netty</h3>
-
-<ul><li>RATIS-1550. Rewrite stream client reply queue. (#740)</li><li>RATIS-1847. Stream has memory leak. (#884)</li><li>RATIS-1850. When the stream server side receives a disconnection,
-memory is cleared (#887)</li><li>RATIS-1853. When the stream server channelInactive, all requests in
-the channel. (#889)</li><li>RATIS-1880. Optimize Stream client&amp;server side channel pipeline Create (#910)</li><li>RATIS-1898. Netty should use EpollEventLoopGroup by default (#931)</li><li>RATIS-1899. Use EpollEventLoopGroup for Netty Proxies (#932)</li><li>RATIS-1913. Assert that the primary peers in DataStreamClient and
-RoutingTable are equal (#945)</li><li>RATIS-1921. Shared worker group in WorkerGroupGetter should be closed. (#955)</li><li>RATIS-1923. Netty: atomic operations require side-effect-free
-functions. (#956)</li></ul>
-
-<h3>Read Index</h3>
-
-<ul><li>RATIS-1856. Notify apply index change of all RaftLog entries (#893)</li><li>RATIS-1895. IllegalStateException: Failed to updateIncreasingly for
-nextIndex. (#926)</li><li>RATIS-1861. NullPointerException in readAsync when Ratis leader is
-changing (#895)</li><li>RATIS-1888. Handle exception of readIndexAsync in gRPC readIndex impl (#920)</li><li>RATIS-1927. Use double check to eliminate data race in ReadRequests. (#958)</li></ul>
-
-<h3>RaftServer</h3>
-
-<ul><li>RATIS-1924. Increase the default of raft.server.log.segment.size.max. (#957)</li><li>RATIS-1892. Unify the lifetime of the RaftServerProxy thread pool (#923)</li><li>RATIS-1889. NoSuchMethodError:
-RaftServerMetricsImpl.addNumPendingRequestsGauge #922 (#922)</li><li>RATIS-761. Handle writeStateMachineData failure in leader. (#927)</li><li>RATIS-1902. The snapshot index is set incorrectly in
-InstallSnapshotReplyProto. (#933)</li><li>RATIS-1912. Fix infinity election when perform membership change. (#954)</li><li>RATIS-1858. Follower keeps logging first election timeout. (#894)</li></ul>
-
-<h3>AppendEntries &amp; GrpcLogAppender</h3>
-
-<ul><li>RATIS-1804. Change the default number of outstanding append entries. (#838)</li><li>RATIS-1883. Next Index should be always larger than Match Index in
-GrpcLogAppender (#914)</li><li>RATIS-1886. AppendLog sleep fixed time cause significant drop in
-write throughput. (#929)</li><li>RATIS-1909. Fix Decreasing Next Index When GrpcLogAppender Reset
-Client. (#939)</li><li>RATIS-1920. NPE in AppendLogResponseHandler. (#952)</li><li>RATIS-1928. Join the LogAppenders when closing the server. (#959)</li><li>RATIS-1705. Fix metrics leak (#744)</li></ul>
-
-<h3>RaftLog &amp; RaftLog Cache</h3>
-
-<ul><li>RATIS-1887. Gap between segement log (#919)</li><li>RATIS-1890. SegmentedRaftLogCache#shouldEvict should only iterate
-over closed segments once (#921)</li><li>RATIS-1893. In SegmentedRaftLogCache, start a daemon thread to
-checkAndEvictCache. (#924)</li><li>RATIS-1884. Fix retry cache warning condition (#915)</li><li>RATIS-872. Invalidate replied calls in retry cache. (#942)<ul><li>RATIS-1916. OrderAsync does not call handReply. (#948)</li></ul></li></ul>
-
-<h3>Common Utilities</h3>
-
-<ul><li>RATIS-1932. Create zero-copy Marshaller. (#962)</li><li>RATIS-1910. Deduplicate RaftGroupId and ClientId. (#940)</li><li>RATIS-1867. To uniformly manage the timeout parameters for detecting
-gc. (#899)</li></ul>
-
-<h2>Code Cleanup &amp; Refactoring</h2>
-
-<ul><li>RATIS-1870. Refactor hasMajority code during configuration changes. (#902)</li><li>RATIS-1848. Simplify PeerMap inheritance (#885)</li><li>RATIS-1849. Remove unused getRaftClient (#886)</li><li>RATIS-1854. Remove useless error logs when closing the ratis client
-writing thread (#890)</li><li>RATIS-1904. Refactor RaftServerImpl.submitClientRequestAsync(..). (#935)</li></ul>
-
-<h2>Code Improvement</h2>
-
-<ul><li>RATIS-1852. Fix trivial SonarLint complains (#888)</li><li>RATIS-1855. Fix some sonar code smell and bugs in ratis-server (#892)</li><li>RATIS-1903. Fix parameter number warning in RaftClientRequest. (#934)</li><li>RATIS-1905. Fix some sonar lint complains (#936)</li><li>RATIS-1915. Do not use FileInputStream/FileOutputStream in
-ratis-common. (#947)</li><li>RATIS-1917. Print Epoll.unavailabilityCause() only once. (#949)</li><li>RATIS-1919. Fix some sonar code smell and bugs in
-ratis-client/common/grpc (#951)</li></ul>
-
-<h2>Documentations &amp; Examples</h2>
-
-<ul><li>RATIS-1842. Fix typo of &quot;configuraions.md&quot; name in ratis-docs project (#880)</li><li>RATIS-1843. Add existing markdown documents to site.xml in the
-ratis-docs project (#881)</li><li>RATIS-1901. Update Counter example to benchmark performance. (#953)</li><li>RATIS-1908. Keep configurations doc updated (#938)</li><li>RATIS-1911. Add MembershipManager example. (#941)</li></ul>
-
-<h2>Tests</h2>
-
-<ul><li>RATIS-1828. Enable TestServerRestartWithNetty (#869)</li><li>RATIS-1830. Intermittent failure in TestRetryPolicy (#871)</li><li>RATIS-1832. Intermittent failure in TestStreamObserverWithTimeout (#873)</li><li>RATIS-1833. Intermittent failure in
-TestRaftStateMachineExceptionWithSimulatedRpc (#874)</li><li>RATIS-1599. Fix test failure from RATIS-1569. (#659)</li></ul>
-
-<h2>Build &amp; Maven</h2>
-
-<ul><li>RATIS-1829. Support magic links to PR and JIRA in IDEA (#870)</li><li>RATIS-1878. checkstyle fails with UnsupportedClassVersionError. (#909)</li><li>RATIS-1906. Bump copyright year to 2023 (#937)</li><li>RATIS-1914. Bouncy Castle For Java LDAP injection vulnerability. (#944)</li><li>RATIS-1929. Bump ratis-thirdparty version to 1.0.5 (#960)</li></ul>
-
-<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a>, <a href="https://iotdb.apache.org">Apache IoTDB</a> and <a href="https://github.com/Alluxio/alluxio">Alluxio</a>
-    where Apache Ratis is used to replicate raw data and to provide high availability.</p>
+<p>This is a major new version that contains 100 improvements and bug fixes. It introduces new features like pluggable metrics and lease read, etc.
+See the changes between 2.5.1 and 3.0.0 releases as below:</p>
+<p>Change list of ratis 3.0.0
+In total, there are roughly 100 commits diffing from 2.5.1</p>
+<h1 id="incompatible-changes">Incompatible Changes</h1>
+<ul>
+<li>
+<p>RaftStorage Auto-Format</p>
+</li>
+<li>
+<p>RATIS-1677. Do not auto format RaftStorage in RECOVER. (#718)</p>
+</li>
+<li>
+<p>RATIS-1694. Fix the compatibility issue of RATIS-1677. (#731)</p>
+</li>
+<li>
+<p>RATIS-1871. Auto format RaftStorage when there is only one
+directory configured. (#903)</p>
+</li>
+<li>
+<p>Pluggable Ratis-Metrics (RATIS-1688)</p>
+</li>
+<li>
+<p>RATIS-1689. Remove the use of the thirdparty Gauge. (#728)</p>
+</li>
+<li>
+<p>RATIS-1692. Remove the use of the thirdparty Counter. (#732)</p>
+</li>
+<li>
+<p>RATIS-1693. Remove the use of the thirdparty Timer. (#734)</p>
+</li>
+<li>
+<p>RATIS-1703. Move MetricsReporting and JvmMetrics to impl. (#741)</p>
+</li>
+<li>
+<p>RATIS-1704. Fix SuppressWarnings(&ldquo;VisibilityModifier&rdquo;) in
+RatisMetrics. (#742)</p>
+</li>
+<li>
+<p>RATIS-1710. Refactor metrics api and implementation to separated
+modules. (#749)</p>
+</li>
+<li>
+<p>RATIS-1712. Add a dropwizard 3 implementation of ratis-metrics-api. (#751)</p>
+</li>
+<li>
+<p>RATIS-1391. Update library dropwizard.metrics version to 4.x (#632)</p>
+</li>
+<li>
+<p>RATIS-1601. Use the shaded dropwizard metrics and remove the
+dependency (#671)</p>
+</li>
+<li>
+<p>Streaming Protocol Change</p>
+</li>
+<li>
+<p>RATIS-1569. Move the asyncRpcApi.sendForward(..) call to the
+client side. (#635)</p>
+</li>
+</ul>
+<h1 id="new-features">New Features</h1>
+<ul>
+<li>Leader Lease (RATIS-1864)</li>
+<li>RATIS-1865. Add leader lease bound ratio configuration (#897)</li>
+<li>RATIS-1866. Maintain leader lease after AppendEntries (#898)</li>
+<li>RATIS-1894. Implement ReadOnly based on leader lease (#925)</li>
+<li>RATIS-1882. Support read-after-write consistency (#913)</li>
+<li>StateMachine API</li>
+<li>RATIS-1874. Add notifyLeaderReady function in IStateMachine (#906)</li>
+<li>RATIS-1897. Make TransactionContext available in DataApi.write(..). (#930)</li>
+<li>New Configuration Properties</li>
+<li>RATIS-1862. Add the parameter whether to take Snapshot when
+stopping to adapt to different services (#896)</li>
+<li>RATIS-1930. Add a conf for enable/disable majority-add. (#961)</li>
+<li>RATIS-1918. Introduces parameters that separately control the
+shutdown of RaftServerProxy by JVMPauseMonitor. (#950)</li>
+<li>RATIS-1636. Support re-config ratis properties (#800)</li>
+<li>RATIS-1860. Add ratis-shell cmd to generate a new raft-meta.conf. (#901)</li>
+</ul>
+<h1 id="improvements--bug-fixes">Improvements &amp; Bug Fixes</h1>
+<h2 id="streaming--netty">Streaming &amp; Netty</h2>
+<ul>
+<li>RATIS-1550. Rewrite stream client reply queue. (#740)</li>
+<li>RATIS-1847. Stream has memory leak. (#884)</li>
+<li>RATIS-1850. When the stream server side receives a disconnection,
+memory is cleared (#887)</li>
+<li>RATIS-1853. When the stream server channelInactive, all requests in
+the channel. (#889)</li>
+<li>RATIS-1880. Optimize Stream client&amp;server side channel pipeline Create (#910)</li>
+<li>RATIS-1898. Netty should use EpollEventLoopGroup by default (#931)</li>
+<li>RATIS-1899. Use EpollEventLoopGroup for Netty Proxies (#932)</li>
+<li>RATIS-1913. Assert that the primary peers in DataStreamClient and
+RoutingTable are equal (#945)</li>
+<li>RATIS-1921. Shared worker group in WorkerGroupGetter should be closed. (#955)</li>
+<li>RATIS-1923. Netty: atomic operations require side-effect-free
+functions. (#956)</li>
+</ul>
+<h2 id="read-index">Read Index</h2>
+<ul>
+<li>RATIS-1856. Notify apply index change of all RaftLog entries (#893)</li>
+<li>RATIS-1895. IllegalStateException: Failed to updateIncreasingly for
+nextIndex. (#926)</li>
+<li>RATIS-1861. NullPointerException in readAsync when Ratis leader is
+changing (#895)</li>
+<li>RATIS-1888. Handle exception of readIndexAsync in gRPC readIndex impl (#920)</li>
+<li>RATIS-1927. Use double check to eliminate data race in ReadRequests. (#958)</li>
+</ul>
+<h2 id="raftserver">RaftServer</h2>
+<ul>
+<li>RATIS-1924. Increase the default of raft.server.log.segment.size.max. (#957)</li>
+<li>RATIS-1892. Unify the lifetime of the RaftServerProxy thread pool (#923)</li>
+<li>RATIS-1889. NoSuchMethodError:
+RaftServerMetricsImpl.addNumPendingRequestsGauge #922 (#922)</li>
+<li>RATIS-761. Handle writeStateMachineData failure in leader. (#927)</li>
+<li>RATIS-1902. The snapshot index is set incorrectly in
+InstallSnapshotReplyProto. (#933)</li>
+<li>RATIS-1912. Fix infinity election when perform membership change. (#954)</li>
+<li>RATIS-1858. Follower keeps logging first election timeout. (#894)</li>
+</ul>
+<h2 id="appendentries--grpclogappender">AppendEntries &amp; GrpcLogAppender</h2>
+<ul>
+<li>RATIS-1804. Change the default number of outstanding append entries. (#838)</li>
+<li>RATIS-1883. Next Index should be always larger than Match Index in
+GrpcLogAppender (#914)</li>
+<li>RATIS-1886. AppendLog sleep fixed time cause significant drop in
+write throughput. (#929)</li>
+<li>RATIS-1909. Fix Decreasing Next Index When GrpcLogAppender Reset
+Client. (#939)</li>
+<li>RATIS-1920. NPE in AppendLogResponseHandler. (#952)</li>
+<li>RATIS-1928. Join the LogAppenders when closing the server. (#959)</li>
+<li>RATIS-1705. Fix metrics leak (#744)</li>
+</ul>
+<h2 id="raftlog--raftlog-cache">RaftLog &amp; RaftLog Cache</h2>
+<ul>
+<li>RATIS-1887. Gap between segement log (#919)</li>
+<li>RATIS-1890. SegmentedRaftLogCache#shouldEvict should only iterate
+over closed segments once (#921)</li>
+<li>RATIS-1893. In SegmentedRaftLogCache, start a daemon thread to
+checkAndEvictCache. (#924)</li>
+<li>RATIS-1884. Fix retry cache warning condition (#915)</li>
+<li>RATIS-872. Invalidate replied calls in retry cache. (#942)</li>
+<li>RATIS-1916. OrderAsync does not call handReply. (#948)</li>
+</ul>
+<h2 id="common-utilities">Common Utilities</h2>
+<ul>
+<li>RATIS-1932. Create zero-copy Marshaller. (#962)</li>
+<li>RATIS-1910. Deduplicate RaftGroupId and ClientId. (#940)</li>
+<li>RATIS-1867. To uniformly manage the timeout parameters for detecting
+gc. (#899)</li>
+</ul>
+<h1 id="code-cleanup--refactoring">Code Cleanup &amp; Refactoring</h1>
+<ul>
+<li>RATIS-1870. Refactor hasMajority code during configuration changes. (#902)</li>
+<li>RATIS-1848. Simplify PeerMap inheritance (#885)</li>
+<li>RATIS-1849. Remove unused getRaftClient (#886)</li>
+<li>RATIS-1854. Remove useless error logs when closing the ratisclient
+writing thread (#890)</li>
+<li>RATIS-1904. Refactor RaftServerImpl.submitClientRequestAsync(..). (#935)</li>
+</ul>
+<h1 id="code-improvement">Code Improvement</h1>
+<ul>
+<li>RATIS-1852. Fix trivial SonarLint complains (#888)</li>
+<li>RATIS-1855. Fix some sonar code smell and bugs in ratis-server (#892)</li>
+<li>RATIS-1903. Fix parameter number warning in RaftClientRequest. (#934)</li>
+<li>RATIS-1905. Fix some sonar lint complains (#936)</li>
+<li>RATIS-1915. Do not use FileInputStream/FileOutputStream in
+ratis-common. (#947)</li>
+<li>RATIS-1917. Print Epoll.unavailabilityCause() only once. (#949)</li>
+<li>RATIS-1919. Fix some sonar code smell and bugs in
+ratis-client/common/grpc (#951)</li>
+</ul>
+<h1 id="documentations--examples">Documentations &amp; Examples</h1>
+<ul>
+<li>RATIS-1842. Fix typo of &ldquo;configuraions.md&rdquo; name in ratis-docs project (#880)</li>
+<li>RATIS-1843. Add existing markdown documents to site.xml in the
+ratis-docs project (#881)</li>
+<li>RATIS-1901. Update Counter example to benchmark performance. (#953)</li>
+<li>RATIS-1908. Keep configurations doc updated (#938)</li>
+<li>RATIS-1911. Add MembershipManager example. (#941)</li>
+</ul>
+<h1 id="tests">Tests</h1>
+<ul>
+<li>RATIS-1828. Enable TestServerRestartWithNetty (#869)</li>
+<li>RATIS-1830. Intermittent failure in TestRetryPolicy (#871)</li>
+<li>RATIS-1832. Intermittent failure in TestStreamObserverWithTimeout (#873)</li>
+<li>RATIS-1833. Intermittent failure in
+TestRaftStateMachineExceptionWithSimulatedRpc (#874)</li>
+<li>RATIS-1599. Fix test failure from RATIS-1569. (#659)</li>
+</ul>
+<h1 id="build--maven">Build &amp; Maven</h1>
+<ul>
+<li>RATIS-1829. Support magic links to PR and JIRA in IDEA (#870)</li>
+<li>RATIS-1878. checkstyle fails with UnsupportedClassVersionError. (#909)</li>
+<li>RATIS-1906. Bump copyright year to 2023 (#937)</li>
+<li>RATIS-1914. Bouncy Castle For Java LDAP injection vulnerability. (#944)</li>
+<li>RATIS-1929. Bump ratis-thirdparty version to 1.0.5 (#960)</li>
+</ul>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a>, <a href="https://iotdb.apache.org">Apache IoTDB</a>, <a href="https://www.alluxio.io/">Alluxio</a>
+where Apache Ratis is used to replicate raw data and to provide high availability.</p>
 
 </div>
 
@@ -196,7 +309,7 @@ TestRaftStateMachineExceptionWithSimulatedRpc (#874)</li><li>RATIS-1599. Fix tes
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/3.0.1.html
+++ b/post/3.0.1.html
@@ -99,13 +99,13 @@
 </div>
 
 <div class="container">
-<h1>Release 2.2.0 is available</h1>
+<h1>Release 3.0.1 is available</h1>
 <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
 <p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
-<p>It contains improvements and bug fixes based on various Apache Ozone use cases.
-See the <a href="https://github.com/apache/ratis/compare/ratis-2.1.0...ratis-2.2.0">changes between 2.1.0 and 2.2.0</a> releases.</p>
-<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data and to provide high availability.</p>
+<p>This is a bugfix release.  See the <a href="https://github.com/apache/ratis/compare/ratis-3.0.0...ratis-3.0.1">changes between 3.0.0 and 3.0.1</a> releases.</p>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> and <a href="https://iotdb.apache.org">Apache IoTDB</a>,
+where Apache Ratis is used to replicate raw data and to provide high availability.</p>
 
 </div>
 

--- a/post/index.xml
+++ b/post/index.xml
@@ -6,19 +6,33 @@
     <description>Recent content in Posts on Apache Ratis</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Tue, 21 Nov 2023 00:00:00 +0000</lastBuildDate><atom:link href="https://ratis.apache.org/post/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Tue, 09 Jan 2024 00:00:00 +0000</lastBuildDate><atom:link href="https://ratis.apache.org/post/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Release 3.0.1 is available</title>
+      <link>https://ratis.apache.org/post/3.0.1.html</link>
+      <pubDate>Tue, 09 Jan 2024 00:00:00 +0000</pubDate>
+      
+      <guid>https://ratis.apache.org/post/3.0.1.html</guid>
+      <description>Download
+This is a bugfix release. See the changes between 3.0.0 and 3.0.1 releases.
+It has been tested with Apache Ozone and Apache IoTDB, where Apache Ratis is used to replicate raw data and to provide high availability.</description>
+    </item>
+    
     <item>
       <title>Release 3.0.0 is available</title>
       <link>https://ratis.apache.org/post/3.0.0.html</link>
       <pubDate>Tue, 21 Nov 2023 00:00:00 +0000</pubDate>
-
+      
       <guid>https://ratis.apache.org/post/3.0.0.html</guid>
       <description>Download
-This is a major new version that contains 100 improvements and bug fixes. It introduces new features like pluggable metrics and lease read, etc.
-It has been tested with Apache Ozone, Apache IoTDB where Apache Ratis is used to replicate raw data and to provide high availability.</description>
+This is a major new version that contains 100 improvements and bug fixes. It introduces new features like pluggable metrics and lease read, etc. See the changes between 2.5.1 and 3.0.0 releases as below:
+Change list of ratis 3.0.0 In total, there are roughly 100 commits diffing from 2.5.1
+Incompatible Changes   RaftStorage Auto-Format
+  RATIS-1677. Do not auto format RaftStorage in RECOVER. (#718)
+  RATIS-1694. Fix the compatibility issue of RATIS-1677.</description>
     </item>
-
-      <item>
+    
+    <item>
       <title>Release 2.5.1 is available</title>
       <link>https://ratis.apache.org/post/2.5.1.html</link>
       <pubDate>Fri, 05 May 2023 00:00:00 +0000</pubDate>

--- a/post/page/2.html
+++ b/post/page/2.html
@@ -105,6 +105,30 @@
     <h1 id="title">Posts Archive</h1>
         <ul id="list">
             
+            <h1><a href="/post/1.0.0.html">GA Release 1.0.0 is available</a></h1>
+            <p><small>2020 Jul 20 </small></p>
+
+            <!-- raw HTML omitted -->
+<!-- raw HTML omitted -->
+<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
+<p>It contains around 119 improvements and bug fixes based on various Apache Ozone use cases.
+See the <a href="https://github.com/apache/ratis/compare/ratis-0.5.0-rc0...ratis-1.0.0">changes between 0.5.0 and 1.0.0</a> releases.</p>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data and to provide high availability.</p>
+
+
+            
+            <h1><a href="/post/0.5.0.html">Release 0.5.0 is available</a></h1>
+            <p><small>2020 Feb 4 </small></p>
+
+            <!-- raw HTML omitted -->
+<!-- raw HTML omitted -->
+<p><a href="https://ratis.apache.org/downloads.html">Download</a></p>
+<p>It contains more than 94 improvements and bug fixes based on various Apache Ozone use cases.
+See the <a href="https://github.com/apache/ratis/compare/0.4.0-rc4...ratis-0.5.0-rc0">changes between 0.4.0 and 0.5.0</a> releases.</p>
+<p>It has been tested with <a href="https://ozone.apache.org">Apache Ozone</a> where Apache Ratis is used to replicate raw data.</p>
+
+
+            
             <h1><a href="/post/0.4.0.html">Release 0.4.0 is available</a></h1>
             <p><small>2019 Sep 12 </small></p>
 
@@ -186,7 +210,7 @@ See the <a href="https://github.com/apache/ratis/compare/ratis-0.2.0...ratis-0.3
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,10 +3,13 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://ratis.apache.org/</loc>
-    <lastmod>2023-11-21T00:00:00+00:00</lastmod>
+    <lastmod>2024-01-09T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://ratis.apache.org/post.html</loc>
-    <lastmod>2023-11-21T00:00:00+00:00</lastmod>
+    <lastmod>2024-01-09T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://ratis.apache.org/post/3.0.1.html</loc>
+    <lastmod>2024-01-09T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://ratis.apache.org/post/3.0.0.html</loc>
     <lastmod>2023-11-21T00:00:00+00:00</lastmod>

--- a/source.html
+++ b/source.html
@@ -113,7 +113,7 @@ Only the source code from the released artifacts are checked by the Project Mana
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/tags.html
+++ b/tags.html
@@ -115,7 +115,7 @@
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2023 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2024 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, and the Apache Ratis logo are trademarks of The Apache Software Foundation.
             <p>
         </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Regenerate Ratis website from latest sources to publish the post about 3.0.1.

Please double-check `post/3.0.0.html`: its content is slightly different from the version currently published, due to how the source was updated in 36317bdb.  Is it OK, or should we first update the source to more closely match the current website?

https://issues.apache.org/jira/browse/RATIS-1992

## How was this patch tested?

```
open index.html
open downloads.html
open post/3.0.1.html
```