### PR TITLE
RATIS-1989. Intermittent timeout in TestStreamObserverWithTimeout

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -139,7 +139,7 @@ public class GrpcServerProtocolClient implements Closeable {
   StreamObserver<InstallSnapshotRequestProto> installSnapshot(
       String name, TimeDuration timeout, int limit, StreamObserver<InstallSnapshotReplyProto> responseHandler) {
     return StreamObserverWithTimeout.newInstance(name, ServerStringUtils::toInstallSnapshotRequestString,
-        timeout, limit, i -> asyncStub.withInterceptors(i).installSnapshot(responseHandler));
+        () -> timeout, limit, i -> asyncStub.withInterceptors(i).installSnapshot(responseHandler));
   }
 
   // short-circuit the backoff timer and make them reconnect immediately.

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/util/GrpcTestServer.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/util/GrpcTestServer.java
@@ -23,6 +23,8 @@ import org.apache.ratis.test.proto.HelloRequest;
 import org.apache.ratis.thirdparty.io.grpc.Server;
 import org.apache.ratis.thirdparty.io.grpc.ServerBuilder;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.apache.ratis.thirdparty.io.netty.util.concurrent.ThreadPerTaskExecutor;
+import org.apache.ratis.util.Daemon;
 import org.apache.ratis.util.IOUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
@@ -31,16 +33,22 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /** gRPC server for testing */
 class GrpcTestServer implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(GrpcTestServer.class);
+  private static final AtomicLong COUNTER = new AtomicLong();
 
   private final Server server;
 
