### PR TITLE
Ratis-2040. Fix RaftPeerId generated by command of "raftMetaConf" to use real PeerId

### DIFF
--- a/ratis-docs/src/site/markdown/cli.md
+++ b/ratis-docs/src/site/markdown/cli.md
@@ -182,5 +182,5 @@ It has the following subcommands:
 ### local raftMetaConf
 Generate a new raft-meta.conf file based on original raft-meta.conf and new peers, which is used to move a raft node to a new node.
 ```
-$ ratis sh local raftMetaConf -peers <P0_Id|P0_HOST:P0_PORT,P1_Id|P1_HOST:P1_PORT,P2_Id|P2_HOST:P2_PORT> -path <PARENT_PATH_OF_RAFT_META_CONF>
+$ ratis sh local raftMetaConf -peers <[P0_Id|]P0_HOST:P0_PORT,[P1_Id]|P1_HOST:P1_PORT,[P2_Id]|P2_HOST:P2_PORT> -path <PARENT_PATH_OF_RAFT_META_CONF>
 ```

--- a/ratis-docs/src/site/markdown/cli.md
+++ b/ratis-docs/src/site/markdown/cli.md
@@ -182,5 +182,5 @@ It has the following subcommands:
 ### local raftMetaConf
 Generate a new raft-meta.conf file based on original raft-meta.conf and new peers, which is used to move a raft node to a new node.
 ```
-$ ratis sh local raftMetaConf -peers <P0_HOST:P0_PORT,P1_HOST:P1_PORT,P2_HOST:P2_PORT> -path <PARENT_PATH_OF_RAFT_META_CONF>
+$ ratis sh local raftMetaConf -peers <P0_Id|P0_HOST:P0_PORT,P1_Id|P1_HOST:P1_PORT,P2_Id|P2_HOST:P2_PORT> -path <PARENT_PATH_OF_RAFT_META_CONF>
 ```

