### PR TITLE
RATIS-2053. Notify term index change when configuration changes

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
@@ -18,7 +18,7 @@
 
 package org.apache.ratis.statemachine.impl;
 
-import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.proto.RaftProtos.RaftConfigurationProto;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
@@ -132,8 +132,7 @@ public class BaseStateMachine implements StateMachine, StateMachine.DataApi,
   }
 
   @Override
-  public void notifyConfigurationChanged(long term, long index,
-                                         RaftProtos.RaftConfigurationProto newRaftConfiguration) {
+  public void notifyConfigurationChanged(long term, long index, RaftConfigurationProto newRaftConfiguration) {
     // update last applied index for linearizable reads
     notifyTermIndexUpdated(term, index);
   }

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
@@ -18,6 +18,7 @@
 
 package org.apache.ratis.statemachine.impl;
 
+import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
@@ -128,6 +129,13 @@ public class BaseStateMachine implements StateMachine, StateMachine.DataApi,
   @Override
   public void notifyTermIndexUpdated(long term, long index) {
     updateLastAppliedTermIndex(term, index);
+  }
+
+  @Override
+  public void notifyConfigurationChanged(long term, long index,
+                                         RaftProtos.RaftConfigurationProto newRaftConfiguration) {
+    // update last applied index for linearizable reads
+    notifyTermIndexUpdated(term, index);
   }
 
   protected boolean updateLastAppliedTermIndex(long term, long index) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Statemachine will not update LastApplied TermIndex when handling configuration change logs. This will lead problems for linearizable reads here https://github.com/apache/ratis/blob/bc6221b32fff9022cebb02bb243aea9fff35e290/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadRequests.java#L102-L105.

Linearizable read will compare the `apply index` (of state machine instead of RaftServer) with `read index`. So we need to update the state machines' `apply index` when applying configuration logs.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2053
