### PR TITLE
RATIS-2044. Fix ReadIndex loss caused by data race in AppendEntriesListeners

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -1159,6 +1159,11 @@ class LeaderStateImpl implements LeaderState {
       return CompletableFuture.completedFuture(readIndex);
     }
 
+    if (!isRunning()) {
+      // to eliminate the potential data race on AppendEntriesListeners
+      return JavaUtils.completeExceptionally(server.generateNotLeaderException());
+    }
+
     return listener.getFuture();
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -1159,11 +1159,6 @@ class LeaderStateImpl implements LeaderState {
       return CompletableFuture.completedFuture(readIndex);
     }
 
-    if (!isRunning()) {
-      // to eliminate the potential data race on AppendEntriesListeners
-      return JavaUtils.completeExceptionally(server.generateNotLeaderException());
-    }
-
     return listener.getFuture();
   }
 


### PR DESCRIPTION
# Issue
One linearizable read (read-index based) thread is stuck and never returned. jstack shows
```
"pool-75-IoTDB-ClientRPC-Processor-35$20240317_005430_35720_4.1.0" #14477 prio=5 os_prio=0 tid=0x00007ffafc049800 nid=0x3eb65e waiting on condition [0x00007ff8f5bc6000]
   java.lang.Thread.State: WAITING (parking)
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for  <0x000000031efd8348> (a java.util.concurrent.CompletableFuture$Signaller)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1707)
	at java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3323)
	at java.util.concurrent.CompletableFuture.waitingGet(CompletableFuture.java:1742)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)
	at org.apache.ratis.server.impl.RaftServerImpl.waitForReply(RaftServerImpl.java:1153)
	at org.apache.ratis.server.impl.RaftServerImpl.waitForReply(RaftServerImpl.java:1145)
	at org.apache.ratis.server.impl.RaftServerImpl.submitClientRequest(RaftServerImpl.java:1140)
	at org.apache.ratis.server.impl.RaftServerProxy.submitClientRequest(RaftServerProxy.java:462)
	at org.apache.iotdb.consensus.ratis.utils.Retriable.attempt(Retriable.java:104)
	at org.apache.iotdb.consensus.ratis.RatisConsensus.doRead(RatisConsensus.java:385)
	at org.apache.iotdb.consensus.ratis.RatisConsensus.read(RatisConsensus.java:350)
	at org.apache.iotdb.db.queryengine.execution.executor.RegionReadExecutor.execute(RegionReadExecutor.java:82)
	at org.apache.iotdb.db.queryengine.plan.scheduler.FragmentInstanceDispatcherImpl.dispatchLocally(FragmentInstanceDispatcherImpl.java:413)
	......
```

The read thread is forever stuck because the read-index future is never completed. The future loss is caused by the data race in `AppendEntriesListeners`. Specifically, the leader may add a new AppendEntriesListener [code here](https://github.com/apache/ratis/blob/422cb9d4cb3f6be8e3169797d11a3c2e666c138f/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java#L1154) after the leaderStateImpl already being shutting down [code here](https://github.com/apache/ratis/blob/422cb9d4cb3f6be8e3169797d11a3c2e666c138f/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java#L448). This AppendEntriesListener future then will never be completed.


# How to Solve
We can add `synchronized` to both `addAppendEntriesListener` and `failListeners` methods. 
Or we can simply check the leader running state before the read index returns, as in this patch.

@szetszwo Could you please take a look? What solution do you prefer?

