### PR TITLE
RATIS-2009. ReferenceCount should work for all LogEntry types.

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcClientProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcClientProtocolService.java
@@ -64,7 +64,11 @@ class GrpcClientProtocolService extends RaftClientProtocolServiceImplBase {
 
     PendingOrderedRequest(ReferenceCountedObject<RaftClientRequest> requestRef) {
       this.requestRef = requestRef;
-      this.request = requestRef != null ? requestRef.get() : null;
+      this.request = requestRef != null ? requestRef.retain() : null;
+    }
+
+    void release() {
+      requestRef.release();
     }
 
     @Override
@@ -363,6 +367,7 @@ class GrpcClientProtocolService extends RaftClientProtocolServiceImplBase {
       final long seq = pending.getSeqNum();
       processClientRequest(pending.getRequestRef(),
           reply -> slidingWindow.receiveReply(seq, reply, this::sendReply));
+      pending.release();
     }
 
     @Override

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcClientProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcClientProtocolService.java
@@ -67,10 +67,6 @@ class GrpcClientProtocolService extends RaftClientProtocolServiceImplBase {
       this.request = requestRef != null ? requestRef.retain() : null;
     }
 
-    void release() {
-      requestRef.release();
-    }
-
     @Override
     public void fail(Throwable t) {
       final RaftException e = Preconditions.assertInstanceOf(t, RaftException.class);
@@ -367,7 +363,7 @@ class GrpcClientProtocolService extends RaftClientProtocolServiceImplBase {
       final long seq = pending.getSeqNum();
       processClientRequest(pending.getRequestRef(),
           reply -> slidingWindow.receiveReply(seq, reply, this::sendReply));
-      pending.release();
+      pending.getRequestRef().release();
     }
 
     @Override

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/raftlog/RaftLogSequentialOps.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/raftlog/RaftLogSequentialOps.java
@@ -125,13 +125,22 @@ interface RaftLogSequentialOps {
 
   /**
    * Append asynchronously an entry.
-   * Used by the leader.
+   * Used by the leader for scenarios that there is no needs to clean up resources when the given entry is no
+   * longer used/referenced by this log.
    */
   default CompletableFuture<Long> appendEntry(LogEntryProto entry, TransactionContext context) {
     return appendEntry(ReferenceCountedObject.wrap(entry), context);
   }
 
-  CompletableFuture<Long> appendEntry(ReferenceCountedObject<LogEntryProto> entryRef, TransactionContext context);
+  /**
+   * Append asynchronously an entry.
+   * Used for scenarios that there is a ReferenceCountedObject context for resource cleanup when the given entry
+   * is no longer used/referenced by this log.
+   */
+  default CompletableFuture<Long> appendEntry(ReferenceCountedObject<LogEntryProto> entryRef,
+      TransactionContext context) {
+    return appendEntry(entryRef.get(), context);
+  }
 
   /**
    * The same as append(Arrays.asList(entries)).

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/raftlog/RaftLogSequentialOps.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/raftlog/RaftLogSequentialOps.java
@@ -128,8 +128,10 @@ interface RaftLogSequentialOps {
    * Used by the leader.
    */
   default CompletableFuture<Long> appendEntry(LogEntryProto entry, TransactionContext context) {
-    return appendEntry(entry);
+    return appendEntry(ReferenceCountedObject.wrap(entry), context);
   }
+
+  CompletableFuture<Long> appendEntry(ReferenceCountedObject<LogEntryProto> entryRef, TransactionContext context);
 
   /**
    * The same as append(Arrays.asList(entries)).

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/raftlog/RaftLogSequentialOps.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/raftlog/RaftLogSequentialOps.java
@@ -124,12 +124,11 @@ interface RaftLogSequentialOps {
   CompletableFuture<Long> appendEntry(LogEntryProto entry);
 
   /**
-   * Append asynchronously an entry.
-   * Used by the leader for scenarios that there is no needs to clean up resources when the given entry is no
-   * longer used/referenced by this log.
+   * @deprecated use {@link #appendEntry(ReferenceCountedObject, TransactionContext)}}.
    */
+  @Deprecated
   default CompletableFuture<Long> appendEntry(LogEntryProto entry, TransactionContext context) {
-    return appendEntry(ReferenceCountedObject.wrap(entry), context);
+    throw new UnsupportedOperationException();
   }
 
   /**

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -187,7 +187,8 @@ public abstract class RaftLogBase implements RaftLog {
         throw new StateMachineException(memberId, new RaftLogIOException(
             "Log entry size " + entrySize + " exceeds the max buffer limit of " + maxBufferSize));
       }
-      appendEntry(e, operation).whenComplete((returned, t) -> {
+
+      appendEntry(operation.wrap(e), operation).whenComplete((returned, t) -> {
         if (t != null) {
           LOG.error(name + ": Failed to write log entry " + LogProtoUtils.toLogEntryString(e), t);
         } else if (returned != nextIndex) {
@@ -349,11 +350,13 @@ public abstract class RaftLogBase implements RaftLog {
   }
 
   @Override
-  public final CompletableFuture<Long> appendEntry(LogEntryProto entry, TransactionContext context) {
+  public final CompletableFuture<Long> appendEntry(ReferenceCountedObject<LogEntryProto> entry,
+      TransactionContext context) {
     return runner.runSequentially(() -> appendEntryImpl(entry, context));
   }
 
-  protected abstract CompletableFuture<Long> appendEntryImpl(LogEntryProto entry, TransactionContext context);
+  protected abstract CompletableFuture<Long> appendEntryImpl(ReferenceCountedObject<LogEntryProto> entry,
+      TransactionContext context);
 
   @Override
   public final List<CompletableFuture<Long>> append(ReferenceCountedObject<List<LogEntryProto>> entries) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -346,7 +346,7 @@ public abstract class RaftLogBase implements RaftLog {
 
   @Override
   public final CompletableFuture<Long> appendEntry(LogEntryProto entry) {
-    return appendEntry(entry, null);
+    return appendEntry(ReferenceCountedObject.wrap(entry), null);
   }
 
   @Override

--- a/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
@@ -31,6 +31,7 @@ import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.impl.BlockRequestHandlingInjection;
 import org.apache.ratis.server.impl.DelayLocalExecutionInjection;
 import org.apache.ratis.server.impl.MiniRaftCluster;
+import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.LogEntryHeader;
 import org.apache.ratis.server.raftlog.LogProtoUtils;
 import org.apache.ratis.server.raftlog.RaftLog;
@@ -491,7 +492,7 @@ public interface RaftTestUtil {
     final long lastIndex = expected.getNextIndex() - 1;
     Assert.assertEquals(expected.getLastEntryTermIndex().getIndex(), lastIndex);
     for(long i = 0; i < lastIndex; i++) {
-      Assert.assertEquals(expected.get(i), computed.get(i));
+      Assert.assertEquals("Checking " + TermIndex.valueOf(expected.get(i)), expected.get(i), computed.get(i));
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

See [RATIS-2009](https://issues.apache.org/jira/browse/RATIS-2009)

Found this issue when running tests for #1014, TestServerRestartWithGrpc failed because RaftConfiguration entry zero-copy buffer are released too early (while the log entry are still in the EntryCache.)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2009


## How was this patch tested?

Existing tests.