### PR TITLE
RATIS-2043. Change toString() of RaftConfigurationImpl

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
@@ -298,7 +298,7 @@ final class RaftConfigurationImpl implements RaftConfiguration {
 
   @Override
   public String toString() {
-    return logEntryIndex + ": " + conf + ", old=" + oldConf;
+    return "conf: {index: " + logEntryIndex + ", cur=" + conf + ", old=" + oldConf + "}";
   }
 
   boolean hasNoChange(Collection<RaftPeer> newMembers, Collection<RaftPeer> newListeners) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1210,7 +1210,7 @@ class RaftServerImpl implements RaftServer.Division,
 
       if (!conf.isHighestPriority(request.getNewLeader())) {
         String msg = getMemberId() + " refused to transfer leadership to peer " + request.getNewLeader() +
-            " as it does not has highest priority " + conf;
+            " as it does not has highest priority in " + conf;
         return logAndReturnTransferLeadershipFail(request, msg);
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When testing the tranferLeadership feature, I get the following exeption:

```
org.apache.ratis.protocol.exceptions.TransferLeadershipException: s0@group-5B01F2A9DF29 refused to transfer leadership to peer s1 as it does not has highest priority 5: peers:[s0|rpc:localhost:62939|admin:localhost:62940|client:localhost:62941|dataStream:localhost:62942|priority:2|startupRole:FOLLOWER, s1|rpc:localhost:62943|admin:localhost:62944|client:localhost:62945|dataStream:localhost:62946|priority:0|startupRole:FOLLOWER, s2|rpc:localhost:62947|admin:localhost:62948|client:localhost:62949|dataStream:localhost:62950|priority:0|startupRole:FOLLOWER]|listeners:[], old=null
```

The expression of "it does not has highest priority 5" doesn't seem good.

After the change, log becomes as follows:
```
org.apache.ratis.protocol.exceptions.TransferLeadershipException: s0@group-C02BAFD5E173 refused to transfer leadership to peer s1 as it does not has highest priority in conf: {index: 5, cur=peers:[s0|rpc:localhost:63088|admin:localhost:63089|client:localhost:63090|dataStream:localhost:63091|priority:2|startupRole:FOLLOWER, s1|rpc:localhost:63092|admin:localhost:63093|client:localhost:63094|dataStream:localhost:63095|priority:0|startupRole:FOLLOWER, s2|rpc:localhost:63096|admin:localhost:63097|client:localhost:63098|dataStream:localhost:63099|priority:0|startupRole:FOLLOWER]|listeners:[], old=null}
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2043

## How was this patch tested?

No need additional tests.
