### PR TITLE
RATIS-2004. Fix EQ_COMPARETO_USE_OBJECT_EQUALS in LogSegment

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -244,13 +244,13 @@ public class SegmentedRaftLogCache {
 
     int binarySearch(long index) {
       try(AutoCloseableLock readLock = readLock()) {
-        return Collections.binarySearch(segments, index);
+        return Collections.binarySearch(segments, index, LogSegment.SEGMENT_TO_INDEX_COMPARATOR);
       }
     }
 
     LogSegment search(long index) {
       try(AutoCloseableLock readLock = readLock()) {
-        final int i = Collections.binarySearch(segments, index);
+        final int i = Collections.binarySearch(segments, index, LogSegment.SEGMENT_TO_INDEX_COMPARATOR);
         return i < 0? null: segments.get(i);
       }
     }
@@ -261,7 +261,7 @@ public class SegmentedRaftLogCache {
       long index = startIndex;
 
       try(AutoCloseableLock readLock = readLock()) {
-        searchIndex = Collections.binarySearch(segments, startIndex);
+        searchIndex = Collections.binarySearch(segments, startIndex, LogSegment.SEGMENT_TO_INDEX_COMPARATOR);
         if (searchIndex >= 0) {
           for(int i = searchIndex; i < segments.size() && index < realEnd; i++) {
             final LogSegment s = segments.get(i);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace `compareTo` with `Comparator` in `LogSegment` to get rid of `EQ_COMPARETO_USE_OBJECT_EQUALS` warning (previously suppressed).

https://issues.apache.org/jira/browse/RATIS-2004

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis/actions/runs/7574274326