### PR TITLE
RATIS-2010. Remove dependency on spotbugs-annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,14 +440,6 @@
         <version>6.0.53</version>
         <scope>provided</scope>
       </dependency>
-
-      <dependency>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-annotations</artifactId>
-        <version>${spotbugs.version}</version>
-        <scope>provided</scope>
-        <optional>true</optional>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/ratis-assembly/src/main/resources/NOTICE
+++ b/ratis-assembly/src/main/resources/NOTICE
@@ -292,27 +292,5 @@ networking library, which can be obtained at:
   * HOMEPAGE:
     * https://netty.io
   * LOCATION_IN_GRPC:
-* netty/third_party/netty
------------------------------------------------------------------------
-The JSR-305 reference implementation (jsr305.jar) is distributed under the terms of the New BSD:
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation and/or
-other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
-OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+    * netty/third_party/netty
 -----------------------------------------------------------------------

--- a/ratis-common/pom.xml
+++ b/ratis-common/pom.xml
@@ -69,12 +69,5 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 </project>

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftPeerId.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftPeerId.java
@@ -17,7 +17,6 @@
  */
 package org.apache.ratis.protocol;
 
-import javax.annotation.concurrent.Immutable;
 import org.apache.ratis.proto.RaftProtos.RaftPeerIdProto;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.JavaUtils;
@@ -34,7 +33,6 @@ import java.util.function.Supplier;
  * <p>
  * This is a value-based class.
  */
-@Immutable
 public final class RaftPeerId {
   private static final Map<ByteString, RaftPeerId> BYTE_STRING_MAP = new ConcurrentHashMap<>();
   private static final Map<String, RaftPeerId> STRING_MAP = new ConcurrentHashMap<>();

--- a/ratis-netty/pom.xml
+++ b/ratis-netty/pom.xml
@@ -73,11 +73,5 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 </project>

--- a/ratis-server-api/pom.xml
+++ b/ratis-server-api/pom.xml
@@ -47,12 +47,5 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 </project>

--- a/ratis-server/pom.xml
+++ b/ratis-server/pom.xml
@@ -84,13 +84,5 @@
       <artifactId>ratis-metrics-default</artifactId>
       <scope>test</scope>
     </dependency>
-
-
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 </project>

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
@@ -17,7 +17,6 @@
  */
 package org.apache.ratis.server.raftlog.segmented;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.function.CheckedBiFunction;
 import org.apache.ratis.util.function.CheckedConsumer;
@@ -177,7 +176,6 @@ class BufferedWriteChannel implements Closeable {
   }
 
   @Override
-  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void close() throws IOException {
     if (!isOpen()) {
       return;

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
@@ -18,7 +18,6 @@
 
 package org.apache.ratis.statemachine.impl;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
@@ -197,7 +196,6 @@ public class BaseStateMachine implements StateMachine, StateMachine.DataApi,
   }
 
   @Override
-  @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
   public CompletableFuture<Message> query(Message request) {
     return CompletableFuture.completedFuture(null);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Remove some unnecessary `@SuppressFBWarnings`
* Remove dependency on `spotbugs-annotations`
* Remove single usage of `javax.annotation` coming from `jsr305`, which is a transitive dependency via `spotbugs-annotations`

https://issues.apache.org/jira/browse/RATIS-2010

## How was this patch tested?

```
$ mvn -DskipTests clean package
$ ./dev-support/checks/findbugs.sh
```

CI:
https://github.com/adoroszlai/ratis/actions/runs/7575711637