### PR TITLE
RATIS-2042. Prevent unnecessary updates on FollowerInfoImpl#peer

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftPeer.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftPeer.java
@@ -261,4 +261,14 @@ public final class RaftPeer {
   public int hashCode() {
     return id.hashCode();
   }
+
+  public boolean isSame(RaftPeer other) {
+    return this.id.equals(other.id) &&
+        this.address.equals(other.address) &&
+        this.dataStreamAddress.equals(other.dataStreamAddress) &&
+        this.adminAddress.equals(other.adminAddress) &&
+        this.clientAddress.equals(other.clientAddress) &&
+        this.priority == other.priority &&
+        this.startupRole.equals(other.startupRole);
+  }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftPeer.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftPeer.java
@@ -263,12 +263,12 @@ public final class RaftPeer {
   }
 
   public boolean isSame(RaftPeer other) {
-    return this.id.equals(other.id) &&
-        this.address.equals(other.address) &&
-        this.dataStreamAddress.equals(other.dataStreamAddress) &&
-        this.adminAddress.equals(other.adminAddress) &&
-        this.clientAddress.equals(other.clientAddress) &&
-        this.priority == other.priority &&
-        this.startupRole.equals(other.startupRole);
+    return other != null && priority == other.priority &&
+        Objects.equals(id, other.id) &&
+        Objects.equals(address, other.address) &&
+        Objects.equals(adminAddress, other.adminAddress) &&
+        Objects.equals(clientAddress, other.clientAddress) &&
+        Objects.equals(dataStreamAddress, other.dataStreamAddress) &&
+        startupRole == other.startupRole;
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -32,7 +32,7 @@ import java.util.function.LongUnaryOperator;
 class FollowerInfoImpl implements FollowerInfo {
   private final String name;
 
-  private final AtomicReference<RaftPeer> peer;
+  private final RaftPeerId peerId;
   private final Function<RaftPeerId, RaftPeer> getPeer;
   private final AtomicReference<Timestamp> lastRpcResponseTime;
   private final AtomicReference<Timestamp> lastRpcSendTime;
@@ -47,9 +47,8 @@ class FollowerInfoImpl implements FollowerInfo {
 
   FollowerInfoImpl(RaftGroupMemberId id, RaftPeer peer, Function<RaftPeerId, RaftPeer> getPeer,
       Timestamp lastRpcTime, long nextIndex, boolean caughtUp) {
-    this.name = id + "->" + peer.getId();
-
-    this.peer = new AtomicReference<>(peer);
+    this.peerId = peer.getId();
+    this.name = id + "->" + peerId;
     this.getPeer = getPeer;
     this.lastRpcResponseTime = new AtomicReference<>(lastRpcTime);
     this.lastRpcSendTime = new AtomicReference<>(lastRpcTime);
@@ -183,19 +182,12 @@ class FollowerInfoImpl implements FollowerInfo {
 
   @Override
   public RaftPeerId getId() {
-    return peer.get().getId();
+    return peerId;
   }
 
   @Override
   public RaftPeer getPeer() {
-    final RaftPeer newPeer = getPeer.apply(getId());
-    if (newPeer != null) {
-      RaftPeer curPeer = peer.get();
-      if (!curPeer.isSame(newPeer)) {
-        peer.compareAndSet(peer.get(), newPeer);
-      }
-    }
-    return peer.get();
+    return getPeer.apply(getId());
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -190,11 +190,12 @@ class FollowerInfoImpl implements FollowerInfo {
   public RaftPeer getPeer() {
     final RaftPeer newPeer = getPeer.apply(getId());
     if (newPeer != null) {
-      peer.set(newPeer);
-      return newPeer;
-    } else {
-      return peer.get();
+      RaftPeer curPeer = peer.get();
+      if (!curPeer.isSame(newPeer)) {
+        peer.compareAndSet(peer.get(), newPeer);
+      }
     }
+    return peer.get();
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

FollowerInfoImpl#getPeer() will always update peer now, we should only update it when it's changed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2042

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
