### PR TITLE
RATIS-2026. LogAppender to consume log entries with reference count

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -379,7 +379,7 @@ public class GrpcLogAppender extends LogAppenderBase {
   }
 
   private void appendLog(boolean heartbeat) throws IOException {
-    final ReferenceCountedObject<AppendEntriesRequestProto> pending;
+    ReferenceCountedObject<AppendEntriesRequestProto> pending = null;
     final AppendEntriesRequest request;
     try (AutoCloseableLock writeLock = lock.writeLock(caller, LOG::trace)) {
       // Prepare and send the append request.
@@ -395,6 +395,11 @@ public class GrpcLogAppender extends LogAppenderBase {
         appendLogRequestObserver = new StreamObservers(
             getClient(), new AppendLogResponseHandler(), useSeparateHBChannel, getWaitTimeMin());
       }
+    } catch(Exception e) {
+      if (pending != null) {
+        pending.release();
+      }
+      throw e;
     }
 
     try {

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -384,7 +384,7 @@ public class GrpcLogAppender extends LogAppenderBase {
     try (AutoCloseableLock writeLock = lock.writeLock(caller, LOG::trace)) {
       // Prepare and send the append request.
       // Note changes on follower's nextIndex and ops on pendingRequests should always be done under the write-lock
-      pending = newAppendEntriesRequest(callId.getAndIncrement(), heartbeat);
+      pending = nextAppendEntriesRequest(callId.getAndIncrement(), heartbeat);
       if (pending == null) {
         return;
       }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -27,6 +27,7 @@ import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.server.raftlog.RaftLogIOException;
 import org.apache.ratis.statemachine.SnapshotInfo;
 import org.apache.ratis.util.AwaitForSignal;
+import org.apache.ratis.util.ReferenceCountedObject;
 import org.apache.ratis.util.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,12 +121,15 @@ public interface LogAppender {
    * The {@link AppendEntriesRequestProto} object may contain zero or more log entries.
    * When there is zero log entries, the {@link AppendEntriesRequestProto} object is a heartbeat.
    *
+   *
    * @param callId The call id of the returned request.
    * @param heartbeat the returned request must be a heartbeat.
    *
-   * @return a new {@link AppendEntriesRequestProto} object.
+   * @return a new {@link ReferenceCountedObject} that wraps {@link AppendEntriesRequestProto} object. The return proto
+   * contains retained underlying resources and the client code needs to ensure calling {@link ReferenceCountedObject#release()}
+   * after finishing using it.
    */
-  AppendEntriesRequestProto newAppendEntriesRequest(long callId, boolean heartbeat) throws RaftLogIOException;
+  ReferenceCountedObject<AppendEntriesRequestProto> newAppendEntriesRequest(long callId, boolean heartbeat) throws RaftLogIOException;
 
   /** @return a new {@link InstallSnapshotRequestProto} object. */
   InstallSnapshotRequestProto newInstallSnapshotNotificationRequest(TermIndex firstAvailableLogTermIndex);

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -27,7 +27,6 @@ import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.server.raftlog.RaftLogIOException;
 import org.apache.ratis.statemachine.SnapshotInfo;
 import org.apache.ratis.util.AwaitForSignal;
-import org.apache.ratis.util.ReferenceCountedObject;
 import org.apache.ratis.util.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,13 +120,13 @@ public interface LogAppender {
    * The {@link AppendEntriesRequestProto} object may contain zero or more log entries.
    * When there is zero log entries, the {@link AppendEntriesRequestProto} object is a heartbeat.
    *
-   *
    * @param callId The call id of the returned request.
    * @param heartbeat the returned request must be a heartbeat.
    *
    * @return a new {@link AppendEntriesRequestProto} object.
    * @deprecated this is not supposed to be an external-facing API.
    */
+  @Deprecated
   AppendEntriesRequestProto newAppendEntriesRequest(long callId, boolean heartbeat) throws RaftLogIOException;
 
   /** @return a new {@link InstallSnapshotRequestProto} object. */

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -124,7 +124,7 @@ public interface LogAppender {
    * @param heartbeat the returned request must be a heartbeat.
    *
    * @return a new {@link AppendEntriesRequestProto} object.
-   * @deprecated this is not supposed to be an external-facing API.
+   * @deprecated this is no longer a public API.
    */
   @Deprecated
   AppendEntriesRequestProto newAppendEntriesRequest(long callId, boolean heartbeat) throws RaftLogIOException;

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -126,8 +126,8 @@ public interface LogAppender {
    * @param heartbeat the returned request must be a heartbeat.
    *
    * @return a new {@link ReferenceCountedObject} that wraps {@link AppendEntriesRequestProto} object. The return proto
-   * contains retained underlying resources and the client code needs to ensure calling {@link ReferenceCountedObject#release()}
-   * after finishing using it.
+   * contains retained underlying resources and the client code needs to ensure calling
+   * {@link ReferenceCountedObject#release()} after finishing using it.
    */
   ReferenceCountedObject<AppendEntriesRequestProto> newAppendEntriesRequest(long callId, boolean heartbeat)
       throws RaftLogIOException;

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -129,7 +129,8 @@ public interface LogAppender {
    * contains retained underlying resources and the client code needs to ensure calling {@link ReferenceCountedObject#release()}
    * after finishing using it.
    */
-  ReferenceCountedObject<AppendEntriesRequestProto> newAppendEntriesRequest(long callId, boolean heartbeat) throws RaftLogIOException;
+  ReferenceCountedObject<AppendEntriesRequestProto> newAppendEntriesRequest(long callId, boolean heartbeat)
+      throws RaftLogIOException;
 
   /** @return a new {@link InstallSnapshotRequestProto} object. */
   InstallSnapshotRequestProto newInstallSnapshotNotificationRequest(TermIndex firstAvailableLogTermIndex);

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -125,12 +125,10 @@ public interface LogAppender {
    * @param callId The call id of the returned request.
    * @param heartbeat the returned request must be a heartbeat.
    *
-   * @return a new {@link ReferenceCountedObject} that wraps {@link AppendEntriesRequestProto} object. The return proto
-   * contains retained underlying resources and the client code needs to ensure calling
-   * {@link ReferenceCountedObject#release()} after finishing using it.
+   * @return a new {@link AppendEntriesRequestProto} object.
+   * @deprecated this is not supposed to be an external-facing API.
    */
-  ReferenceCountedObject<AppendEntriesRequestProto> newAppendEntriesRequest(long callId, boolean heartbeat)
-      throws RaftLogIOException;
+  AppendEntriesRequestProto newAppendEntriesRequest(long callId, boolean heartbeat) throws RaftLogIOException;
 
   /** @return a new {@link InstallSnapshotRequestProto} object. */
   InstallSnapshotRequestProto newInstallSnapshotNotificationRequest(TermIndex firstAvailableLogTermIndex);

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
@@ -21,6 +21,7 @@ import org.apache.ratis.proto.RaftProtos.*;
 import org.apache.ratis.server.metrics.RaftLogMetrics;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.storage.RaftStorageMetadata;
+import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.ratis.util.ReferenceCountedObject;
 import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
@@ -81,7 +82,7 @@ public interface RaftLog extends RaftLogSequentialOps, Closeable {
    *         otherwise, return the {@link EntryWithData} corresponding to the given index.
    *         The {@link EntryWithData} enclosed retained underlying resource. The client code need to ensure either
    *         calling {@link ReferenceCountedObject#release()} on the result of
-   *         {@link EntryWithData#getEntry(TimeDuration)} or {@link EntryWithData#release()} if the entry is discarded.
+   *         {@link EntryWithData#getEntryRef(TimeDuration)} or {@link EntryWithData#release()} if the entry is discarded.
    */
   EntryWithData getEntryWithData(long index) throws RaftLogIOException;
 
@@ -179,16 +180,38 @@ public interface RaftLog extends RaftLogSequentialOps, Closeable {
     int getSerializedSize();
 
     /**
+     * @return the {@link LogEntryProto} containing both the log entry and the state machine data.
+     * @deprecated use {@link EntryWithData#getEntryRef(TimeDuration)}.
+     * */
+    @Deprecated
+    default LogEntryProto getEntry(TimeDuration timeout) throws RaftLogIOException, TimeoutException {
+      ReferenceCountedObject<LogEntryProto> ref = getEntryRef(timeout);
+      try {
+        return LogEntryProto.parseFrom(ref.get().toByteString());
+      } catch (InvalidProtocolBufferException e) {
+        throw new RuntimeException("Error copying LogEntryProto", e);
+      } finally {
+        ref.release();
+      }
+    }
+
+    /**
      * @return the {@link ReferenceCountedObject} wraps the {@link LogEntryProto} containing both the log entry and
      * the state machine data.
      * The return proto object contains underlying retained resources, so the client code needs to ensure calling
      * {@link ReferenceCountedObject#release()} to release those resources.
      * */
-    ReferenceCountedObject<LogEntryProto> getEntry(TimeDuration timeout) throws RaftLogIOException, TimeoutException;
+    default ReferenceCountedObject<LogEntryProto> getEntryRef(TimeDuration timeout)
+        throws RaftLogIOException, TimeoutException {
+      LogEntryProto entry = getEntry(timeout);
+      ReferenceCountedObject<LogEntryProto> ref = ReferenceCountedObject.wrap(entry);
+      ref.retain();
+      return ref;
+    }
 
     /**
      * Releasing underlying resource. This is used to clear up this entry in case a {@link ReferenceCountedObject} is
-     * not handed successfully to the client code via {@link EntryWithData#getEntry(TimeDuration)}.
+     * not handed successfully to the client code via {@link EntryWithData#getEntryRef(TimeDuration)}.
      */
     default void release() {
     }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
@@ -82,7 +82,8 @@ public interface RaftLog extends RaftLogSequentialOps, Closeable {
    *         otherwise, return the {@link EntryWithData} corresponding to the given index.
    *         The {@link EntryWithData} enclosed retained underlying resource. The client code need to ensure either
    *         calling {@link ReferenceCountedObject#release()} on the result of
-   *         {@link EntryWithData#getEntryRef(TimeDuration)} or {@link EntryWithData#release()} if the entry is discarded.
+   *         {@link EntryWithData#getEntryRef(TimeDuration)} or {@link EntryWithData#release()} if the entry
+   *         is discarded.
    */
   EntryWithData getEntryWithData(long index) throws RaftLogIOException;
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
@@ -253,7 +253,8 @@ public abstract class LogAppenderBase implements LogAppender {
       return null;
     }
 
-    final List<ReferenceCountedObject<LogEntryProto>> refs = buffer.pollList(getHeartbeatWaitTimeMs(), EntryWithData::getEntry,
+    final List<ReferenceCountedObject<LogEntryProto>> refs = buffer.pollList(getHeartbeatWaitTimeMs(),
+        EntryWithData::getEntry,
         (entry, time, exception) -> LOG.warn("Failed to get " + entry
             + " in " + time.toString(TimeUnit.MILLISECONDS, 3), exception));
     // Release failed entries.

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
@@ -254,7 +254,7 @@ public abstract class LogAppenderBase implements LogAppender {
     }
 
     final List<ReferenceCountedObject<LogEntryProto>> refs = buffer.pollList(getHeartbeatWaitTimeMs(),
-        EntryWithData::getEntry,
+        EntryWithData::getEntryRef,
         (entry, time, exception) -> LOG.warn("Failed to get " + entry
             + " in " + time.toString(TimeUnit.MILLISECONDS, 3), exception));
     // Release failed entries.

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
@@ -243,7 +243,9 @@ public abstract class LogAppenderBase implements LogAppender {
     final long followerNext = follower.getNextIndex();
     final long halfMs = heartbeatWaitTimeMs/2;
     for (long next = followerNext; leaderNext > next && getHeartbeatWaitTimeMs() - halfMs > 0; ) {
-      if (!buffer.offer(getRaftLog().getEntryWithData(next++))) {
+      EntryWithData entryWithData = getRaftLog().getEntryWithData(next++);
+      if (!buffer.offer(entryWithData)) {
+        entryWithData.release();
         break;
       }
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
@@ -28,7 +28,6 @@ import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.server.raftlog.RaftLog.EntryWithData;
 import org.apache.ratis.server.raftlog.RaftLogIOException;
 import org.apache.ratis.statemachine.SnapshotInfo;
-import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.ratis.util.AwaitForSignal;
 import org.apache.ratis.util.DataQueue;
 import org.apache.ratis.util.JavaUtils;

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
@@ -26,6 +26,7 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLogIOException;
 import org.apache.ratis.server.util.ServerStringUtils;
 import org.apache.ratis.statemachine.SnapshotInfo;
+import org.apache.ratis.util.ReferenceCountedObject;
 import org.apache.ratis.util.Timestamp;
 
 import java.io.IOException;
@@ -58,10 +59,14 @@ class LogAppenderDefault extends LogAppenderBase {
       throws InterruptedException, InterruptedIOException, RaftLogIOException {
     int retry = 0;
 
-    AppendEntriesRequestProto request = newAppendEntriesRequest(CallId.getAndIncrement(), false);
+    ReferenceCountedObject<AppendEntriesRequestProto> request = newAppendEntriesRequest(
+        CallId.getAndIncrement(), false);
     while (isRunning()) { // keep retrying for IOException
       try {
-        if (request == null || request.getEntriesCount() == 0) {
+        if (request == null || request.get().getEntriesCount() == 0) {
+          if (request != null) {
+            request.release();
+          }
           request = newAppendEntriesRequest(CallId.getAndIncrement(), false);
         }
 
@@ -73,14 +78,8 @@ class LogAppenderDefault extends LogAppenderBase {
           return null;
         }
 
-        resetHeartbeatTrigger();
-        final Timestamp sendTime = Timestamp.currentTime();
-        getFollower().updateLastRpcSendTime(request.getEntriesCount() == 0);
-        final AppendEntriesReplyProto r = getServerRpc().appendEntries(request);
-        getFollower().updateLastRpcResponseTime();
-        getFollower().updateLastRespondedAppendEntriesSendTime(sendTime);
-
-        getLeaderState().onFollowerCommitIndex(getFollower(), r.getFollowerCommit());
+        AppendEntriesReplyProto r = sendAppendEntries(request.get());
+        request.release();
         return r;
       } catch (InterruptedIOException | RaftLogIOException e) {
         throw e;
@@ -96,6 +95,18 @@ class LogAppenderDefault extends LogAppenderBase {
       }
     }
     return null;
+  }
+
+  private AppendEntriesReplyProto sendAppendEntries(AppendEntriesRequestProto request) throws IOException {
+    resetHeartbeatTrigger();
+    final Timestamp sendTime = Timestamp.currentTime();
+    getFollower().updateLastRpcSendTime(request.getEntriesCount() == 0);
+    final AppendEntriesReplyProto r = getServerRpc().appendEntries(request);
+    getFollower().updateLastRpcResponseTime();
+    getFollower().updateLastRespondedAppendEntriesSendTime(sendTime);
+
+    getLeaderState().onFollowerCommitIndex(getFollower(), r.getFollowerCommit());
+    return r;
   }
 
   private InstallSnapshotReplyProto installSnapshot(SnapshotInfo snapshot) throws InterruptedIOException {

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
@@ -59,7 +59,7 @@ class LogAppenderDefault extends LogAppenderBase {
       throws InterruptedException, InterruptedIOException, RaftLogIOException {
     int retry = 0;
 
-    ReferenceCountedObject<AppendEntriesRequestProto> request = newAppendEntriesRequest(
+    ReferenceCountedObject<AppendEntriesRequestProto> request = nextAppendEntriesRequest(
         CallId.getAndIncrement(), false);
     while (isRunning()) { // keep retrying for IOException
       try {
@@ -67,7 +67,7 @@ class LogAppenderDefault extends LogAppenderBase {
           if (request != null) {
             request.release();
           }
-          request = newAppendEntriesRequest(CallId.getAndIncrement(), false);
+          request = nextAppendEntriesRequest(CallId.getAndIncrement(), false);
         }
 
         if (request == null) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -440,7 +440,8 @@ public abstract class RaftLogBase implements RaftLog {
     }
 
     @Override
-    public ReferenceCountedObject<LogEntryProto> getEntry(TimeDuration timeout) throws RaftLogIOException, TimeoutException {
+    public ReferenceCountedObject<LogEntryProto> getEntry(TimeDuration timeout)
+        throws RaftLogIOException, TimeoutException {
       if (future == null) {
         return logEntry;
       }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -440,7 +440,7 @@ public abstract class RaftLogBase implements RaftLog {
     }
 
     @Override
-    public ReferenceCountedObject<LogEntryProto> getEntry(TimeDuration timeout)
+    public ReferenceCountedObject<LogEntryProto> getEntryRef(TimeDuration timeout)
         throws RaftLogIOException, TimeoutException {
       if (future == null) {
         return logEntry;

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/memory/MemoryRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/memory/MemoryRaftLog.java
@@ -136,13 +136,7 @@ public class MemoryRaftLog extends RaftLogBase {
 
   @Override
   public EntryWithData getEntryWithData(long index) {
-    // TODO. The reference counted object should be passed to LogAppender RATIS-2026.
-    ReferenceCountedObject<LogEntryProto> ref = retainLog(index);
-    try {
-      return newEntryWithData(ref.get(), null);
-    } finally {
-      ref.release();
-    }
+    return newEntryWithData(retainLog(index), null);
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/memory/MemoryRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/memory/MemoryRaftLog.java
@@ -135,8 +135,14 @@ public class MemoryRaftLog extends RaftLogBase {
   }
 
   @Override
-  public EntryWithData getEntryWithData(long index) {
-    return newEntryWithData(retainLog(index), null);
+  public EntryWithData getEntryWithData(long index) throws RaftLogIOException {
+    throw new UnsupportedOperationException("Use retainEntryWithData(" + index + ") instead.");
+  }
+
+  @Override
+  public ReferenceCountedObject<EntryWithData> retainEntryWithData(long index) {
+    final ReferenceCountedObject<LogEntryProto> ref = retainLog(index);
+    return ref.delegate(newEntryWithData(ref.get(), null));
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

LogAppender must consume log entries as reference counted objects because it keeps the entries for asynchronous processing.


This must include `StateMachine.read` to provide a reference as well. This will be done in RATIS-1979 (see the last comment in the JIRA). 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2026

## How was this patch tested?

CI.
