### PR TITLE
RATIS-2008. Follower should recognize candidate if the candidate is the same peer as the current valid leader

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/VoteContext.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/VoteContext.java
@@ -102,12 +102,10 @@ class VoteContext {
     if (info.isFollower()) {
       final RaftPeerId leader = impl.getState().getLeaderId();
       if (leader != null
+          && !leader.equals(candidateId)
           && impl.getRole().getFollowerState().map(FollowerState::isCurrentLeaderValid).orElse(false)) {
-        // if the candidate is the same peer as the current valid leader, we should allow
-        // the PreVote / RequestVote to proceed
-        if (!leader.equals(candidateId)) {
-          return reject("this server is a follower and still has a valid leader " + leader);
-        }
+        return reject("this server is a follower and still has a valid leader " + leader
+            + " different than the candidate " + candidateId);
       }
     }
     return true;

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/VoteContext.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/VoteContext.java
@@ -103,7 +103,11 @@ class VoteContext {
       final RaftPeerId leader = impl.getState().getLeaderId();
       if (leader != null
           && impl.getRole().getFollowerState().map(FollowerState::isCurrentLeaderValid).orElse(false)) {
-        return reject("this server is a follower and still has a valid leader " + leader);
+        // if the candidate is the same peer as the current valid leader, we should allow
+        // the PreVote / RequestVote to proceed
+        if (!leader.equals(candidateId)) {
+          return reject("this server is a follower and still has a valid leader " + leader);
+        }
       }
     }
     return true;


### PR DESCRIPTION
## What changes were proposed in this pull request?

During pre-vote, some follower reject the PRE_VOTE request from a candidate although the candidate has the same peer ID as the current leader. 

`2024-01-18 13:44:50,123 [grpc-default-executor-100] INFO org.apache.ratis.server.impl.VoteContext: e46cc30b-13ca-4778-b856-e84b0677493d@group-059247EC8137-FOLLOWER: reject PRE_VOTE from c7e3fa47-df62-4883-8d6e-50c3b6a9b94c: this server is a follower and still has a valid leader c7e3fa47-df62-4883-8d6e-50c3b6a9b94c`

It might be a good idea to add another check so that if the candidate has the same peer ID as the follower's current recognized leader, we approve the PRE_VOTE request.

Note: The optimization might be marginal since leader is only valid after min.rpc.timeout (150ms). Afterwards, the follower should recognize the candidate.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2008

## How was this patch tested?

Existing tests.
