### PR TITLE
RATIS-2056. Update purge index when snapshot installed

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -142,6 +142,14 @@ public abstract class RaftLogBase implements RaftLog {
     return false;
   }
 
+  protected void updatePurgeIndex(Long purged) {
+    try (AutoCloseableLock writeLock = writeLock()) {
+      if (purged != null) {
+        purgeIndex.updateToMax(purged, infoIndexChange);
+      }
+    }
+  }
+
   protected void updateSnapshotIndexFromStateMachine() {
       updateSnapshotIndex(getSnapshotIndexFromStateMachine.getAsLong());
   }
@@ -340,9 +348,7 @@ public abstract class RaftLogBase implements RaftLog {
     LOG.info("{}: purge {}", getName(), suggestedIndex);
     final long finalSuggestedIndex = suggestedIndex;
     return purgeImpl(suggestedIndex).whenComplete((purged, e) -> {
-      if (purged != null) {
-        purgeIndex.updateToMax(purged, infoIndexChange);
-      }
+      updatePurgeIndex(purged);
       if (e != null) {
         LOG.warn(getName() + ": Failed to purge " + finalSuggestedIndex, e);
       }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -272,7 +272,7 @@ public final class SegmentedRaftLog extends RaftLogBase {
       if (!cache.isEmpty() && cache.getEndIndex() < lastIndexInSnapshot) {
         LOG.warn("End log index {} is smaller than last index in snapshot {}",
             cache.getEndIndex(), lastIndexInSnapshot);
-        purgeImpl(lastIndexInSnapshot);
+        purgeImpl(lastIndexInSnapshot).whenComplete((purged, e) -> updatePurgeIndex(purged));
       }
     }
   }
@@ -557,7 +557,7 @@ public final class SegmentedRaftLog extends RaftLogBase {
         cacheEviction.signal();
       }
     }
-    return purgeImpl(lastSnapshotIndex);
+    return purgeImpl(lastSnapshotIndex).whenComplete((purged, e) -> updatePurgeIndex(purged));
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
```java
java.lang.IllegalStateException: Unexpected gap in segments: binarySearch(5066) returns -1, segments=[log-6057_6058, log-6059_6060]
at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogCache$LogSegmentList.purge(SegmentedRaftLogCache.java:373)
at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogCache.purge(SegmentedRaftLogCache.java:614)
at org.apache.ratis.server.raftlog.segmented.SegmentedRaftLog.purgeImpl(SegmentedRaftLog.java:379)
at org.apache.ratis.server.raftlog.RaftLogBase.purge(RaftLogBase.java:332)
at org.apache.ratis.server.impl.StateMachineUpdater.takeSnapshot(StateMachineUpdater.java:313)
at org.apache.ratis.server.impl.StateMachineUpdater.checkAndTakeSnapshot(StateMachineUpdater.java:275)
at org.apache.ratis.server.impl.StateMachineUpdater.run(StateMachineUpdater.java:192)
at java.base/java.lang.Thread.run(Thread.java:834)
```
1. This server was recently added to the group, with a snapshot (index=6056) installed from the leader.
2. It then applied some new logs and formed log segments log-6057_6058, log-6059_6060.
3. Then the server took a new snapshot with index = 6065.
4. When the server tried to purge logs, its suggest purge index was set to 5066 (6066 - 1000, 1000 is the preserved logs set by server.log.purge.preservation.log.num)
5. The IllegalStateException occurred.

I think `purgeIndex` is not updated after installing a snapshot from leader. Therefore, the purgeGap check passed instead of returning a completed future.
https://github.com/apache/ratis/blob/8638a2ffa802de576aae546c22160da3d9339a8f/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java#L336-L339

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2056