--- a/ratis-docs/src/site/markdown/cli.md
+++ b/ratis-docs/src/site/markdown/cli.md
@@ -182,5 +182,5 @@ It has the following subcommands:
 ### local raftMetaConf
 Generate a new raft-meta.conf file based on original raft-meta.conf and new peers, which is used to move a raft node to a new node.
 ```
-$ ratis sh local raftMetaConf -peers <[P0_Id|]P0_HOST:P0_PORT,[P1_Id]|P1_HOST:P1_PORT,[P2_Id]|P2_HOST:P2_PORT> -path <PARENT_PATH_OF_RAFT_META_CONF>
+$ ratis sh local raftMetaConf -peers <[P0_ID|]P0_HOST:P0_PORT,[P1_ID|]P1_HOST:P1_PORT,[P2_ID|]P2_HOST:P2_PORT> -path <PARENT_PATH_OF_RAFT_META_CONF>
 ```

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/local/RaftMetaConfCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/local/RaftMetaConfCommand.java
@@ -82,11 +82,10 @@ public class RaftMetaConfCommand extends AbstractCommand {
 
       if (peerIdWithAddressArray.length < 1 || peerIdWithAddressArray.length > 2) {
         String message =
-            "Failed to parse peer's Id and address for: %s, " +
+            "Failed to parse peer's ID and address for: %s, " +
                 "from option: -peers %s. \n" +
                 "Please make sure to provide list of peers" +
-                " in format <P0_Id|P0_HOST:P0_PORT,P1_Id|P1_HOST:P1_PORT,P2_Id|P2_HOST:P2_PORT> or " +
-                "<P0_HOST:P0_PORT,P1_HOST:P1_PORT,P2_HOST:P2_PORT>";
+                " in format <[P0_ID|]P0_HOST:P0_PORT,[P1_ID|]P1_HOST:P1_PORT,[P2_ID|]P2_HOST:P2_PORT>";
         printf(message, idWithAddress, peersStr);
         return -1;
       }
@@ -106,7 +105,7 @@ public class RaftMetaConfCommand extends AbstractCommand {
         peerId = RaftPeerId.getRaftPeerId(peerIdWithAddressArray[0]).toString();
 
         if (ids.contains(peerId)) {
-          printf("Found duplicated id: %s. Please make sure the id of peer have no duplicated value.", peerId);
+          printf("Found duplicated ID: %s. Please make sure the ID of peer have no duplicated value.", peerId);
           return -1;
         }
         ids.add(peerId);
@@ -117,7 +116,7 @@ public class RaftMetaConfCommand extends AbstractCommand {
 
       raftPeerProtos.add(RaftPeerProto.newBuilder()
           .setId(ByteString.copyFrom(peerId.getBytes(StandardCharsets.UTF_8)))
-          .setAddress(parseInetSocketAddress(peerIdWithAddressArray[1]).toString())
+          .setAddress(addressString)
           .setStartupRole(RaftPeerRole.FOLLOWER).build());
     }
     try (InputStream in = Files.newInputStream(Paths.get(path, RAFT_META_CONF));
@@ -137,7 +136,7 @@ public class RaftMetaConfCommand extends AbstractCommand {
   @Override
   public String getUsage() {
     return String.format("%s"
-            + " -%s <PEER0_HOST:PEER0_PORT,PEER1_HOST:PEER1_PORT,PEER2_HOST:PEER2_PORT>"
+            + " -%s <[P0_ID|]P0_HOST:P0_PORT,[P1_ID|]P1_HOST:P1_PORT,[P2_ID|]P2_HOST:P2_PORT>"
             + " -%s <PARENT_PATH_OF_RAFT_META_CONF>",
         getCommandName(), PEER_OPTION_NAME, PATH_OPTION_NAME);
   }

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/local/RaftMetaConfCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/local/RaftMetaConfCommand.java
@@ -50,8 +50,6 @@ public class RaftMetaConfCommand extends AbstractCommand {
   private static final String NEW_RAFT_META_CONF = "new-raft-meta.conf";
 
   private static final String SEPARATOR = "\\|";
-
-
   /**
    * @param context command context
    */

--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/local/RaftMetaConfCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/local/RaftMetaConfCommand.java
@@ -24,7 +24,7 @@ import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.proto.RaftProtos.RaftConfigurationProto;
 import org.apache.ratis.proto.RaftProtos.RaftPeerProto;
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
-import org.apache.ratis.shell.cli.RaftUtils;
+import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.shell.cli.sh.command.AbstractCommand;
 import org.apache.ratis.shell.cli.sh.command.Context;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
@@ -49,6 +49,9 @@ public class RaftMetaConfCommand extends AbstractCommand {
   private static final String RAFT_META_CONF = "raft-meta.conf";
   private static final String NEW_RAFT_META_CONF = "new-raft-meta.conf";
 
+  private static final String SEPARATOR = "\\|";
+
+
   /**
    * @param context command context
    */
@@ -70,10 +73,14 @@ public class RaftMetaConfCommand extends AbstractCommand {
       return -1;
     }
     List<RaftPeerProto> raftPeerProtos = new ArrayList<>();
-    for (String address : peersStr.split(",")) {
-      String peerId = RaftUtils.getPeerId(parseInetSocketAddress(address)).toString();
+    for (String idWithAddress : peersStr.split(",")) {
+      String[] peerIdWithAddress = idWithAddress.split(SEPARATOR);
+
+      String peerId = RaftPeerId.getRaftPeerId(peerIdWithAddress[0]).toString();
+
       raftPeerProtos.add(RaftPeerProto.newBuilder()
-          .setId(ByteString.copyFrom(peerId.getBytes(StandardCharsets.UTF_8))).setAddress(address)
+          .setId(ByteString.copyFrom(peerId.getBytes(StandardCharsets.UTF_8)))
+          .setAddress(parseInetSocketAddress(peerIdWithAddress[1]).toString())
           .setStartupRole(RaftPeerRole.FOLLOWER).build());
     }
     try (InputStream in = Files.newInputStream(Paths.get(path, RAFT_META_CONF));

--- a/ratis-test/src/test/java/org/apache/ratis/shell/cli/sh/LocalCommandIntegrationTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/shell/cli/sh/LocalCommandIntegrationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.shell.cli.sh;
+
+import org.apache.ratis.proto.RaftProtos.LogEntryProto;
+import org.apache.ratis.proto.RaftProtos.RaftConfigurationProto;
+import org.apache.ratis.proto.RaftProtos.RaftPeerProto;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class LocalCommandIntegrationTest {
+
+  private static final String RAFT_META_CONF = "raft-meta.conf";
+  private static final String NEW_RAFT_META_CONF = "new-raft-meta.conf";
+
+  @Test
+  public void testRunMethod(@TempDir Path tempDir) throws Exception {
+    int index = 1;
+    generateRaftConf(tempDir.resolve(RAFT_META_CONF), index);
+
+    final StringPrintStream out = new StringPrintStream();
+    RatisShell shell = new RatisShell(out.getPrintStream());
+    String updatedPeersList = "peer1_Id|host1:9872,peer2_id|host2:9872,peer3_id|host3:9872";
+    int ret = shell.run("local", "raftMetaConf", "-peers", updatedPeersList, "-path", tempDir.toString());
+    Assertions.assertEquals(0, ret);
+
+    // verify the contents of the new-raft-meta.conf file
+    long indexFromNewConf;
+    List<RaftPeerProto> peers;
+    try (InputStream in = Files.newInputStream(tempDir.resolve(NEW_RAFT_META_CONF))) {
+      LogEntryProto logEntry = LogEntryProto.newBuilder().mergeFrom(in).build();
+      indexFromNewConf = logEntry.getIndex();
+      peers = logEntry.getConfigurationEntry().getPeersList();
+    }
+
+    Assertions.assertEquals(index + 1, indexFromNewConf);
+
+    StringBuilder sb = new StringBuilder();
+    peers.stream().forEach(peer ->
+        sb.append(peer.getId().toStringUtf8()).append("|").append(peer.getAddress()).append(","));
+    sb.deleteCharAt(sb.length() - 1); // delete trailing comma
+
+    Assertions.assertEquals(updatedPeersList, sb.toString());
+  }
+
+
+  void generateRaftConf(Path path, int index) throws IOException {
+    Map<String, String> map = new HashMap<>();
+    map.put("peer1_Id", "host1:9872");
+    map.put("peer2_Id", "host2:9872");
+    map.put("peer3_Id", "host3:9872");
+    map.put("peer4_Id", "host4:9872");
+    List<RaftProtos.RaftPeerProto> raftPeerProtos = new ArrayList<>();
+    for (Map.Entry<String, String> en : map.entrySet()) {
+      raftPeerProtos.add(RaftPeerProto.newBuilder()
+          .setId(ByteString.copyFrom(en.getKey().getBytes(StandardCharsets.UTF_8))).setAddress(en.getValue())
+          .setStartupRole(RaftPeerRole.FOLLOWER).build());
+    }
+
+    LogEntryProto generateLogEntryProto = LogEntryProto.newBuilder()
+        .setConfigurationEntry(RaftConfigurationProto.newBuilder().addAllPeers(raftPeerProtos).build())
+        .setIndex(index).build();
+    try (OutputStream out = Files.newOutputStream(path)) {
+      generateLogEntryProto.writeTo(out);
+    }
+  }
+
+}

--- a/ratis-test/src/test/java/org/apache/ratis/shell/cli/sh/LocalCommandIntegrationTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/shell/cli/sh/LocalCommandIntegrationTest.java
@@ -48,7 +48,7 @@ public class LocalCommandIntegrationTest {
 
   @Test
   public void testDuplicatedPeerAddresses() throws Exception {
-    String[] duplicatedAddressesList = {"peer1_id1|host1:9872,peer2_id|host2:9872,peer1_id2|host1:9872",
+    String[] duplicatedAddressesList = {"peer1_ID1|host1:9872,peer2_ID|host2:9872,peer1_ID2|host1:9872",
         "host1:9872,host2:9872,host1:9872"};
 
     testDuplicatedPeers(duplicatedAddressesList, "address", "host1:9872");
@@ -56,9 +56,9 @@ public class LocalCommandIntegrationTest {
 
   @Test
   public void testDuplicatedPeerIds() throws Exception {
-    String[] duplicatedIdsList = {"peer1_id1|host1:9872,peer2_id|host2:9872,peer1_id1|host3:9872"};
+    String[] duplicatedIdsList = {"peer1_ID1|host1:9872,peer2_ID|host2:9872,peer1_ID1|host3:9872"};
 
-    testDuplicatedPeers(duplicatedIdsList, "id", "peer1_id1");
+    testDuplicatedPeers(duplicatedIdsList, "ID", "peer1_ID1");
   }
 
   private void testDuplicatedPeers(String[] peersList, String expectedErrorMessagePart, String expectedDuplicatedValue) throws Exception {
@@ -78,7 +78,7 @@ public class LocalCommandIntegrationTest {
     int index = 1;
     generateRaftConf(tempDir.resolve(RAFT_META_CONF), index);
 
-     String[] testPeersListArray = {"peer1_Id|host1:9872,peer2_id|host2:9872,peer3_id|host3:9872",
+     String[] testPeersListArray = {"peer1_ID|host1:9872,peer2_ID|host2:9872,peer3_ID|host3:9872",
       "host1:9872,host2:9872,host3:9872"};
 
     for (String peersListStr : testPeersListArray) {
@@ -116,10 +116,10 @@ public class LocalCommandIntegrationTest {
 
   private void generateRaftConf(Path path, int index) throws IOException {
     Map<String, String> map = new HashMap<>();
-    map.put("peer1_Id", "host1:9872");
-    map.put("peer2_Id", "host2:9872");
-    map.put("peer3_Id", "host3:9872");
-    map.put("peer4_Id", "host4:9872");
+    map.put("peer1_ID", "host1:9872");
+    map.put("peer2_ID", "host2:9872");
+    map.put("peer3_ID", "host3:9872");
+    map.put("peer4_ID", "host4:9872");
     List<RaftPeerProto> raftPeerProtos = new ArrayList<>();
     for (Map.Entry<String, String> en : map.entrySet()) {
       raftPeerProtos.add(RaftPeerProto.newBuilder()

--- a/ratis-test/src/test/java/org/apache/ratis/shell/cli/sh/LocalCommandIntegrationTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/shell/cli/sh/LocalCommandIntegrationTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.shell.cli.sh;
 
+import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.proto.RaftProtos.RaftConfigurationProto;
 import org.apache.ratis.proto.RaftProtos.RaftPeerProto;
@@ -78,7 +79,7 @@ public class LocalCommandIntegrationTest {
     map.put("peer2_Id", "host2:9872");
     map.put("peer3_Id", "host3:9872");
     map.put("peer4_Id", "host4:9872");
-    List<RaftProtos.RaftPeerProto> raftPeerProtos = new ArrayList<>();
+    List<RaftPeerProto> raftPeerProtos = new ArrayList<>();
     for (Map.Entry<String, String> en : map.entrySet()) {
       raftPeerProtos.add(RaftPeerProto.newBuilder()
           .setId(ByteString.copyFrom(en.getKey().getBytes(StandardCharsets.UTF_8))).setAddress(en.getValue())


### PR DESCRIPTION
## What changes were proposed in this pull request?
Originally, the PeerId generated in file new-raft-meta.conf by command 
`$ ratis sh local raftMetaConf -peers <P0_HOST:P0_PORT,P1_HOST:P1_PORT,P2_HOST:P2_PORT> -path <PARENT_PATH_OF_RAFT_META_CONF> `
it uses the address of server as PeerId, which would cause the ratis group to fail to start if there are some duplicated addresses stored in raft-meta.conf.
Thus, need to fix that by using actual PeerId in raft-meta.conf and store back to generated new-raft-meta.conf.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2040

## How was this patch tested?
tested in dev cluster, integration test