### PR TITLE
RATIS-2011. When a log entry is truncated, remove TransactionContext.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
@@ -35,7 +35,13 @@ public final class BatchLogger {
   private BatchLogger() {
   }
 
-  public interface Key {}
+  public interface Key {
+    TimeDuration DEFAULT_DURATION = TimeDuration.valueOf(5, TimeUnit.SECONDS);
+
+    default TimeDuration getBatchDuration() {
+      return DEFAULT_DURATION;
+    }
+  }
 
   private static final class UniqueId {
     private final Key key;
@@ -92,6 +98,10 @@ public final class BatchLogger {
 
   private static final TimeoutExecutor SCHEDULER = TimeoutExecutor.getInstance();
   private static final ConcurrentMap<UniqueId, BatchedLogEntry> LOG_CACHE = new ConcurrentHashMap<>();
+
+  public static void warn(Key key, String name, Consumer<String> op) {
+    warn(key, name, op, key.getBatchDuration(), true);
+  }
 
   public static void warn(Key key, String name, Consumer<String> op, TimeDuration batchDuration) {
     warn(key, name, op, batchDuration, true);

--- a/ratis-common/src/main/java/org/apache/ratis/util/JavaUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/JavaUtils.java
@@ -41,7 +41,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
-import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -229,7 +228,7 @@ public interface JavaUtils {
         }
         if (log != null && log.isWarnEnabled()) {
           log.warn("FAILED \"" + name.get() + "\", attempt #" + i + "/" + numAttempts
-              + ": " + t + ", sleep " + sleepTime + " and then retry.", t);
+              + ", sleep " + sleepTime + " and then retry: " + t);
         }
       }
 
@@ -244,19 +243,6 @@ public interface JavaUtils {
       throws THROWABLE, InterruptedException {
     attemptRepeatedly(CheckedRunnable.asCheckedSupplier(runnable), numAttempts, sleepTime, name, log);
   }
-
-  /** Attempt to wait the given condition to return true multiple times. */
-  static void attemptUntilTrue(
-      BooleanSupplier condition, int numAttempts, TimeDuration sleepTime, String name, Logger log)
-      throws InterruptedException {
-    Objects.requireNonNull(condition, "condition == null");
-    attempt(() -> {
-      if (!condition.getAsBoolean()) {
-        throw new IllegalStateException("Condition " + name + " is false.");
-      }
-    }, numAttempts, sleepTime, name, log);
-  }
-
 
   static Timer runRepeatedly(Runnable runnable, long delay, long period, TimeUnit unit) {
     final Timer timer = new Timer(true);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/LogProtoUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/LogProtoUtils.java
@@ -53,17 +53,27 @@ public final class LogProtoUtils {
       s = "(c:" + metadata.getCommitIndex() + ")";
     } else if (entry.hasConfigurationEntry()) {
       final RaftConfigurationProto config = entry.getConfigurationEntry();
-      s = "(current:" + config.getPeersList().stream().map(AbstractMessage::toString).collect(Collectors.joining(",")) +
-          ", old:" + config.getOldPeersList().stream().map(AbstractMessage::toString).collect(Collectors.joining(","))
-          + ")";
+      s = "(current:" + peersToString(config.getPeersList())
+          + ", old:" + peersToString(config.getOldPeersList()) + ")";
     } else {
       s = "";
     }
     return TermIndex.valueOf(entry) + ", " + entry.getLogEntryBodyCase() + s;
   }
 
+  static String peersToString(List<RaftPeerProto> peers) {
+    return peers.stream().map(AbstractMessage::toString)
+        .map(s -> s.replace("\n", ""))
+        .map(s -> s.replace(" ", ""))
+        .collect(Collectors.joining(", "));
+  }
+
+  static String stateMachineLogEntryProtoToString(StateMachineLogEntryProto p) {
+    return "logData:" + p.getLogData() + ", stateMachineEntry:" + p.getType() + ":" + p.getStateMachineEntry();
+  }
+
   public static String toLogEntryString(LogEntryProto entry) {
-    return toLogEntryString(entry, null);
+    return toLogEntryString(entry, LogProtoUtils::stateMachineLogEntryProtoToString);
   }
 
   public static String toLogEntriesString(List<LogEntryProto> entries) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -375,7 +375,8 @@ public abstract class RaftLogBase implements RaftLog {
 
   @Override
   public String toString() {
-    return getName() + ":" + state + ":c" + getLastCommittedIndex();
+    return getName() + ":" + state + ":c" + getLastCommittedIndex()
+        + (isOpened()? ":last" + getLastEntryTermIndex(): "");
   }
 
   public AutoCloseableLock readLock() {

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
@@ -31,9 +31,12 @@ import org.apache.ratis.server.RaftConfiguration;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerRpc;
 import org.apache.ratis.server.leader.LogAppender;
+import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.segmented.SegmentedRaftLog;
 import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.statemachine.TransactionContext;
 import org.apache.ratis.util.JavaUtils;
+import org.apache.ratis.util.MemoizedSupplier;
 import org.apache.ratis.util.Slf4jUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.function.CheckedConsumer;
@@ -49,6 +52,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -136,6 +140,15 @@ public class RaftServerTestUtil {
 
   public static ConfigurationManager getConfigurationManager(RaftServer.Division server) {
     return (ConfigurationManager) RaftTestUtil.getDeclaredField(getState(server), "configurationManager");
+  }
+
+  public static Logger getTransactionContextLog() {
+    return TransactionManager.LOG;
+  }
+
+  public static Map<TermIndex, MemoizedSupplier<TransactionContext>> getTransactionContextMap(
+      RaftServer.Division server) {
+    return ((RaftServerImpl)server).getTransactionContextMapForTesting();
   }
 
   public static RaftConfiguration newRaftConfiguration(Collection<RaftPeer> peers) {


### PR DESCRIPTION
See RATIS-2011
