### PR TITLE
RATIS-1973. Migrate ratis-examples tests to Junit 5.

### DIFF
--- a/ratis-examples/pom.xml
+++ b/ratis-examples/pom.xml
@@ -124,7 +124,17 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/ratis-examples/src/test/java/org/apache/ratis/TestMultiRaftGroup.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/TestMultiRaftGroup.java
@@ -27,45 +27,40 @@ import org.apache.ratis.server.impl.GroupManagementBaseTest;
 import org.apache.ratis.server.impl.MiniRaftCluster;
 import org.apache.ratis.util.Slf4jUtils;
 import org.apache.ratis.util.function.CheckedBiConsumer;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.event.Level;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@RunWith(Parameterized.class)
 public class TestMultiRaftGroup extends BaseTest {
   static {
     Slf4jUtils.setLogLevel(RaftServer.Division.LOG, Level.DEBUG);
   }
 
-  @Parameterized.Parameters
   public static Collection<Object[]> data() throws IOException {
     return ParameterizedBaseTest.getMiniRaftClusters(ArithmeticStateMachine.class, 0);
   }
 
-  @Parameterized.Parameter
-  public MiniRaftCluster cluster;
-
-  @Test
-  public void testMultiRaftGroup() throws Exception {
-    runTestMultiRaftGroup(3, 6, 9, 12, 15);
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testMultiRaftGroup(MiniRaftCluster cluster) throws Exception {
+    runTestMultiRaftGroup(cluster, 3, 6, 9, 12, 15);
   }
 
-  private void runTestMultiRaftGroup(int... idIndex) throws Exception {
-    runTestMultiRaftGroup(idIndex, -1);
+  private void runTestMultiRaftGroup(MiniRaftCluster cluster, int... idIndex) throws Exception {
+    runTestMultiRaftGroup(cluster, idIndex, -1);
   }
 
   private final AtomicInteger start = new AtomicInteger(3);
   private final int count = 10;
 
-  private void runTestMultiRaftGroup(int[] idIndex, int chosen) throws Exception {
+  private void runTestMultiRaftGroup(MiniRaftCluster cluster, int[] idIndex, int chosen) throws Exception {
 
-    final CheckedBiConsumer<MiniRaftCluster, RaftGroup, IOException> checker = (cluster, group) -> {
-      try (final RaftClient client = cluster.createClient(group)) {
+    final CheckedBiConsumer<MiniRaftCluster, RaftGroup, IOException> checker = (c, group) -> {
+      try (final RaftClient client = c.createClient(group)) {
         TestArithmetic.runTestPythagorean(client, start.getAndAdd(2*count), count);
       }
     };

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/ParameterizedBaseTest.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/ParameterizedBaseTest.java
@@ -28,10 +28,9 @@ import org.apache.ratis.server.simulation.MiniRaftClusterWithSimulatedRpc;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.TimeDuration;
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,17 +39,15 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-@RunWith(Parameterized.class)
 public abstract class ParameterizedBaseTest extends BaseTest {
   public static final Logger LOG = LoggerFactory.getLogger(ParameterizedBaseTest.class);
 
   /** Subclasses should override this method to provide real data parameters. */
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Collections.emptyList();
   }
 
-  /** For {@link Parameterized} test so that a cluster can be shared by multiple {@link Test} */
+  /** For {@link ParameterizedTest} so that a cluster can be shared by multiple {@link Test} */
   private static final AtomicReference<MiniRaftCluster> currentCluster = new AtomicReference<>();
 
   /** Set {@link #currentCluster} to the given cluster and start it if {@link #currentCluster} is changed. */
@@ -66,7 +63,7 @@ public abstract class ParameterizedBaseTest extends BaseTest {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdownCurrentCluster() {
     final MiniRaftCluster cluster = currentCluster.getAndSet(null);
     if (cluster != null) {

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/TestArithmetic.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/TestArithmetic.java
@@ -27,9 +27,9 @@ import org.apache.ratis.examples.arithmetic.expression.Variable;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.util.Slf4jUtils;
 import org.apache.ratis.util.Preconditions;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.event.Level;
 
 import java.io.IOException;
@@ -44,16 +44,13 @@ public class TestArithmetic extends ParameterizedBaseTest {
     Slf4jUtils.setLogLevel(ArithmeticStateMachine.LOG, Level.DEBUG);
   }
 
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return getMiniRaftClusters(ArithmeticStateMachine.class, 3);
   }
 
-  @Parameterized.Parameter
-  public MiniRaftCluster cluster;
-
-  @Test
-  public void testPythagorean() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPythagorean(MiniRaftCluster cluster) throws Exception {
     setAndStart(cluster);
     try (final RaftClient client = cluster.createClient()) {
       runTestPythagorean(client, 3, 10);
@@ -85,8 +82,9 @@ public class TestArithmetic extends ParameterizedBaseTest {
     }
   }
 
-  @Test
-  public void testGaussLegendre() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testGaussLegendre(MiniRaftCluster cluster) throws Exception {
     setAndStart(cluster);
     try (final RaftClient client = cluster.createClient()) {
       runGaussLegendre(client);
@@ -117,14 +115,14 @@ public class TestArithmetic extends ParameterizedBaseTest {
       final double pi = e.evaluate(null);
 
       if (converged) {
-        Assert.assertTrue(pi == previous);
+        Assertions.assertEquals(pi, previous);
       } else if (pi == previous) {
         converged = true;
       }
       LOG.info("{} = {}, converged? {}", pi_i, pi, converged);
       previous = pi;
     }
-    Assert.assertTrue(converged);
+    Assertions.assertTrue(converged);
   }
 
   static Variable defineVariable(RaftClient client, String name, double value) throws IOException {
@@ -145,7 +143,7 @@ public class TestArithmetic extends ParameterizedBaseTest {
 
   static void assignNull(RaftClient client, Variable x) throws IOException {
     final Expression e = assign(client, x, NullValue.getInstance());
-    Assert.assertEquals(NullValue.getInstance(), e);
+    Assertions.assertEquals(NullValue.getInstance(), e);
   }
 
   static Expression assign(RaftClient client, Variable x, Expression e) throws IOException {
@@ -158,11 +156,11 @@ public class TestArithmetic extends ParameterizedBaseTest {
   }
 
   static Expression assertRaftClientReply(RaftClientReply reply, Double expected) {
-    Assert.assertTrue(reply.isSuccess());
+    Assertions.assertTrue(reply.isSuccess());
     final Expression e = Expression.Utils.bytes2Expression(
         reply.getMessage().getContent().toByteArray(), 0);
     if (expected != null) {
-      Assert.assertEquals(expected, e.evaluate(null));
+      Assertions.assertEquals(expected, e.evaluate(null));
     }
     return e;
   }

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/TestArithmeticLogDump.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/TestArithmeticLogDump.java
@@ -34,10 +34,10 @@ import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.tools.ParseRatisLog;
 import org.apache.ratis.util.Slf4jUtils;
 import org.apache.ratis.util.TimeDuration;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 public class TestArithmeticLogDump extends BaseTest {
@@ -60,13 +60,13 @@ public class TestArithmeticLogDump extends BaseTest {
     return properties;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
-    Assert.assertNull(cluster.getLeader());
+    Assertions.assertNull(cluster.getLeader());
     cluster.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -77,7 +77,7 @@ public class TestArithmeticLogDump extends BaseTest {
   public void testLogDump() throws Exception {
     final RaftServer.Division leaderServer = RaftTestUtil.waitForLeader(cluster);
     final List<LogSegmentPath> files = LogSegmentPath.getLogSegmentPaths(leaderServer.getRaftStorage());
-    Assert.assertEquals(1, files.size());
+    Assertions.assertEquals(1, files.size());
     cluster.shutdown();
 
     ParseRatisLog.Builder builder =  new ParseRatisLog.Builder();

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/cli/TestAssignCli.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/cli/TestAssignCli.java
@@ -19,8 +19,8 @@ package org.apache.ratis.examples.arithmetic.cli;
 
 import org.apache.ratis.examples.arithmetic.expression.DoubleValue;
 import org.apache.ratis.examples.arithmetic.expression.Variable;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.ratis.examples.arithmetic.expression.BinaryExpression.Op.ADD;
 import static org.apache.ratis.examples.arithmetic.expression.BinaryExpression.Op.MULT;
@@ -32,55 +32,55 @@ import static org.apache.ratis.examples.arithmetic.expression.UnaryExpression.Op
 public class TestAssignCli {
   @Test
   public void createExpression() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new DoubleValue(2.0),
         new Assign().createExpression("2.0"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new DoubleValue(42.0),
         new Assign().createExpression("42"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         MULT.apply(2.0, new Variable("a")),
         new Assign().createExpression("2*a"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         MULT.apply(new Variable("v1"), 2.0),
         new Assign().createExpression("v1 * 2"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ADD.apply(2.0, 1.0),
         new Assign().createExpression("2+1"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SUBTRACT.apply(1.0, 6.0),
         new Assign().createExpression("1 - 6"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ADD.apply(new Variable("a"), new Variable("v2")),
         new Assign().createExpression("a+v2"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ADD.apply(new Variable("v1"), new Variable("b")),
         new Assign().createExpression("v1 + b"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SQRT.apply(new Variable("a")),
         new Assign().createExpression("√a"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SQRT.apply(new Variable("ABC")),
         new Assign().createExpression("√ABC"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SQRT.apply(2.0),
         new Assign().createExpression("√2"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         NEG.apply(2.0),
         new Assign().createExpression("~2.0"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         MINUS.apply(6.0),
         new Assign().createExpression("-6.0"));
   }

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/expression/TestExpression.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/expression/TestExpression.java
@@ -19,8 +19,8 @@ package org.apache.ratis.examples.arithmetic.expression;
 
 
 import org.apache.ratis.BaseTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
@@ -42,21 +42,21 @@ public class TestExpression extends BaseTest {
         final int n = ran.nextInt();
         Expression.Utils.int2bytes(n, buf, offset);
         final int m = Expression.Utils.bytes2int(buf, offset);
-        Assert.assertEquals(n, m);
+        Assertions.assertEquals(n, m);
         offset += 4;
       }
       {
         final long n = ran.nextLong();
         Expression.Utils.long2bytes(n, buf, offset);
         final long m = Expression.Utils.bytes2long(buf, offset);
-        Assert.assertEquals(n, m);
+        Assertions.assertEquals(n, m);
         offset += 8;
       }
       {
         final double n = ran.nextDouble();
         Expression.Utils.double2bytes(n, buf, offset);
         final double m = Expression.Utils.bytes2double(buf, offset);
-        Assert.assertTrue(n == m);
+        Assertions.assertEquals(n, m);
         offset += 8;
       }
     }
@@ -65,11 +65,11 @@ public class TestExpression extends BaseTest {
   public void testOp() throws Exception {
     for(BinaryExpression.Op op : BinaryExpression.Op.values()) {
       final byte b = op.byteValue();
-      Assert.assertEquals(op, BinaryExpression.Op.valueOf(b));
+      Assertions.assertEquals(op, BinaryExpression.Op.valueOf(b));
     }
     for(UnaryExpression.Op op : UnaryExpression.Op.values()) {
       final byte b = op.byteValue();
-      Assert.assertEquals(op, UnaryExpression.Op.valueOf(b));
+      Assertions.assertEquals(op, UnaryExpression.Op.valueOf(b));
     }
   }
 
@@ -84,9 +84,9 @@ public class TestExpression extends BaseTest {
       final int len = a.toBytes(buf, offset);
       final Variable a2 = new Variable(buf, offset);
       LOG.info("var a2: " + a2);
-      Assert.assertEquals(a.getName(), a2.getName());
-      Assert.assertEquals(len, a.length());
-      Assert.assertEquals(len, a2.length());
+      Assertions.assertEquals(a.getName(), a2.getName());
+      Assertions.assertEquals(len, a.length());
+      Assertions.assertEquals(len, a2.length());
       offset += len;
     }
 
@@ -96,9 +96,9 @@ public class TestExpression extends BaseTest {
       final int len = three.toBytes(buf, offset);
       final DoubleValue three2 = new DoubleValue(buf, offset);
       LOG.info("double three2: " + three2.evaluate(null));
-      Assert.assertTrue(three.evaluate(null).equals(three2.evaluate(null)));
-      Assert.assertEquals(len, three.length());
-      Assert.assertEquals(len, three2.length());
+      Assertions.assertEquals(three.evaluate(null), three2.evaluate(null));
+      Assertions.assertEquals(len, three.length());
+      Assertions.assertEquals(len, three2.length());
     }
   }
 }

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/common/TestSubCommand.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/common/TestSubCommand.java
@@ -22,23 +22,23 @@ package org.apache.ratis.examples.common;
 import java.util.Collection;
 import java.util.Collections;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
 public class TestSubCommand {
 
-  @Parameterized.Parameters
   public static Collection<String> data() {
     return Collections.singleton("127.0.0.1:6667");
   }
 
-  @Parameterized.Parameter
-  public String peers;
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testParsePeers() {
-    SubCommandBase.parsePeers(peers);
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testParsePeers(String peers) {
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> SubCommandBase.parsePeers(peers));
   }
 
 }

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/counter/TestCounter.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/counter/TestCounter.java
@@ -24,42 +24,39 @@ import org.apache.ratis.examples.ParameterizedBaseTest;
 import org.apache.ratis.examples.counter.server.CounterStateMachine;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Collection;
 
 public class TestCounter extends ParameterizedBaseTest {
 
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return getMiniRaftClusters(CounterStateMachine.class, 3);
   }
 
-  @Parameterized.Parameter
-  public MiniRaftCluster cluster;
-
-  @Test
-  public void testSeveralCounter() throws IOException, InterruptedException {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testSeveralCounter(MiniRaftCluster cluster) throws IOException, InterruptedException {
     setAndStart(cluster);
     try (final RaftClient client = cluster.createClient()) {
       for (int i = 0; i < 10; i++) {
         client.io().send(Message.valueOf("INCREMENT"));
       }
       RaftClientReply reply1 = client.io().sendReadOnly(Message.valueOf("GET"));
-      Assert.assertEquals(10, reply1.getMessage().getContent().asReadOnlyByteBuffer().getInt());
+      Assertions.assertEquals(10, reply1.getMessage().getContent().asReadOnlyByteBuffer().getInt());
       for (int i = 0; i < 10; i++) {
         client.io().send(Message.valueOf("INCREMENT"));
       }
       RaftClientReply reply2 = client.io().sendReadOnly(Message.valueOf("GET"));
-      Assert.assertEquals(20, reply2.getMessage().getContent().asReadOnlyByteBuffer().getInt());
+      Assertions.assertEquals(20, reply2.getMessage().getContent().asReadOnlyByteBuffer().getInt());
       for (int i = 0; i < 10; i++) {
         client.io().send(Message.valueOf("INCREMENT"));
       }
       RaftClientReply reply3 = client.io().sendReadOnly(Message.valueOf("GET"));
-      Assert.assertEquals(30, reply3.getMessage().getContent().asReadOnlyByteBuffer().getInt());
+      Assertions.assertEquals(30, reply3.getMessage().getContent().asReadOnlyByteBuffer().getInt());
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR migrates ratis-examples tests to Junit 5

## What is the link to the Apache JIRA
RATIS-1973

## How was this patch tested?
Using existing unit tests
