### PR TITLE
RATIS-1974. Migrate ratis-metrics-default tests to Junit 5.

### DIFF
--- a/ratis-metrics-default/pom.xml
+++ b/ratis-metrics-default/pom.xml
@@ -55,6 +55,17 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/ratis-metrics-default/src/test/java/org/apache/ratis/metrics/TestMetricRegistriesLoader.java
+++ b/ratis-metrics-default/src/test/java/org/apache/ratis/metrics/TestMetricRegistriesLoader.java
@@ -17,15 +17,15 @@
  */
 package org.apache.ratis.metrics;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import org.apache.ratis.metrics.impl.MetricRegistriesImpl;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -57,7 +57,7 @@ public class TestMetricRegistriesLoader {
   @Test
   public void testLoadDefault() {
     final MetricRegistries r = MetricRegistriesLoader.load();
-    Assert.assertSame(MetricRegistriesImpl.class, r.getClass());
+    Assertions.assertSame(MetricRegistriesImpl.class, r.getClass());
   }
 
   @Test
@@ -71,16 +71,16 @@ public class TestMetricRegistriesLoader {
     // check if add and remove of metric do reporting counter increase
     MetricRegistryInfo info = new MetricRegistryInfo("t1", "t1", "t1", "t1");
     r.create(info);
-    Assert.assertTrue(cntr.get() == 1);
+    assertEquals(1, cntr.get());
     r.remove(info);
-    Assert.assertTrue(cntr.get() == 2);
+    assertEquals(2, cntr.get());
 
     // after removal, add and remove of metric must not do any increase
     r.removeReporterRegistration(reporter, stopReporter);
     r.create(info);
-    Assert.assertTrue(cntr.get() == 2);
+    assertEquals(2, cntr.get());
     r.remove(info);
-    Assert.assertTrue(cntr.get() == 2);
+    assertEquals(2, cntr.get());
   }
 
 }

--- a/ratis-metrics-default/src/test/java/org/apache/ratis/metrics/impl/TestRefCountingMap.java
+++ b/ratis-metrics-default/src/test/java/org/apache/ratis/metrics/impl/TestRefCountingMap.java
@@ -17,23 +17,23 @@
  */
 package org.apache.ratis.metrics.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.Set;
 
 import org.apache.ratis.thirdparty.com.google.common.collect.Lists;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestRefCountingMap {
 
   private RefCountingMap<String, String> map;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     map = new RefCountingMap<>();
   }
@@ -128,7 +128,7 @@ public class TestRefCountingMap {
     Set<String> keys = map.keySet();
     assertEquals(3, keys.size());
 
-    Lists.newArrayList("foo", "bar", "baz").stream().forEach(v -> assertTrue(keys.contains(v)));
+    Lists.newArrayList("foo", "bar", "baz").forEach(v -> assertTrue(keys.contains(v)));
   }
 
   @Test
@@ -141,7 +141,7 @@ public class TestRefCountingMap {
     Collection<String> values = map.values();
     assertEquals(3, values.size());
 
-    Lists.newArrayList("foovalue", "foovalue3", "foovalue4").stream()
+    Lists.newArrayList("foovalue", "foovalue3", "foovalue4")
             .forEach(v -> assertTrue(values.contains(v)));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Migrate ratis-metrics-default tests to Junit 5.

## What is the link to the Apache JIRA
RATIS-1974

## How was this patch tested?
Ran unit test locally
