### PR TITLE
RATIS-2003. Fix IT_NO_SUCH_ELEMENT in InstallSnapshotRequests

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/InstallSnapshotRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/InstallSnapshotRequests.java
@@ -112,20 +112,11 @@ class InstallSnapshotRequests implements Iterable<InstallSnapshotRequestProto> {
 
     @Override
     public InstallSnapshotRequestProto next() {
-      checkCurrentIndex(fileIndex);
-      return nextInstallSnapshotRequestProto();
-    }
-
-    private int checkCurrentIndex(int currentIndex) {
-      if (currentIndex >= numFiles) {
-        throw new NoSuchElementException("fileIndex = " + currentIndex + " >= numFiles = " + numFiles);
+      if (!hasNext()) {
+        throw new NoSuchElementException("fileIndex = " + fileIndex + " >= numFiles = " + numFiles);
       }
-      return currentIndex;
-    }
 
-    private InstallSnapshotRequestProto nextInstallSnapshotRequestProto() {
-      final int currentIndex = checkCurrentIndex(fileIndex);
-      final FileInfo info = snapshot.getFiles().get(currentIndex);
+      final FileInfo info = snapshot.getFiles().get(fileIndex);
       try {
         if (current == null) {
           current = new FileChunkReader(info, getRelativePath.apply(info));
@@ -137,7 +128,7 @@ class InstallSnapshotRequests implements Iterable<InstallSnapshotRequestProto> {
           fileIndex++;
         }
 
-        final boolean done = currentIndex == numFiles - 1 && chunk.getDone();
+        final boolean done = fileIndex == numFiles && chunk.getDone();
         return newInstallSnapshotRequest(chunk, done);
       } catch (IOException e) {
         if (current != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove `@SuppressFBWarnings("IT_NO_SUCH_ELEMENT")` in `InstallSnapshotRequests`, and ensure spotbugs does not complain.

https://issues.apache.org/jira/browse/RATIS-2003

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis/actions/runs/7562098256