### PR TITLE
RATIS-2018. Zero-copy buffers are not released - 2nd chunk

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
@@ -118,7 +118,7 @@ public interface ReferenceCountedObject<T> {
       @Override
       public boolean release() {
         boolean allReleased = true;
-        for (ReferenceCountedObject ref : fromRefs) {
+        for (ReferenceCountedObject<T> ref : fromRefs) {
           if (!ref.release()) {
             allReleased = false;
           }

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
@@ -117,7 +117,13 @@ public interface ReferenceCountedObject<T> {
 
       @Override
       public boolean release() {
-        return fromRefs.stream().map(ReferenceCountedObject::release).allMatch(r -> r);
+        boolean allReleased = true;
+        for (ReferenceCountedObject ref : fromRefs) {
+          if (!ref.release()) {
+            allReleased = false;
+          }
+        }
+        return allReleased;
       }
     };
   }

--- a/ratis-common/src/main/java/org/apache/ratis/util/SlidingWindow.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/SlidingWindow.java
@@ -167,6 +167,7 @@ public interface SlidingWindow {
                 + " will NEVER be processed; request = " + r);
         r.fail(e);
         replyMethod.accept(r);
+        r.release();
       }
       tail.clear();
 
@@ -462,6 +463,9 @@ public interface SlidingWindow {
       } else {
         final boolean isRetry = requests.putIfAbsent(request);
         LOG.debug("Received seq={}, isRetry? {}, {}", seqNum, isRetry, this);
+        if (isRetry || request.getSeqNum() < nextToProcess) {
+          request.release();
+        }
         if (isRetry) {
           return;
         }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
@@ -63,14 +63,8 @@ public interface GrpcUtil {
       Metadata.Key.of("heartbeat", Metadata.ASCII_STRING_MARSHALLER);
 
   static StatusRuntimeException wrapException(Throwable t) {
-    return wrapException(t, -1);
-  }
-
-  static StatusRuntimeException wrapException(Throwable t, long callId) {
     t = JavaUtils.unwrapCompletionException(t);
-    Metadata trailers = new StatusRuntimeExceptionMetadataBuilder(t)
-        .addCallId(callId)
-        .build();
+    Metadata trailers = new StatusRuntimeExceptionMetadataBuilder(t).build();
     return wrapException(t, trailers);
   }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcClientProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcClientProtocolService.java
@@ -320,11 +320,13 @@ class GrpcClientProtocolService extends RaftClientProtocolServiceImplBase {
 
       final CompletableFuture<Void> f = processClientRequest(requestRef, reply -> {
         if (!reply.isSuccess()) {
-          LOG.info("Failed {}, reply={}", request, reply);
+          LOG.info("Failed {}, reply={}", request.toStringShort(), reply);
         }
         final RaftClientReplyProto proto = ClientProtoUtils.toRaftClientReplyProto(reply);
         responseNext(proto);
-      }).whenComplete((r, e) -> requestRef.release());
+      });
+
+      requestRef.release();
 
       put(callId, f);
       f.thenAccept(dummy -> remove(callId));

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcClientProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcClientProtocolService.java
@@ -29,6 +29,7 @@ import org.apache.ratis.thirdparty.io.grpc.ServerServiceDefinition;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.proto.RaftProtos.RaftClientReplyProto;
 import org.apache.ratis.proto.RaftProtos.RaftClientRequestProto;
+import org.apache.ratis.proto.RaftProtos.SlidingWindowEntry;
 import org.apache.ratis.proto.grpc.RaftClientProtocolServiceGrpc.RaftClientProtocolServiceImplBase;
 import org.apache.ratis.util.CollectionUtils;
 import org.apache.ratis.util.JavaUtils;
@@ -317,10 +318,10 @@ class GrpcClientProtocolService extends RaftClientProtocolServiceImplBase {
     void processClientRequest(ReferenceCountedObject<RaftClientRequest> requestRef) {
       final RaftClientRequest request = requestRef.retain();
       final long callId = request.getCallId();
-
+      final SlidingWindowEntry slidingWindowEntry = request.getSlidingWindowEntry();
       final CompletableFuture<Void> f = processClientRequest(requestRef, reply -> {
         if (!reply.isSuccess()) {
-          LOG.info("Failed {}, reply={}", request.toStringShort(), reply);
+          LOG.info("Failed request cid={}, {}, reply={}", callId, slidingWindowEntry, reply);
         }
         final RaftClientReplyProto proto = ClientProtoUtils.toRaftClientReplyProto(reply);
         responseNext(proto);

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -125,7 +125,8 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
     abstract boolean replyInOrder(REQUEST request);
 
     private synchronized void handleError(Throwable e, long callId, boolean isHeartbeat) {
-      GrpcUtil.warn(LOG, () -> getId() + ": Failed " + op + " request cid=" + callId + ", isHeartbeat? " + isHeartbeat, e);
+      GrpcUtil.warn(LOG, () -> getId() + ": Failed " + op + " request cid=" + callId + ", isHeartbeat? "
+          + isHeartbeat, e);
       if (isClosed.compareAndSet(false, true)) {
         responseObserver.onError(GrpcUtil.wrapException(e, callId, isHeartbeat));
       }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -28,7 +28,6 @@ import org.apache.ratis.server.protocol.RaftServerProtocol;
 import org.apache.ratis.server.util.ServerStringUtils;
 import org.apache.ratis.thirdparty.io.grpc.ServerServiceDefinition;
 import org.apache.ratis.thirdparty.io.grpc.Status;
-import org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.proto.RaftProtos.*;
 import org.apache.ratis.proto.grpc.RaftServerProtocolServiceGrpc.RaftServerProtocolServiceImplBase;
@@ -51,18 +50,18 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
   public static final Logger LOG = LoggerFactory.getLogger(GrpcServerProtocolService.class);
 
   static class PendingServerRequest<REQUEST> {
-    private final REQUEST request;
-    private final ReferenceCountedObject<REQUEST> requestRef;
-    private AtomicBoolean released = new AtomicBoolean(false);
+    private final AtomicReference<ReferenceCountedObject<REQUEST>> requestRef;
     private final CompletableFuture<Void> future = new CompletableFuture<>();
 
     PendingServerRequest(ReferenceCountedObject<REQUEST> requestRef) {
-      this.request = requestRef.retain();
-      this.requestRef = requestRef;
+      requestRef.retain();
+      this.requestRef = new AtomicReference<>(requestRef);
     }
 
     REQUEST getRequest() {
-      return request;
+      return Optional.ofNullable(requestRef.get())
+          .map(ReferenceCountedObject::get)
+          .orElse(null);
     }
 
     CompletableFuture<Void> getFuture() {
@@ -70,9 +69,8 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
     }
 
     void release() {
-      if (released.compareAndSet(false, true)) {
-        requestRef.release();
-      }
+      Optional.ofNullable(requestRef.getAndSet(null))
+          .ifPresent(ReferenceCountedObject::release);
     }
   }
 
@@ -116,20 +114,20 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
 
     abstract long getCallId(REQUEST request);
 
+    boolean isHeartbeat(REQUEST request) {
+      return false;
+    }
+
     abstract String requestToString(REQUEST request);
 
     abstract String replyToString(REPLY reply);
 
     abstract boolean replyInOrder(REQUEST request);
 
-    StatusRuntimeException wrapException(Throwable e, REQUEST request) {
-      return GrpcUtil.wrapException(e, getCallId(request));
-    }
-
-    private void handleError(Throwable e, REQUEST request) {
-      GrpcUtil.warn(LOG, () -> getId() + ": Failed " + op + " request " + requestToString(request), e);
+    private synchronized void handleError(Throwable e, long callId, boolean isHeartbeat) {
+      GrpcUtil.warn(LOG, () -> getId() + ": Failed " + op + " request cid=" + callId + ", isHeartbeat? " + isHeartbeat, e);
       if (isClosed.compareAndSet(false, true)) {
-        responseObserver.onError(wrapException(e, request));
+        responseObserver.onError(GrpcUtil.wrapException(e, callId, isHeartbeat));
       }
     }
 
@@ -159,20 +157,22 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
         try {
           composeRequest(process(requestRef).thenApply(this::handleReply));
         } catch (Exception e) {
-          handleError(e, request);
+          handleError(e, getCallId(request), isHeartbeat(request));
           release(request);
         }
         return;
       }
 
       final PendingServerRequest<REQUEST> current = new PendingServerRequest<>(requestRef);
+      final long callId = getCallId(current.getRequest());
+      final boolean isHeartbeat = isHeartbeat(current.getRequest());
       final Optional<PendingServerRequest<REQUEST>> previous = Optional.ofNullable(previousOnNext.getAndSet(current));
       final CompletableFuture<Void> previousFuture = previous.map(PendingServerRequest::getFuture)
           .orElse(CompletableFuture.completedFuture(null));
       try {
         final CompletableFuture<REPLY> f = process(requestRef).exceptionally(e -> {
           // Handle cases, such as RaftServer is paused
-          handleError(e, request);
+          handleError(e, callId, isHeartbeat);
           current.getFuture().completeExceptionally(e);
           return null;
         }).thenCombine(previousFuture, (reply, v) -> {
@@ -182,7 +182,7 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
         });
         composeRequest(f);
       } catch (Exception e) {
-        handleError(e, request);
+        handleError(e, callId, isHeartbeat);
         current.getFuture().completeExceptionally(e);
       } finally {
         previous.ifPresent(PendingServerRequest::release);
@@ -204,6 +204,7 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
         releaseLast();
       }
     }
+
     @Override
     public void onError(Throwable t) {
       GrpcUtil.warn(LOG, () -> getId() + ": "+ op + " onError, lastRequest: " + getPreviousRequestString(), t);
@@ -308,6 +309,11 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
       }
 
       @Override
+      boolean isHeartbeat(AppendEntriesRequestProto request) {
+        return request.getEntriesCount() == 0;
+      }
+
+      @Override
       String requestToString(AppendEntriesRequestProto request) {
         return ServerStringUtils.toAppendEntriesRequestString(request);
       }
@@ -320,11 +326,6 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
       @Override
       boolean replyInOrder(AppendEntriesRequestProto request) {
         return request.getEntriesCount() != 0;
-      }
-
-      @Override
-      StatusRuntimeException wrapException(Throwable e, AppendEntriesRequestProto request) {
-        return GrpcUtil.wrapException(e, getCallId(request), request.getEntriesCount() == 0);
       }
     };
   }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/RaftServerAsynchronousProtocol.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/RaftServerAsynchronousProtocol.java
@@ -50,11 +50,9 @@ public interface RaftServerAsynchronousProtocol {
       ReferenceCountedObject<AppendEntriesRequestProto> requestRef) throws IOException {
     // Default implementation for backward compatibility.
     try {
-      return appendEntriesAsync(requestRef.retain())
-          .whenComplete((r, e) -> requestRef.release());
-    } catch (Exception e) {
+      return appendEntriesAsync(requestRef.retain());
+    } finally {
       requestRef.release();
-      throw e;
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1076,7 +1076,13 @@ class RaftServerImpl implements RaftServer.Division,
         return f.thenApply(r -> null);
       }
       // the message stream has ended and the request become a WRITE request
-      return replyFuture(f.join());
+      ReferenceCountedObject<RaftClientRequest> joinedRequest = f.join();
+      try {
+        return replyFuture(joinedRequest);
+      } finally {
+        // Released pending streaming requests.
+        joinedRequest.release();
+      }
     }
 
     return role.getLeaderState()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Zero-copy buffers are not released - 2nd chunk, including fixes in:
1. Sliding window: requests being replied as `will NEVER be processed`, requests coming with seqNum < nextToProcess.
2. appendEntries: avoid releasing at `whenComplete`.
3. Streaming request: pending requests retained must be released after completing.
4. Log entries being purged (after snapshot) must be released.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2018

## How was this patch tested?

CI