### PR TITLE
RATIS-2059. Missing reference count when putting log entries to cache on follower

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -457,7 +457,7 @@ public final class SegmentedRaftLog extends RaftLogBase {
       // to statemachine first and then to the cache. Not following the order
       // will leave a spurious entry in the cache.
       final Task write = fileLogWorker.writeLogEntry(entryRef, removedStateMachineData, context);
-      if (stateMachineCachingEnabled) {
+      if (stateMachineCachingEnabled && (removedStateMachineData != entry)) {
         // The stateMachineData will be cached inside the StateMachine itself.
         cache.appendEntry(LogSegment.Op.WRITE_CACHE_WITH_STATE_MACHINE_CACHE,
             ReferenceCountedObject.wrap(removedStateMachineData));


### PR DESCRIPTION
## What changes were proposed in this pull request?

See [RATIS-2059](https://issues.apache.org/jira/browse/RATIS-2059).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2059

## How was this patch tested?

CI.