-  GrpcTestServer(int port, int slow, TimeDuration timeout) {
+  GrpcTestServer(int port, int warmup, int slow, TimeDuration timeout) {
     this.server = ServerBuilder.forPort(port)
-        .addService(new GreeterImpl(slow, timeout))
+        .executor(new ThreadPerTaskExecutor(r -> Daemon.newBuilder()
+            .setName("test-server-" + COUNTER.getAndIncrement())
+            .setRunnable(r)
+            .build()))
+        .addService(new GreeterImpl(warmup, slow, timeout))
         .build();
   }
 
@@ -64,12 +72,14 @@ class GrpcTestServer implements Closeable {
       return ") Hello " + request;
     }
 
+    private final int warmup;
     private final int slow;
     private final TimeDuration shortSleepTime;
     private final TimeDuration longSleepTime;
     private int count = 0;
 
-    GreeterImpl(int slow, TimeDuration timeout) {
+    GreeterImpl(int warmup, int slow, TimeDuration timeout) {
+      this.warmup = warmup;
       this.slow = slow;
       this.shortSleepTime = timeout.multiply(0.25);
       this.longSleepTime = timeout.multiply(2);
@@ -81,7 +91,8 @@ class GrpcTestServer implements Closeable {
         @Override
         public void onNext(HelloRequest helloRequest) {
           final String reply = count + toReplySuffix(helloRequest.getName());
-          final TimeDuration sleepTime = count < slow ? shortSleepTime : longSleepTime;
+          final TimeDuration sleepTime = count < warmup ? TimeDuration.ZERO :
+              count < (warmup + slow) ? shortSleepTime : longSleepTime;
           LOG.info("count = {}, slow = {}, sleep {}", reply, slow, sleepTime);
           try {
             sleepTime.sleep();

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/util/GrpcTestServer.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/util/GrpcTestServer.java
@@ -71,7 +71,7 @@ class GrpcTestServer implements Closeable {
 
     GreeterImpl(int slow, TimeDuration timeout) {
       this.slow = slow;
-      this.shortSleepTime = timeout.multiply(0.1);
+      this.shortSleepTime = timeout.multiply(0.25);
       this.longSleepTime = timeout.multiply(2);
     }
 

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/util/TestStreamObserverWithTimeout.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/util/TestStreamObserverWithTimeout.java
@@ -57,14 +57,14 @@ public class TestStreamObserverWithTimeout extends BaseTest {
   @Test
   public void testWithDeadline() throws Exception {
     //the total sleep time is within the deadline
-    runTestTimeout(8, Type.WithDeadline);
+    runTestTimeout(2, Type.WithDeadline);
   }
 
   @Test
   public void testWithDeadlineFailure() {
     //Expected to have DEADLINE_EXCEEDED
     testFailureCase("total sleep time is longer than the deadline",
-        () -> runTestTimeout(12, Type.WithDeadline),
+        () -> runTestTimeout(5, Type.WithDeadline),
         ExecutionException.class, StatusRuntimeException.class);
   }
 
@@ -72,7 +72,7 @@ public class TestStreamObserverWithTimeout extends BaseTest {
   public void testWithTimeout() throws Exception {
     //Each sleep time is within the timeout,
     //Note that the total sleep time is longer than the timeout, but it does not matter.
-    runTestTimeout(12, Type.WithTimeout);
+    runTestTimeout(5, Type.WithTimeout);
   }
 
   void runTestTimeout(int slow, Type type) throws Exception {

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/util/TestStreamObserverWithTimeout.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/util/TestStreamObserverWithTimeout.java
@@ -24,6 +24,7 @@ import org.apache.ratis.util.NetUtils;
 import org.apache.ratis.util.Slf4jUtils;
 import org.apache.ratis.util.StringUtils;
 import org.apache.ratis.util.TimeDuration;
+import org.apache.ratis.util.TimeoutTimer;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.event.Level;
@@ -37,6 +38,8 @@ import java.util.function.Function;
 public class TestStreamObserverWithTimeout extends BaseTest {
   {
     Slf4jUtils.setLogLevel(ResponseNotifyClientInterceptor.LOG, Level.TRACE);
+    Slf4jUtils.setLogLevel(StreamObserverWithTimeout.LOG, Level.DEBUG);
+    Slf4jUtils.setLogLevel(TimeoutTimer.LOG, Level.DEBUG);
   }
 
   enum Type {
@@ -80,13 +83,19 @@ public class TestStreamObserverWithTimeout extends BaseTest {
     final TimeDuration timeout = ONE_SECOND.multiply(0.5);
     final StreamObserverFactory function = type.createFunction(timeout);
 
+    // first request may take longer due to initialization
+    final int warmup = type == Type.WithTimeout ? 1 : 0;
     final List<String> messages = new ArrayList<>();
     for (int i = 0; i < 2 * slow; i++) {
-      messages.add("m" + i);
+      messages.add("m" + (i + warmup));
     }
-    try (GrpcTestServer server = new GrpcTestServer(NetUtils.getFreePort(), slow, timeout)) {
+    try (GrpcTestServer server = new GrpcTestServer(NetUtils.getFreePort(), warmup, slow, timeout)) {
       final int port = server.start();
       try (GrpcTestClient client = new GrpcTestClient(NetUtils.LOCALHOST, port, function)) {
+
+        if (warmup == 1) {
+          client.send("warmup").join();
+        }
 
         final List<CompletableFuture<String>> futures = new ArrayList<>();
         for (String m : messages) {
@@ -95,20 +104,20 @@ public class TestStreamObserverWithTimeout extends BaseTest {
 
         int i = 0;
         for (; i < slow; i++) {
-          final String expected = i + GrpcTestServer.GreeterImpl.toReplySuffix(messages.get(i));
+          final String expected = (i + warmup) + GrpcTestServer.GreeterImpl.toReplySuffix(messages.get(i));
           final String reply = futures.get(i).get();
-          Assert.assertEquals("expected = " + expected + " != reply = " + reply, expected, reply);
-          LOG.info("{}) passed", i);
+          Assert.assertEquals(expected, reply);
+          LOG.info("{}) passed", (i + warmup));
         }
 
         for (; i < messages.size(); i++) {
           final CompletableFuture<String> f = futures.get(i);
           try {
             final String reply = f.get();
-            Assert.fail(i + ") reply = " + reply + ", "
+            Assert.fail((i + warmup) + ") reply = " + reply + ", "
                 + StringUtils.completableFuture2String(f, false));
           } catch (ExecutionException e) {
-             LOG.info("GOOD! {}) {}, {}", i, StringUtils.completableFuture2String(f, true), e);
+             LOG.info("GOOD! {}) {}, {}", (i + warmup), StringUtils.completableFuture2String(f, true), e);
           }
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent timeout in `TestStreamObserverWithTimeout#testWithTimeout`.

1. The first request may take long to reach the server, probably due to some initialization overhead.  The patch adds a "warmup" request, for which timeout is not applied.
2. Client and server seem to share `grpc-default-executor` thread pool.  This may result in delay at client due to server sleeping.  The patch uses a thread per request in `GrpcTestServer`.
3. With these, we can restore test settings prior to 29d032dde65cfb441e7c912b1621cfff6c266674.

https://issues.apache.org/jira/browse/RATIS-1989

## How was this patch tested?

Passed 500x in [repeated run](https://github.com/adoroszlai/ratis/actions/runs/7528357858) (although it [also passed](https://github.com/adoroszlai/ratis/actions/runs/7529250422) 500x on `master`).

Since it's passing more frequently in regular CI, repeated full `unit (grpc)` 10 times.  `TestStreamObserverWithTimeout` failed 4 times [on `master`](https://github.com/adoroszlai/ratis/actions/runs/7529643511), passed in all 10 runs [with the patch](https://github.com/adoroszlai/ratis/actions/runs/7529628120).

Also passed 500x locally.

Regular CI:
https://github.com/adoroszlai/ratis/actions/runs/7528350705