### PR TITLE
RATIS-2006. Fix DM_EXIT in filestore Client

### DIFF
--- a/ratis-examples/pom.xml
+++ b/ratis-examples/pom.xml
@@ -122,13 +122,6 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
@@ -18,7 +18,6 @@
 package org.apache.ratis.examples.filestore.cli;
 
 import com.beust.jcommander.Parameter;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.RaftConfigKeys;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.client.RaftClientConfigKeys;
@@ -143,12 +142,10 @@ public abstract class Client extends SubCommandBase {
   }
 
 
-  @SuppressFBWarnings("DM_EXIT")
-  protected void stop(List<FileStoreClient> clients) throws IOException {
+  protected void close(List<FileStoreClient> clients) throws IOException {
     for (FileStoreClient client : clients) {
       client.close();
     }
-    System.exit(0);
   }
 
   public String getPath(String fileName) {

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/DataStream.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/DataStream.java
@@ -116,7 +116,8 @@ public class DataStream extends Client {
   @Override
   protected void operation(List<FileStoreClient> clients) throws IOException, ExecutionException, InterruptedException {
     if (!checkParam()) {
-      stop(clients);
+      close(clients);
+      return;
     }
 
     final ExecutorService executor = Executors.newFixedThreadPool(getNumThread());
@@ -136,7 +137,7 @@ public class DataStream extends Client {
     System.out.println("Total data written: " + totalWrittenBytes + " bytes");
     System.out.println("Total time taken: " + (endTime - startTime) + " millis");
 
-    stop(clients);
+    close(clients);
   }
 
   private Map<String, CompletableFuture<List<CompletableFuture<DataStreamReply>>>> streamWrite(

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/LoadGen.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/LoadGen.java
@@ -64,7 +64,7 @@ public class LoadGen extends Client {
     System.out.println("Total data written: " + totalWrittenBytes + " bytes");
     System.out.println("Total time taken: " + (endTime - startTime) + " millis");
 
-    stop(clients);
+    close(clients);
   }
 
   long write(FileChannel in, long offset, FileStoreClient fileStoreClient, String path,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove `System.exit` and `@SuppressFBWarnings("DM_EXIT")`.

https://issues.apache.org/jira/browse/RATIS-2006

## How was this patch tested?

Verified that filestore client exits if the wrong params are provided:

```
$ cd ratis-assembly/target/apache-ratis-3.1.0-SNAPSHOT-bin/apache-ratis-3.1.0-SNAPSHOT-bin/examples
$ PEERS=n0:127.0.0.1:6000,n1:127.0.0.1:6001,n2:127.0.0.1:6002
$ bin/client.sh filestore datastream --type asdf --peers "${PEERS}" --numFiles 4 --numClients 2 -s /tmp/filestore --size 444 --bufferSize 123 --syncSize 555
Error: syncSize % bufferSize should be zero
```

CI:
https://github.com/adoroszlai/ratis/actions/runs/7563180996