### PR TITLE
RATIS-1998. Add watch request metrics

### DIFF
--- a/ratis-docs/src/site/markdown/metrics.md
+++ b/ratis-docs/src/site/markdown/metrics.md
@@ -80,31 +80,34 @@
 
 ### Raft Server Metrics
 
-| Application | Component | Name                             | Type    | Description                                                         |
-|-------------|-----------|----------------------------------|---------|---------------------------------------------------------------------|
-| ratis       | server    | {peer}_lastHeartbeatElapsedTime  | Gauge   | Time elapsed since last heartbeat rpc response                      |
-| ratis       | server    | follower_append_entry_latency    | Timer   | Time taken for followers to append log entries                      |
-| ratis       | server    | {peer}_peerCommitIndex           | Gauge   | Commit index of peer                                                |
-| ratis       | server    | clientReadRequest                | Timer   | Time taken to process read requests from client                     |
-| ratis       | server    | clientStaleReadRequest           | Timer   | Time taken to process stale-read requests from client               |
-| ratis       | server    | clientWriteRequest               | Timer   | Time taken to process write requests from client                    |
-| ratis       | server    | clientWatch{level}Request        | Timer   | Time taken to process watch(replication_level) requests from client |
-| ratis       | server    | numRequestQueueLimitHits         | Counter | Number of (total client requests in queue) limit hits               |
-| ratis       | server    | numRequestsByteSizeLimitHits     | Counter | Number of (total size of client requests in queue) limit hits       |
-| ratis       | server    | numResourceLimitHits             | Counter | Sum of numRequestQueueLimitHits and numRequestsByteSizeLimitHits    |
-| ratis       | server    | numPendingRequestInQueue         | Gauge   | Number of pending client requests in queue                          |
-| ratis       | server    | numPendingRequestMegaByteSize    | Gauge   | Total size of pending client requests in queue                      |
-| ratis       | server    | retryCacheEntryCount             | Gauge   | Number of entries in retry cache                                    |
-| ratis       | server    | retryCacheHitCount               | Gauge   | Number of retry cache hits                                          |
-| ratis       | server    | retryCacheHitRate                | Gauge   | Retry cache hit rate                                                |
-| ratis       | server    | retryCacheMissCount              | Gauge   | Number of retry cache misses                                        |
-| ratis       | server    | retryCacheMissRate               | Gauge   | Retry cache miss rate                                               |
-| ratis       | server    | numFailedClientStaleReadOnServer | Counter | Number of failed stale-read requests                                |
-| ratis       | server    | numFailedClientReadOnServer      | Counter | Number of failed read requests                                      |
-| ratis       | server    | numFailedClientWriteOnServer     | Counter | Number of failed write requests                                     |
-| ratis       | server    | numFailedClientWatchOnServer     | Counter | Number of failed watch requests                                     |
-| ratis       | server    | numFailedClientStreamOnServer    | Counter | Number of failed stream requests                                    |
-| ratis       | server    | numInstallSnapshot               | Counter | Number of install-snapshot requests                                 |
+| Application | Component | Name                                 | Type    | Description                                                         |
+|-------------|-----------|--------------------------------------|---------|---------------------------------------------------------------------|
+| ratis       | server    | {peer}_lastHeartbeatElapsedTime      | Gauge   | Time elapsed since last heartbeat rpc response                      |
+| ratis       | server    | follower_append_entry_latency        | Timer   | Time taken for followers to append log entries                      |
+| ratis       | server    | {peer}_peerCommitIndex               | Gauge   | Commit index of peer                                                |
+| ratis       | server    | clientReadRequest                    | Timer   | Time taken to process read requests from client                     |
+| ratis       | server    | clientStaleReadRequest               | Timer   | Time taken to process stale-read requests from client               |
+| ratis       | server    | clientWriteRequest                   | Timer   | Time taken to process write requests from client                    |
+| ratis       | server    | clientWatch{level}Request            | Timer   | Time taken to process watch(replication_level) requests from client |
+| ratis       | server    | numRequestQueueLimitHits             | Counter | Number of (total client requests in queue) limit hits               |
+| ratis       | server    | numRequestsByteSizeLimitHits         | Counter | Number of (total size of client requests in queue) limit hits       |
+| ratis       | server    | numResourceLimitHits                 | Counter | Sum of numRequestQueueLimitHits and numRequestsByteSizeLimitHits    |
+| ratis       | server    | numPendingRequestInQueue             | Gauge   | Number of pending client requests in queue                          |
+| ratis       | server    | numPendingRequestMegaByteSize        | Gauge   | Total size of pending client requests in queue                      |
+| ratis       | server    | retryCacheEntryCount                 | Gauge   | Number of entries in retry cache                                    |
+| ratis       | server    | retryCacheHitCount                   | Gauge   | Number of retry cache hits                                          |
+| ratis       | server    | retryCacheHitRate                    | Gauge   | Retry cache hit rate                                                |
+| ratis       | server    | retryCacheMissCount                  | Gauge   | Number of retry cache misses                                        |
+| ratis       | server    | retryCacheMissRate                   | Gauge   | Retry cache miss rate                                               |
+| ratis       | server    | numFailedClientStaleReadOnServer     | Counter | Number of failed stale-read requests                                |
+| ratis       | server    | numFailedClientReadOnServer          | Counter | Number of failed read requests                                      |
+| ratis       | server    | numFailedClientWriteOnServer         | Counter | Number of failed write requests                                     |
+| ratis       | server    | numFailedClientWatchOnServer         | Counter | Number of failed watch requests                                     |
+| ratis       | server    | numFailedClientStreamOnServer        | Counter | Number of failed stream requests                                    |
+| ratis       | server    | numInstallSnapshot                   | Counter | Number of install-snapshot requests                                 |
+| ratis       | server    | numWatch{level}RequestTimeout        | Counter | Number of watch(replication_level) request timeout                  |
+| ratis       | server    | numWatch{level}RequestInQueue        | Gauge   | Number of watch(replication_level) requests in queue                |
+| ratis       | server    | numWatch{level}RequestQueueLimitHits | Counter | Number of (total watch request in queue) limit hits                 |
 
 
 ## Ratis Netty Metrics

