### PR TITLE
RATIS-2007. Zero-copy buffers are not released

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientAsynchronousProtocol.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientAsynchronousProtocol.java
@@ -46,11 +46,11 @@ public interface RaftClientAsynchronousProtocol {
       ReferenceCountedObject<RaftClientRequest> requestRef) {
     try {
       // for backward compatibility
-      return submitClientRequestAsync(requestRef.retain())
-          .whenComplete((r, e) -> requestRef.release());
+      return submitClientRequestAsync(requestRef.retain());
     } catch (Exception e) {
-      requestRef.release();
       return JavaUtils.completeExceptionally(e);
+    } finally {
+      requestRef.retain();
     }
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientAsynchronousProtocol.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientAsynchronousProtocol.java
@@ -50,7 +50,7 @@ public interface RaftClientAsynchronousProtocol {
     } catch (Exception e) {
       return JavaUtils.completeExceptionally(e);
     } finally {
-      requestRef.retain();
+      requestRef.release();
     }
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -882,8 +882,8 @@ class RaftServerImpl implements RaftServer.Division,
     try {
       assertLifeCycleState(LifeCycle.States.RUNNING);
     } catch (ServerNotReadyException e) {
-      requestRef.release();
       final RaftClientReply reply = newExceptionReply(request, e);
+      requestRef.release();
       return CompletableFuture.completedFuture(reply);
     }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -245,6 +245,7 @@ public final class LogSegment {
         if (ti.equals(key.getTermIndex())) {
           toReturn.set(entry);
         }
+        entryRef.release();
       });
       loadingTimes.incrementAndGet();
       return Objects.requireNonNull(toReturn.get());


### PR DESCRIPTION
## What changes were proposed in this pull request?

When running tests as per #1023, some buffer leaks are discovered.

1. The `ReferenceCountedObject` `release` in `whenComplete` (e.g. `RaftServerImpl`'s `submitClientRequestAsync ` and `appendEntriesAsync`) does not always guarantee an execution. As the retuned future may be discarded when the client connection is terminated.
2. The `processClientRequest` called from SlidingWindow doesn't always guarantee 100% execution either. `PendingOrderedRequest ` entries may not be processed at all because of client cancellation, or request duplications (`IllegalStateException` due to retries.  
3. LogEntryProto loaded from files is not released after being retained. This is harmless for now but is noisy in leak detection mode.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2007

## How was this patch tested?

Tests.
