### PR TITLE
RATIS-1978. Add tests assertions to verify all zero-copy messages are released properly

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/LeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/LeakDetector.java
@@ -114,7 +114,7 @@ public class LeakDetector {
     return "allLeaks.size = " + allLeaks.size();
   }
 
-  private final class LeakTracker extends WeakReference<Object> implements UncheckedAutoCloseable {
+  private final static class LeakTracker extends WeakReference<Object> implements UncheckedAutoCloseable {
     private final Set<LeakTracker> allLeaks;
     private final Runnable leakReporter;
     LeakTracker(Object referent, ReferenceQueue<Object> referenceQueue,

--- a/ratis-common/src/main/java/org/apache/ratis/util/LeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/LeakDetector.java
@@ -114,7 +114,7 @@ public class LeakDetector {
     return "allLeaks.size = " + allLeaks.size();
   }
 
-  private final static class LeakTracker extends WeakReference<Object> implements UncheckedAutoCloseable {
+  private static final class LeakTracker extends WeakReference<Object> implements UncheckedAutoCloseable {
     private final Set<LeakTracker> allLeaks;
     private final Runnable leakReporter;
     LeakTracker(Object referent, ReferenceQueue<Object> referenceQueue,

--- a/ratis-common/src/main/java/org/apache/ratis/util/LeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/LeakDetector.java
@@ -101,7 +101,7 @@ public class LeakDetector {
     return tracker;
   }
 
-  private final static class LeakTracker extends WeakReference<Object> implements UncheckedAutoCloseable {
+  private static final class LeakTracker extends WeakReference<Object> implements UncheckedAutoCloseable {
     private final Set<LeakTracker> allLeaks;
     private final Runnable leakReporter;
     LeakTracker(Object referent, ReferenceQueue<Object> referenceQueue,

--- a/ratis-common/src/main/java/org/apache/ratis/util/LeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/LeakDetector.java
@@ -62,15 +62,15 @@ public class LeakDetector {
 
   public LeakDetector(String name) {
     this.name = name + COUNTER.getAndIncrement();
-    start();
   }
 
-  private void start() {
+  LeakDetector start() {
     Thread t = new Thread(this::run);
     t.setName(LeakDetector.class.getSimpleName() + "-" + name);
     t.setDaemon(true);
     LOG.info("Starting leak detector thread {}.", name);
     t.start();
+    return this;
   }
 
   private void run() {

--- a/ratis-common/src/main/java/org/apache/ratis/util/LeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/LeakDetector.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Simple general resource leak detector using {@link ReferenceQueue} and {@link java.lang.ref.WeakReference} to
+ * observe resource object life-cycle and assert proper resource closure before they are GCed.
+ *
+ * <p>
+ * Example usage:
+ *
+ * <pre> {@code
+ * class MyResource implements AutoClosable {
+ *   static final LeakDetector LEAK_DETECTOR = new LeakDetector("MyResource");
+ *
+ *   private final UncheckedAutoCloseable leakTracker = LEAK_DETECTOR.track(this, () -> {
+ *      // report leaks, don't refer to the original object (MyResource) here.
+ *      System.out.println("MyResource is not closed before being discarded.");
+ *   });
+ *
+ *   @Override
+ *   public void close() {
+ *     // proper resources cleanup...
+ *     // inform tracker that this object is closed properly.
+ *     leakTracker.close();
+ *   }
+ * }
+ *
+ * }</pre>
+ */
+public class LeakDetector {
+  private static final Logger LOG = LoggerFactory.getLogger(LeakDetector.class);
+  private static final AtomicLong COUNTER = new AtomicLong();
+  private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+  private final Set<LeakTracker> allLeaks = Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private final String name;
+
+  public LeakDetector(String name) {
+    this.name = name + COUNTER.getAndIncrement();
+    start();
+  }
+
+  private void start() {
+    Thread t = new Thread(this::run);
+    t.setName(LeakDetector.class.getSimpleName() + "-" + name);
+    t.setDaemon(true);
+    LOG.info("Starting leak detector thread {}.", name);
+    t.start();
+  }
+
+  private void run() {
+    while (true) {
+      try {
+        LeakTracker tracker = (LeakTracker) queue.remove();
+        // Original resource already been GCed, if tracker is not closed yet,
+        // report a leak.
+        if (allLeaks.remove(tracker)) {
+          tracker.reportLeak();
+        }
+      } catch (InterruptedException e) {
+        LOG.warn("Thread interrupted, exiting.", e);
+        break;
+      }
+    }
+
+    LOG.warn("Exiting leak detector {}.", name);
+  }
+
+  public UncheckedAutoCloseable track(Object leakable, Runnable reportLeak) {
+    // A rate filter can be put here to only track a subset of all objects, e.g. 5%, 10%,
+    // if we have proofs that leak tracking impacts performance, or a single LeakDetector
+    // thread can't keep up with the pace of object allocation.
+    // For now, it looks effective enough and let keep it simple.
+    LeakTracker tracker = new LeakTracker(leakable, queue, allLeaks, reportLeak);
+    allLeaks.add(tracker);
+    return tracker;
+  }
+
+  private final static class LeakTracker extends WeakReference<Object> implements UncheckedAutoCloseable {
+    private final Set<LeakTracker> allLeaks;
+    private final Runnable leakReporter;
+    LeakTracker(Object referent, ReferenceQueue<Object> referenceQueue,
+        Set<LeakTracker> allLeaks, Runnable leakReporter) {
+      super(referent, referenceQueue);
+      this.allLeaks = allLeaks;
+      this.leakReporter = leakReporter;
+    }
+
+    /**
+     * Called by the tracked resource when closing.
+     */
+    @Override
+    public void close() {
+      allLeaks.remove(this);
+    }
+
+    void reportLeak() {
+      leakReporter.run();
+    }
+  }
+}

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
@@ -112,9 +112,11 @@ final class ReferenceCountedLeakDetector {
       final List<StackTraceElement[]> localReleaseTraces = new LinkedList<>();
 
       this.leakTracker = leakDetector.track(this, () -> {
-        LOG.warn("LEAK: A {} is not released properly.\nCreation trace\n{}\nRetain traces:\n{}\nRelease traces\n{}",
-            clazz.getName(), formatStackTrace(createStrace, 3), formatStackTraces(localRetainsTraces, 2),
-            formatStackTraces(localReleaseTraces, 2));
+        LOG.warn("LEAK: A {} is not released properly.\nCreation trace:\n{}\n" +
+                "Retain traces({}):\n{}\nRelease traces({}):\n{}",
+            clazz.getName(), formatStackTrace(createStrace, 3),
+            localRetainsTraces.size(), formatStackTraces(localRetainsTraces, 2),
+            localReleaseTraces.size(), formatStackTraces(localReleaseTraces, 2));
       });
 
       this.retainsTraces = localRetainsTraces;

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
@@ -18,6 +18,8 @@
 package org.apache.ratis.util;
 
 import org.apache.ratis.util.ReferenceCountedObject.ReferenceCountedObjectImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -28,12 +30,14 @@ import java.util.function.Consumer;
  * A utility to detect leaks from @{@link ReferenceCountedObject}.
  */
 final class ReferenceCountedLeakDetector {
-  private ReferenceCountedLeakDetector() {
-  }
-
+  private static final Logger LOG = LoggerFactory.getLogger(ReferenceCountedLeakDetector.class);
   // Leak detection is turned off by default.
+
   private static LeakDetectionMode leakDetectionFactory = LeakDetectionMode.NONE;
   private static LeakDetector leakDetector = null;
+
+  private ReferenceCountedLeakDetector() {
+  }
 
   static synchronized void enableLeakDetector(boolean advanced) {
     leakDetector = new LeakDetector("ReferenceCountedObject");

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
 /**
  * A utility to detect leaks from @{@link ReferenceCountedObject}.
  */
-final class ReferenceCountedLeakDetector {
+public final class ReferenceCountedLeakDetector {
   private static final Logger LOG = LoggerFactory.getLogger(ReferenceCountedLeakDetector.class);
   // Leak detection is turned off by default.
 
@@ -42,7 +42,7 @@ final class ReferenceCountedLeakDetector {
     return FACTORY.get();
   }
 
-  static LeakDetector getLeakDetector() {
+  public static LeakDetector getLeakDetector() {
     return SUPPLIER.get();
   }
 
@@ -60,12 +60,14 @@ final class ReferenceCountedLeakDetector {
   private enum Mode implements Factory {
     /** Leak detector is not enable in production to avoid performance impacts. */
     NONE {
+      @Override
       public <V> ReferenceCountedObject<V> create(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod) {
         return new Impl<>(value, retainMethod, releaseMethod);
       }
     },
     /** Leak detector is enabled to detect leaks. This is intended to use in every tests. */
     SIMPLE {
+      @Override
       public <V> ReferenceCountedObject<V> create(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod) {
         return new SimpleTracing<>(value, retainMethod, releaseMethod, getLeakDetector());
       }
@@ -75,6 +77,7 @@ final class ReferenceCountedLeakDetector {
      * release stacktraces. This has severe impact in performance and only used to debug specific test cases.
      */
     ADVANCED {
+      @Override
       public <V> ReferenceCountedObject<V> create(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod) {
         return new AdvancedTracing<>(value, retainMethod, releaseMethod, getLeakDetector());
       }

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
@@ -21,7 +21,6 @@ import org.apache.ratis.util.ReferenceCountedObject.ReferenceCountedObjectImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
@@ -17,13 +17,15 @@
  */
 package org.apache.ratis.util;
 
-import org.apache.ratis.util.ReferenceCountedObject.ReferenceCountedObjectImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * A utility to detect leaks from @{@link ReferenceCountedObject}.
@@ -32,59 +34,114 @@ final class ReferenceCountedLeakDetector {
   private static final Logger LOG = LoggerFactory.getLogger(ReferenceCountedLeakDetector.class);
   // Leak detection is turned off by default.
 
-  private static LeakDetectionMode leakDetectionFactory = LeakDetectionMode.NONE;
-  private static LeakDetector leakDetector = null;
+  private static final AtomicReference<Mode> FACTORY = new AtomicReference<>(Mode.NONE);
+  private static final Supplier<LeakDetector> SUPPLIER
+      = MemoizedSupplier.valueOf(() -> new LeakDetector(FACTORY.get().name()).start());
+
+  static Factory getFactory() {
+    return FACTORY.get();
+  }
+
+  static LeakDetector getLeakDetector() {
+    return SUPPLIER.get();
+  }
 
   private ReferenceCountedLeakDetector() {
   }
 
-  static synchronized void enableLeakDetector(boolean advanced) {
-    leakDetector = new LeakDetector("ReferenceCountedObject");
-    leakDetectionFactory = advanced ? LeakDetectionMode.ADVANCED : LeakDetectionMode.SIMPLE;
+  static synchronized void enable(boolean advanced) {
+    FACTORY.set(advanced ? Mode.ADVANCED : Mode.SIMPLE);
   }
 
-  static LeakDetectionFactory getLeakDetectionFactory() {
-    return leakDetectionFactory;
-  }
-
-  interface LeakDetectionFactory {
+  interface Factory {
     <V> ReferenceCountedObject<V> create(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod);
   }
 
-  private enum LeakDetectionMode implements LeakDetectionFactory {
+  private enum Mode implements Factory {
     /** Leak detector is not enable in production to avoid performance impacts. */
     NONE {
       public <V> ReferenceCountedObject<V> create(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod) {
-        return new ReferenceCountedObjectImpl<>(value, retainMethod, releaseMethod);
+        return new Impl<>(value, retainMethod, releaseMethod);
       }
     },
-    /** Leak detector is enabled to detect leaks. This is intended to use in every tests.
-     */
+    /** Leak detector is enabled to detect leaks. This is intended to use in every tests. */
     SIMPLE {
       public <V> ReferenceCountedObject<V> create(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod) {
-        return new SimpleTracingReferenceCountedObject<>(value, retainMethod, releaseMethod, leakDetector);
+        return new SimpleTracing<>(value, retainMethod, releaseMethod, getLeakDetector());
       }
     },
-    /** Leak detector is enabled to detect leaks and report object creation stacktrace as well as every retain and
+    /**
+     * Leak detector is enabled to detect leaks and report object creation stacktrace as well as every retain and
      * release stacktraces. This has severe impact in performance and only used to debug specific test cases.
      */
     ADVANCED {
       public <V> ReferenceCountedObject<V> create(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod) {
-        return new AdvancedTracingReferenceCountedObject<>(value, retainMethod, releaseMethod, leakDetector);
+        return new AdvancedTracing<>(value, retainMethod, releaseMethod, getLeakDetector());
       }
-    };
+    }
   }
 
-  private static class SimpleTracingReferenceCountedObject<T> extends ReferenceCountedObjectImpl<T> {
-    private UncheckedAutoCloseable leakTracker;
+  private static class Impl<V> implements ReferenceCountedObject<V> {
+    private final AtomicInteger count;
+    private final V value;
+    private final Runnable retainMethod;
+    private final Consumer<Boolean> releaseMethod;
 
-    public SimpleTracingReferenceCountedObject(T value, Runnable retainMethod, Consumer<Boolean> releaseMethod,
-        LeakDetector leakDetector) {
+    Impl(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod) {
+      this.value = value;
+      this.retainMethod = retainMethod;
+      this.releaseMethod = releaseMethod;
+      count = new AtomicInteger();
+    }
+
+    @Override
+    public V get() {
+      final int previous = count.get();
+      if (previous < 0) {
+        throw new IllegalStateException("Failed to get: object has already been completely released.");
+      } else if (previous == 0) {
+        throw new IllegalStateException("Failed to get: object has not yet been retained.");
+      }
+      return value;
+    }
+
+    @Override
+    public V retain() {
+      // n <  0: exception
+      // n >= 0: n++
+      if (count.getAndUpdate(n -> n < 0? n : n + 1) < 0) {
+        throw new IllegalStateException("Failed to retain: object has already been completely released.");
+      }
+
+      retainMethod.run();
+      return value;
+    }
+
+    @Override
+    public boolean release() {
+      // n <= 0: exception
+      // n >  1: n--
+      // n == 1: n = -1
+      final int previous = count.getAndUpdate(n -> n <= 1? -1: n - 1);
+      if (previous < 0) {
+        throw new IllegalStateException("Failed to release: object has already been completely released.");
+      } else if (previous == 0) {
+        throw new IllegalStateException("Failed to release: object has not yet been retained.");
+      }
+      final boolean completedReleased = previous == 1;
+      releaseMethod.accept(completedReleased);
+      return completedReleased;
+    }
+  }
+
+  private static class SimpleTracing<T> extends Impl<T> {
+    private final UncheckedAutoCloseable leakTracker;
+
+    SimpleTracing(T value, Runnable retainMethod, Consumer<Boolean> releaseMethod, LeakDetector leakDetector) {
       super(value, retainMethod, releaseMethod);
       final Class<?> clazz = value.getClass();
-      this.leakTracker = leakDetector.track(this, () -> {
-        LOG.warn("LEAK: A {} is not released properly", clazz.getName());
-      });
+      this.leakTracker = leakDetector.track(this,
+          () -> LOG.warn("LEAK: A {} is not released properly", clazz.getName()));
     }
 
     @Override
@@ -97,13 +154,12 @@ final class ReferenceCountedLeakDetector {
     }
   }
 
-  private static class AdvancedTracingReferenceCountedObject<T> extends ReferenceCountedObjectImpl<T> {
-    private UncheckedAutoCloseable leakTracker;
+  private static class AdvancedTracing<T> extends Impl<T> {
+    private final UncheckedAutoCloseable leakTracker;
     private final List<StackTraceElement[]> retainsTraces;
     private final List<StackTraceElement[]> releaseTraces;
 
-    public AdvancedTracingReferenceCountedObject(T value, Runnable retainMethod, Consumer<Boolean> releaseMethod,
-        LeakDetector leakDetector) {
+    AdvancedTracing(T value, Runnable retainMethod, Consumer<Boolean> releaseMethod, LeakDetector leakDetector) {
       super(value, retainMethod, releaseMethod);
 
       StackTraceElement[] createStrace = Thread.currentThread().getStackTrace();
@@ -111,13 +167,12 @@ final class ReferenceCountedLeakDetector {
       final List<StackTraceElement[]> localRetainsTraces = new LinkedList<>();
       final List<StackTraceElement[]> localReleaseTraces = new LinkedList<>();
 
-      this.leakTracker = leakDetector.track(this, () -> {
-        LOG.warn("LEAK: A {} is not released properly.\nCreation trace:\n{}\n" +
-                "Retain traces({}):\n{}\nRelease traces({}):\n{}",
-            clazz.getName(), formatStackTrace(createStrace, 3),
-            localRetainsTraces.size(), formatStackTraces(localRetainsTraces, 2),
-            localReleaseTraces.size(), formatStackTraces(localReleaseTraces, 2));
-      });
+      this.leakTracker = leakDetector.track(this, () ->
+          LOG.warn("LEAK: A {} is not released properly.\nCreation trace:\n{}\n" +
+              "Retain traces({}):\n{}\nRelease traces({}):\n{}",
+              clazz.getName(), formatStackTrace(createStrace, 3),
+              localRetainsTraces.size(), formatStackTraces(localRetainsTraces, 2),
+              localReleaseTraces.size(), formatStackTraces(localReleaseTraces, 2)));
 
       this.retainsTraces = localRetainsTraces;
       this.releaseTraces = localReleaseTraces;

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.util;
+
+import org.apache.ratis.util.ReferenceCountedObject.ReferenceCountedObjectImpl;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * A utility to detect leaks from @{@link ReferenceCountedObject}.
+ */
+final class ReferenceCountedLeakDetector {
+  private ReferenceCountedLeakDetector() {
+  }
+
+  // Leak detection is turned off by default.
+  private static LeakDetectionMode leakDetectionFactory = LeakDetectionMode.NONE;
+  private static LeakDetector leakDetector = null;
+
+  static synchronized void enableLeakDetector(boolean advanced) {
+    leakDetector = new LeakDetector("ReferenceCountedObject");
+    leakDetectionFactory = advanced ? LeakDetectionMode.ADVANCED : LeakDetectionMode.SIMPLE;
+  }
+
+  static LeakDetectionFactory getLeakDetectionFactory() {
+    return leakDetectionFactory;
+  }
+
+  interface LeakDetectionFactory {
+    <V> ReferenceCountedObject<V> create(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod);
+  }
+
+  private enum LeakDetectionMode implements LeakDetectionFactory {
+    /** Leak detector is not enable in production to avoid performance impacts. */
+    NONE {
+      public <V> ReferenceCountedObject<V> create(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod) {
+        return new ReferenceCountedObjectImpl<>(value, retainMethod, releaseMethod);
+      }
+    },
+    /** Leak detector is enabled to detect leaks. This is intended to use in every tests.
+     */
+    SIMPLE {
+      public <V> ReferenceCountedObject<V> create(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod) {
+        return new SimpleTracingReferenceCountedObject<>(value, retainMethod, releaseMethod, leakDetector);
+      }
+    },
+    /** Leak detector is enabled to detect leaks and report object creation stacktrace as well as every retain and
+     * release stacktraces. This has severe impact in performance and only used to debug specific test cases.
+     */
+    ADVANCED {
+      public <V> ReferenceCountedObject<V> create(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod) {
+        return new AdvancedTracingReferenceCountedObject<>(value, retainMethod, releaseMethod, leakDetector);
+      }
+    };
+  }
+
+  private static class SimpleTracingReferenceCountedObject<T> extends ReferenceCountedObjectImpl<T> {
+    private UncheckedAutoCloseable leakTracker;
+
+    public SimpleTracingReferenceCountedObject(T value, Runnable retainMethod, Consumer<Boolean> releaseMethod,
+        LeakDetector leakDetector) {
+      super(value, retainMethod, releaseMethod);
+      final Class<?> clazz = value.getClass();
+      this.leakTracker = leakDetector.track(this, () -> {
+        LOG.warn("LEAK: A {} is not released properly", clazz.getName());
+      });
+    }
+
+    @Override
+    public boolean release() {
+      boolean released = super.release();
+      if (released) {
+        leakTracker.close();
+      }
+      return released;
+    }
+  }
+
+  private static class AdvancedTracingReferenceCountedObject<T> extends ReferenceCountedObjectImpl<T> {
+    private UncheckedAutoCloseable leakTracker;
+    private final List<StackTraceElement[]> retainsTraces = new LinkedList<>();
+    private final List<StackTraceElement[]> releaseTraces = new LinkedList<>();
+
+    public AdvancedTracingReferenceCountedObject(T value, Runnable retainMethod, Consumer<Boolean> releaseMethod,
+        LeakDetector leakDetector) {
+      super(value, retainMethod, releaseMethod);
+      StackTraceElement[] createStrace = Thread.currentThread().getStackTrace();
+      final Class<?> clazz = value.getClass();
+      this.leakTracker = leakDetector.track(this, () -> {
+        LOG.warn("LEAK: A {} is not released properly.\nCreation trace{}\nRetain traces:{}\nRelease traces\n{}",
+            clazz.getName(), formatStackTrace(createStrace), formatStackTraces(retainsTraces),
+            formatStackTraces(releaseTraces));
+      });
+    }
+
+    @Override
+    public T retain() {
+      T retain = super.retain();
+      retainsTraces.add(Thread.currentThread().getStackTrace());
+      return retain;
+    }
+
+    @Override
+    public boolean release() {
+      boolean released = super.release();
+      if (released) {
+        leakTracker.close();
+      }
+      releaseTraces.add(Thread.currentThread().getStackTrace());
+      return released;
+    }
+  }
+
+  private static String formatStackTrace(StackTraceElement[] stackTrace) {
+    final StringBuilder sb = new StringBuilder();
+    Arrays.stream(stackTrace).forEach(line -> sb.append(line).append("\n"));
+    return sb.toString();
+  }
+
+  private static String formatStackTraces(List<StackTraceElement[]> stackTraces) {
+    final StringBuilder sb = new StringBuilder();
+    stackTraces.forEach(stackTrace -> {
+      if (sb.length() > 0) {
+        sb.append("\n");
+      }
+      Arrays.stream(stackTrace).forEach(line -> sb.append(line).append("\n"));
+    });
+    return sb.toString();
+  }
+}

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
@@ -22,7 +22,6 @@ import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 /**
@@ -168,7 +167,7 @@ public interface ReferenceCountedObject<T> {
     Objects.requireNonNull(retainMethod, "retainMethod == null");
     Objects.requireNonNull(releaseMethod, "releaseMethod == null");
 
-    return ReferenceCountedLeakDetector.getLeakDetectionFactory().create(value, retainMethod, releaseMethod);
+    return ReferenceCountedLeakDetector.getFactory().create(value, retainMethod, releaseMethod);
   }
 
   /** The same as wrap(value, retainMethod, ignored -> releaseMethod.run()). */
@@ -177,63 +176,11 @@ public interface ReferenceCountedObject<T> {
   }
 
   static void enableLeakDetection() {
-    ReferenceCountedLeakDetector.enableLeakDetector(false);
+    ReferenceCountedLeakDetector.enable(false);
   }
 
   static void enableAdvancedLeakDetection() {
-    ReferenceCountedLeakDetector.enableLeakDetector(true);
+    ReferenceCountedLeakDetector.enable(true);
   }
 
-  class ReferenceCountedObjectImpl<V> implements ReferenceCountedObject<V> {
-    private final AtomicInteger count;
-    private final V value;
-    private final Runnable retainMethod;
-    private final Consumer<Boolean> releaseMethod;
-
-    public ReferenceCountedObjectImpl(V value, Runnable retainMethod, Consumer<Boolean> releaseMethod) {
-      this.value = value;
-      this.retainMethod = retainMethod;
-      this.releaseMethod = releaseMethod;
-      count = new AtomicInteger();
-    }
-
-    @Override
-    public V get() {
-      final int previous = count.get();
-      if (previous < 0) {
-        throw new IllegalStateException("Failed to get: object has already been completely released.");
-      } else if (previous == 0) {
-        throw new IllegalStateException("Failed to get: object has not yet been retained.");
-      }
-      return value;
-    }
-
-    @Override
-    public V retain() {
-      // n <  0: exception
-      // n >= 0: n++
-      if (count.getAndUpdate(n -> n < 0? n : n + 1) < 0) {
-        throw new IllegalStateException("Failed to retain: object has already been completely released.");
-      }
-
-      retainMethod.run();
-      return value;
-    }
-
-    @Override
-    public boolean release() {
-      // n <= 0: exception
-      // n >  1: n--
-      // n == 1: n = -1
-      final int previous = count.getAndUpdate(n -> n <= 1? -1: n - 1);
-      if (previous < 0) {
-        throw new IllegalStateException("Failed to release: object has already been completely released.");
-      } else if (previous == 0) {
-        throw new IllegalStateException("Failed to release: object has not yet been retained.");
-      }
-      final boolean completedReleased = previous == 1;
-      releaseMethod.accept(completedReleased);
-      return completedReleased;
-    }
-  }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
@@ -47,7 +47,6 @@ import java.util.function.Consumer;
  * @param <T> The object type.
  */
 public interface ReferenceCountedObject<T> {
-  Logger LOG = LoggerFactory.getLogger(ReferenceCountedObject.class);
 
   /** @return the object. */
   T get();
@@ -188,7 +187,7 @@ public interface ReferenceCountedObject<T> {
   }
 
   class ReferenceCountedObjectImpl<V> implements ReferenceCountedObject<V> {
-    protected final AtomicInteger count;
+    private final AtomicInteger count;
     private final V value;
     private final Runnable retainMethod;
     private final Consumer<Boolean> releaseMethod;

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
@@ -18,8 +18,6 @@
 package org.apache.ratis.util;
 
 import org.apache.ratis.util.function.UncheckedAutoCloseableSupplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Objects;

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/ZeroCopyMetrics.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/ZeroCopyMetrics.java
@@ -21,6 +21,7 @@ import org.apache.ratis.metrics.LongCounter;
 import org.apache.ratis.metrics.MetricRegistryInfo;
 import org.apache.ratis.metrics.RatisMetricRegistry;
 import org.apache.ratis.metrics.RatisMetrics;
+import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.thirdparty.com.google.protobuf.AbstractMessage;
 
 public class ZeroCopyMetrics extends RatisMetrics {
@@ -55,4 +56,21 @@ public class ZeroCopyMetrics extends RatisMetrics {
     releasedMessages.inc();
   }
 
+  @VisibleForTesting
+  public long zeroCopyMessages() {
+    return zeroCopyMessages.getCount();
+  }
+
+  @VisibleForTesting
+  public long nonZeroCopyMessages() {
+    return nonZeroCopyMessages.getCount();
+  }
+
+  @VisibleForTesting
+  public long releasedMessages() {
+    return releasedMessages.getCount();
+  }
+
+  public void reset() {
+  }
 }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/ZeroCopyMetrics.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/ZeroCopyMetrics.java
@@ -70,7 +70,4 @@ public class ZeroCopyMetrics extends RatisMetrics {
   public long releasedMessages() {
     return releasedMessages.getCount();
   }
-
-  public void reset() {
-  }
 }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
@@ -30,6 +30,7 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.RaftServerRpcWithProxy;
 import org.apache.ratis.server.protocol.RaftServerAsynchronousProtocol;
+import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.thirdparty.io.grpc.ServerInterceptors;
 import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;
 import org.apache.ratis.thirdparty.io.grpc.netty.NettyServerBuilder;
@@ -328,6 +329,7 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
 
     serverInterceptor.close();
     ConcurrentUtils.shutdownAndWait(executor);
+    zeroCopyMetrics.unregister();
   }
 
   @Override
@@ -385,4 +387,8 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
     return getProxies().getProxy(target).startLeaderElection(request);
   }
 
+  @VisibleForTesting
+  public ZeroCopyMetrics getZeroCopyMetrics() {
+    return zeroCopyMetrics;
+  }
 }

--- a/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
+++ b/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
@@ -94,13 +94,15 @@ public class MiniRaftClusterWithGrpc extends MiniRaftCluster.RpcBase {
   }
 
   public void assertZeroCopyMetrics() {
-    getPeers().forEach(peer -> {
-      RaftServer.Division server = getDivision(peer.getId());
-      GrpcService service = (GrpcService) RaftServerTestUtil.getServerRpc(server);
+    getServers().forEach(server -> server.getGroupIds().forEach(id -> {
+      LOG.info("Checking {}-{}", server.getId(), id);
+      RaftServer.Division division = RaftServerTestUtil.getDivision(server, id);
+      GrpcService service = (GrpcService) RaftServerTestUtil.getServerRpc(division);
       ZeroCopyMetrics zeroCopyMetrics = service.getZeroCopyMetrics();
       Assert.assertEquals(0, zeroCopyMetrics.nonZeroCopyMessages());
-      Assert.assertEquals(zeroCopyMetrics.zeroCopyMessages(), zeroCopyMetrics.releasedMessages());
-    });
+      Assert.assertEquals("", zeroCopyMetrics.zeroCopyMessages(), zeroCopyMetrics.releasedMessages());
+    }
+  ));
   }
 
 }

--- a/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
+++ b/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
@@ -89,8 +89,6 @@ public class MiniRaftClusterWithGrpc extends MiniRaftCluster.RpcBase {
   @Override
   public void shutdown() {
     super.shutdown();
-    // GC to ensure leak detection work.
-    System.gc();
     assertZeroCopyMetrics();
   }
 
@@ -103,8 +101,6 @@ public class MiniRaftClusterWithGrpc extends MiniRaftCluster.RpcBase {
       Assert.assertEquals(0, zeroCopyMetrics.nonZeroCopyMessages());
       Assert.assertEquals("Zero copy messages are not released, please check logs to find leaks. ",
           zeroCopyMetrics.zeroCopyMessages(), zeroCopyMetrics.releasedMessages());
-    }
-  ));
+    }));
   }
-
 }

--- a/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
+++ b/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
@@ -89,6 +89,7 @@ public class MiniRaftClusterWithGrpc extends MiniRaftCluster.RpcBase {
   @Override
   public void shutdown() {
     super.shutdown();
+    // GC to ensure leak detection work.
     System.gc();
     assertZeroCopyMetrics();
   }
@@ -100,7 +101,8 @@ public class MiniRaftClusterWithGrpc extends MiniRaftCluster.RpcBase {
       GrpcService service = (GrpcService) RaftServerTestUtil.getServerRpc(division);
       ZeroCopyMetrics zeroCopyMetrics = service.getZeroCopyMetrics();
       Assert.assertEquals(0, zeroCopyMetrics.nonZeroCopyMessages());
-      Assert.assertEquals("", zeroCopyMetrics.zeroCopyMessages(), zeroCopyMetrics.releasedMessages());
+      Assert.assertEquals("Zero copy messages are not released, please check logs to find leaks. ",
+          zeroCopyMetrics.zeroCopyMessages(), zeroCopyMetrics.releasedMessages());
     }
   ));
   }

--- a/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
+++ b/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
@@ -32,6 +32,7 @@ import org.apache.ratis.server.impl.DelayLocalExecutionInjection;
 import org.apache.ratis.server.impl.MiniRaftCluster;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.util.NetUtils;
+import org.apache.ratis.util.ReferenceCountedObject;
 import org.junit.Assert;
 
 import java.util.Optional;
@@ -48,6 +49,10 @@ public class MiniRaftClusterWithGrpc extends MiniRaftCluster.RpcBase {
       return new MiniRaftClusterWithGrpc(ids, listenerIds, prop, null);
     }
   };
+
+  static {
+    ReferenceCountedObject.enableLeakDetection();
+  }
 
   public interface FactoryGet extends Factory.Get<MiniRaftClusterWithGrpc> {
     @Override

--- a/ratis-server/src/test/java/org/apache/ratis/LogAppenderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/LogAppenderTests.java
@@ -168,6 +168,7 @@ public abstract class LogAppenderTests<CLUSTER extends MiniRaftCluster>
         assertTrue(t.getTimer().getMeanRate() > 0.0d);
         assertTrue(t.getTimer().getCount() > 0L);
       }
+      cluster.shutdown();
     }
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/RaftExceptionBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftExceptionBaseTest.java
@@ -138,7 +138,7 @@ public abstract class RaftExceptionBaseTest<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testGroupMismatchException() throws Exception {
-    runWithSameCluster(NUM_PEERS, this::runTestGroupMismatchException);
+    runWithNewCluster(NUM_PEERS, this::runTestGroupMismatchException);
   }
 
   void runTestGroupMismatchException(CLUSTER cluster) throws Exception {
@@ -171,7 +171,7 @@ public abstract class RaftExceptionBaseTest<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testStaleReadException() throws Exception {
-    runWithSameCluster(NUM_PEERS, this::runTestStaleReadException);
+    runWithNewCluster(NUM_PEERS, this::runTestStaleReadException);
   }
 
   void runTestStaleReadException(CLUSTER cluster) throws Exception {
@@ -186,7 +186,7 @@ public abstract class RaftExceptionBaseTest<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testLogAppenderBufferCapacity() throws Exception {
-    runWithSameCluster(NUM_PEERS, this::runTestLogAppenderBufferCapacity);
+    runWithNewCluster(NUM_PEERS, this::runTestLogAppenderBufferCapacity);
   }
 
   void runTestLogAppenderBufferCapacity(CLUSTER cluster) throws Exception {

--- a/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
@@ -50,6 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -564,5 +565,19 @@ public interface RaftTestUtil {
   static void assertSuccessReply(RaftClientReply reply) {
     Assert.assertNotNull("reply == null", reply);
     Assert.assertTrue("reply is not success: " + reply, reply.isSuccess());
+  }
+
+  static void gc() throws InterruptedException {
+    // use WeakReference to detect gc
+    Object obj = new Object();
+    final WeakReference<Object> weakRef = new WeakReference<>(obj);
+    obj = null;
+
+    // loop until gc has completed.
+    for (int i = 0; weakRef.get() != null; i++) {
+      LOG.info("gc {}", i);
+      System.gc();
+      Thread.sleep(100);
+    }
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -353,6 +353,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         10, ONE_SECOND, "getLeaderId", LOG);
     LOG.info(cluster.printServers());
     Assert.assertEquals(leader.getId(), lastServerLeaderId);
+    cluster.shutdown();
   }
 
   protected void testDisconnectLeader() throws Exception {
@@ -523,6 +524,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
     Long leaderElectionLatency = (Long) ratisMetricRegistry.getGauges((s, metric) ->
         s.contains(LAST_LEADER_ELECTION_ELAPSED_TIME)).values().iterator().next().getValue();
     assertTrue(leaderElectionLatency > 0L);
+    cluster.shutdown();
   }
 
   @Test

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -50,6 +50,7 @@ import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.NetUtils;
 import org.apache.ratis.util.Preconditions;
+import org.apache.ratis.util.ReferenceCountedLeakDetector;
 import org.apache.ratis.util.ReflectionUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.function.CheckedConsumer;
@@ -854,6 +855,14 @@ public abstract class MiniRaftCluster implements Closeable {
     Optional.ofNullable(timer.get()).ifPresent(Timer::cancel);
     ExitUtils.assertNotTerminated();
     LOG.info("{} shutdown completed", JavaUtils.getClassSimpleName(getClass()));
+
+    // GC to ensure leak detection work.
+    try {
+      RaftTestUtil.gc();
+    } catch (InterruptedException e) {
+      LOG.info("gc interrupted.");
+    }
+    ReferenceCountedLeakDetector.getLeakDetector().assertNoLeaks();
   }
 
   /**

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -842,7 +842,6 @@ public abstract class MiniRaftCluster implements Closeable {
     final ExecutorService executor = Executors.newFixedThreadPool(servers.size(), (t) ->
         Daemon.newBuilder().setName("MiniRaftCluster-" + THREAD_COUNT.incrementAndGet()).setRunnable(t).build());
     getServers().forEach(proxy -> executor.submit(() -> JavaUtils.runAsUnchecked(proxy::close)));
-
     try {
       executor.shutdown();
       // just wait for a few seconds

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -64,7 +64,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -72,7 +71,6 @@ import java.util.Timer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -843,9 +841,7 @@ public abstract class MiniRaftCluster implements Closeable {
 
     final ExecutorService executor = Executors.newFixedThreadPool(servers.size(), (t) ->
         Daemon.newBuilder().setName("MiniRaftCluster-" + THREAD_COUNT.incrementAndGet()).setRunnable(t).build());
-    List<Future<?>> closures = new LinkedList<>();
-    getServers().forEach(proxy -> closures.add(executor.submit(() -> JavaUtils.runAsUnchecked(proxy::close))));
-    closures.forEach(f -> JavaUtils.runAsUnchecked(f::get));
+    getServers().forEach(proxy -> executor.submit(() -> JavaUtils.runAsUnchecked(proxy::close)));
 
     try {
       executor.shutdown();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add metrics assertions to verify all zero-copy messages are released properly. 

This PR also introduces a simple leak-tracing mechanism to help debug the leaks' source. This leak detection is only enabled for tests. It has 2 modes:
- Simple: enabled by default for test. The leak report looks like below.
```
2024-01-22 12:55:50,391 [LeakDetector-ReferenceCountedObject0] WARN  util.ReferenceCountedLeakDetector (ReferenceCountedLeakDetector.java:lambda$new$0(87)) - LEAK: A org.apache.ratis.protocol.RaftClientRequest is not released properly
``` 

- Advanced: the leak report includes all the stacktraces for object creation, retains and releases. The capturing of stacktraces has a severe impact on performance and makes few tests timed out. So, this is only enabled manually to debug specific test cases.  Report looks like below, comparing release and retain traces will ping point the source of leaks. 
```
2024-01-22 15:24:51,033 [LeakDetector-ReferenceCountedObject0] WARN  util.ReferenceCountedLeakDetector (ReferenceCountedLeakDetector.java:lambda$new$0(116)) - LEAK: A org.apache.ratis.protocol.RaftClientRequest is not released properly.
Creation trace:
org.apache.ratis.util.ReferenceCountedObject.wrap(ReferenceCountedObject.java:165)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.onNext(GrpcClientProtocolService.java:266)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.onNext(GrpcClientProtocolService.java:191)
...

Retain traces:
org.apache.ratis.util.ReferenceCountedLeakDetector$AdvancedTracingReferenceCountedObject.retain(ReferenceCountedLeakDetector.java:128)
org.apache.ratis.grpc.server.GrpcClientProtocolService$OrderedRequestStreamObserver.processClientRequest(GrpcClientProtocolService.java:371)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.onNext(GrpcClientProtocolService.java:272)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.onNext(GrpcClientProtocolService.java:191)
org.apache.ratis.thirdparty.io.grpc.stub.ServerCalls$StreamingServerCallHandler$StreamingServerCallListener.onMessage(ServerCalls.java:262)
...

org.apache.ratis.util.ReferenceCountedLeakDetector$AdvancedTracingReferenceCountedObject.retain(ReferenceCountedLeakDetector.java:128)
org.apache.ratis.grpc.server.GrpcClientProtocolService$PendingOrderedRequest.<init>(GrpcClientProtocolService.java:67)
org.apache.ratis.grpc.server.GrpcClientProtocolService$OrderedRequestStreamObserver.processClientRequest(GrpcClientProtocolService.java:381)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.onNext(GrpcClientProtocolService.java:272)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.onNext(GrpcClientProtocolService.java:191)

org.apache.ratis.util.ReferenceCountedLeakDetector$AdvancedTracingReferenceCountedObject.retain(ReferenceCountedLeakDetector.java:128)
org.apache.ratis.server.impl.RaftServerProxy.submitClientRequestAsync(RaftServerProxy.java:450)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.processClientRequest(GrpcClientProtocolService.java:248)
org.apache.ratis.grpc.server.GrpcClientProtocolService$OrderedRequestStreamObserver.processClientRequest(GrpcClientProtocolService.java:364)
org.apache.ratis.util.SlidingWindow$Server.processRequestsFromHead(SlidingWindow.java:459)
org.apache.ratis.util.SlidingWindow$Server.receivedRequest(SlidingWindow.java:451)
org.apache.ratis.grpc.server.GrpcClientProtocolService$OrderedRequestStreamObserver.processClientRequest(GrpcClientProtocolService.java:390)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.onNext(GrpcClientProtocolService.java:272)

java.base/java.lang.Thread.getStackTrace(Thread.java:1602)
org.apache.ratis.util.ReferenceCountedLeakDetector$AdvancedTracingReferenceCountedObject.retain(ReferenceCountedLeakDetector.java:128)
org.apache.ratis.server.impl.RaftServerImpl.submitClientRequestAsync(RaftServerImpl.java:879)
org.apache.ratis.server.impl.RaftServerImpl.lambda$executeSubmitClientRequestAsync$14(RaftServerImpl.java:873)
java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1771)

Release traces
org.apache.ratis.util.ReferenceCountedLeakDetector$AdvancedTracingReferenceCountedObject.release(ReferenceCountedLeakDetector.java:138)
org.apache.ratis.server.impl.RaftServerProxy.submitClientRequestAsync(RaftServerProxy.java:455)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.processClientRequest(GrpcClientProtocolService.java:248)
org.apache.ratis.grpc.server.GrpcClientProtocolService$OrderedRequestStreamObserver.processClientRequest(GrpcClientProtocolService.java:364)
org.apache.ratis.util.SlidingWindow$Server.processRequestsFromHead(SlidingWindow.java:459)
org.apache.ratis.util.SlidingWindow$Server.receivedRequest(SlidingWindow.java:451)
org.apache.ratis.grpc.server.GrpcClientProtocolService$OrderedRequestStreamObserver.processClientRequest(GrpcClientProtocolService.java:390)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.onNext(GrpcClientProtocolService.java:272)

java.base/java.lang.Thread.getStackTrace(Thread.java:1602)
org.apache.ratis.util.ReferenceCountedLeakDetector$AdvancedTracingReferenceCountedObject.release(ReferenceCountedLeakDetector.java:138)
org.apache.ratis.grpc.server.GrpcClientProtocolService$OrderedRequestStreamObserver.processClientRequest(GrpcClientProtocolService.java:366)
org.apache.ratis.util.SlidingWindow$Server.processRequestsFromHead(SlidingWindow.java:459)
org.apache.ratis.util.SlidingWindow$Server.receivedRequest(SlidingWindow.java:451)
org.apache.ratis.grpc.server.GrpcClientProtocolService$OrderedRequestStreamObserver.processClientRequest(GrpcClientProtocolService.java:390)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.onNext(GrpcClientProtocolService.java:272)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.onNext(GrpcClientProtocolService.java:191)

java.base/java.lang.Thread.getStackTrace(Thread.java:1602)
org.apache.ratis.util.ReferenceCountedLeakDetector$AdvancedTracingReferenceCountedObject.release(ReferenceCountedLeakDetector.java:138)
org.apache.ratis.grpc.server.GrpcClientProtocolService$OrderedRequestStreamObserver.processClientRequest(GrpcClientProtocolService.java:392)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.onNext(GrpcClientProtocolService.java:272)
org.apache.ratis.grpc.server.GrpcClientProtocolService$RequestStreamObserver.onNext(GrpcClientProtocolService.java:191)
org.apache.ratis.thirdparty.io.grpc.stub.ServerCalls$StreamingServerCallHandler$StreamingServerCallListener.onMessage(ServerCalls.java:262)
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1978

## How was this patch tested?

Existing tests.