--- a/ratis-metrics-api/src/main/java/org/apache/ratis/metrics/RatisMetrics.java
+++ b/ratis-metrics-api/src/main/java/org/apache/ratis/metrics/RatisMetrics.java
@@ -49,6 +49,13 @@ public class RatisMetrics {
     return Collections.unmodifiableMap(maps);
   }
 
+  protected static <T extends Enum<T>> Map<T, LongCounter> newCounterMap(
+      Class<T> clazz, Function<T, LongCounter> constructor) {
+    final EnumMap<T, LongCounter> map = new EnumMap<>(clazz);
+    Arrays.stream(clazz.getEnumConstants()).forEach(t -> map.put(t, constructor.apply(t)));
+    return Collections.unmodifiableMap(map);
+  }
+
   protected static <T extends Enum<T>> Map<T, Timekeeper> newTimerMap(
       Class<T> clazz, Function<T, Timekeeper> constructor) {
     final EnumMap<T, Timekeeper> map = new EnumMap<>(clazz);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -378,7 +378,7 @@ class LeaderStateImpl implements LeaderState {
     raftServerMetrics = server.getRaftServerMetrics();
     logAppenderMetrics = new LogAppenderMetrics(server.getMemberId());
     this.pendingRequests = new PendingRequests(server.getMemberId(), properties, raftServerMetrics);
-    this.watchRequests = new WatchRequests(server.getMemberId(), properties);
+    this.watchRequests = new WatchRequests(server.getMemberId(), properties, raftServerMetrics);
     this.messageStreamRequests = new MessageStreamRequests(server.getMemberId());
     this.pendingStepDown = new PendingStepDown(this);
     this.readIndexHeartbeats = new ReadIndexHeartbeats();
@@ -456,6 +456,7 @@ class LeaderStateImpl implements LeaderState {
     logAppenderMetrics.unregister();
     raftServerMetrics.unregister();
     pendingRequests.close();
+    watchRequests.close();
     return f;
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
@@ -31,8 +31,10 @@ import org.apache.ratis.retry.RetryPolicies;
 import org.apache.ratis.retry.RetryPolicy;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.server.RaftServerConfigKeys.Watch;
 import org.apache.ratis.server.impl.MiniRaftCluster;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
+import org.apache.ratis.server.metrics.RaftServerMetricsImpl;
 import org.apache.ratis.statemachine.impl.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.util.Slf4jUtils;
@@ -47,12 +49,14 @@ import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.fail;
@@ -465,6 +469,59 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
           Assert.assertEquals(TimeoutIOException.class,
               ex.getCause().getCause().getClass());
         }
+      }
+    }
+  }
+
+  @Test
+  public void testWatchMetrics() throws Exception {
+    final RaftProperties p = getProperties();
+    RaftServerConfigKeys.Watch.setElementLimit(p, 10);
+    RaftServerConfigKeys.Watch.setTimeout(p, TimeDuration.valueOf(2, TimeUnit.SECONDS));
+    try {
+      runWithNewCluster(NUM_SERVERS,
+          cluster -> runSingleTest(WatchRequestTests::runTestWatchMetrics, cluster, LOG));
+    } finally {
+      RaftServerConfigKeys.Watch.setElementLimit(p, Watch.ELEMENT_LIMIT_DEFAULT);
+      RaftServerConfigKeys.Watch.setTimeout(p, RaftServerConfigKeys.Watch.TIMEOUT_DEFAULT);
+    }
+  }
+
+  static RaftServerMetricsImpl getRaftServerMetrics(RaftServer.Division division) {
+    return (RaftServerMetricsImpl) division.getRaftServerMetrics();
+  }
+
+  static void runTestWatchMetrics(TestParameters p) throws Exception {
+    final MiniRaftCluster cluster = p.cluster;
+
+    List<RaftClient> clients = new ArrayList<>();
+
+    final ReplicationLevel replicationLevel = ReplicationLevel.MAJORITY;
+    try {
+      int uncommittedBaseIndex = 10000;
+      // Logs with indices 10001 - 10011 will never be committed, so it should fail with NotReplicatedException
+      for (int i = 1; i <= 11; i++) {
+        RaftClient client = cluster.createClient(cluster.getLeader().getId(), RetryPolicies.noRetry());
+        clients.add(client);
+        client.async().watch(uncommittedBaseIndex + i, replicationLevel);
+      }
+
+      long initialWatchRequestTimeoutCount = getRaftServerMetrics(cluster.getLeader())
+          .getNumWatchRequestsTimeout(replicationLevel).getCount();
+      long initialLimitHit = getRaftServerMetrics(cluster.getLeader())
+          .getNumWatchRequestQueueLimitHits(replicationLevel).getCount();
+
+      // All the watch timeout for each unique index should increment the metric
+      RaftTestUtil.waitFor(() -> getRaftServerMetrics(cluster.getLeader())
+              .getNumWatchRequestsTimeout(replicationLevel).getCount() == initialWatchRequestTimeoutCount + 10,
+          300, 5000);
+      // There are 11 pending watch request, but the pending watch request limit is 10
+      RaftTestUtil.waitFor(() -> getRaftServerMetrics(cluster.getLeader())
+          .getNumWatchRequestQueueLimitHits(replicationLevel).getCount() ==
+          initialLimitHit + 1, 300, 5000);
+    } finally {
+      for(RaftClient client : clients) {
+        client.close();
       }
     }
   }

--- a/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
@@ -498,6 +498,11 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
 
     final ReplicationLevel replicationLevel = ReplicationLevel.MAJORITY;
     try {
+      long initialWatchRequestTimeoutCount = getRaftServerMetrics(cluster.getLeader())
+          .getNumWatchRequestsTimeout(replicationLevel).getCount();
+      long initialLimitHit = getRaftServerMetrics(cluster.getLeader())
+          .getNumWatchRequestQueueLimitHits(replicationLevel).getCount();
+
       int uncommittedBaseIndex = 10000;
       // Logs with indices 10001 - 10011 will never be committed, so it should fail with NotReplicatedException
       for (int i = 1; i <= 11; i++) {
@@ -505,11 +510,6 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
         clients.add(client);
         client.async().watch(uncommittedBaseIndex + i, replicationLevel);
       }
-
-      long initialWatchRequestTimeoutCount = getRaftServerMetrics(cluster.getLeader())
-          .getNumWatchRequestsTimeout(replicationLevel).getCount();
-      long initialLimitHit = getRaftServerMetrics(cluster.getLeader())
-          .getNumWatchRequestQueueLimitHits(replicationLevel).getCount();
 
       // All the watch timeout for each unique index should increment the metric
       RaftTestUtil.waitFor(() -> getRaftServerMetrics(cluster.getLeader())


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add some watch request metrics for better visibility. 

The metrics are:

- number of watch request in queue
- number of watch request queue limit hit
- number of watch request timeout

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1998

## How was this patch tested?

UT.
