### PR TITLE
RATIS-2061. Fix setCloseThreshold parameter in RaftServerConfigKeys

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -77,6 +77,11 @@ public interface RaftServerConfigKeys {
     return getTimeDuration(properties.getTimeDuration(SLEEP_DEVIATION_THRESHOLD_DEFAULT.getUnit()),
         SLEEP_DEVIATION_THRESHOLD_KEY, SLEEP_DEVIATION_THRESHOLD_DEFAULT, getDefaultLog());
   }
+  /** @deprecated use {@link #setSleepDeviationThreshold(RaftProperties, TimeDuration)}. */
+  @Deprecated
+  static void setSleepDeviationThreshold(RaftProperties properties, int thresholdMs) {
+    setInt(properties::setInt, SLEEP_DEVIATION_THRESHOLD_KEY, thresholdMs);
+  }
   static void setSleepDeviationThreshold(RaftProperties properties,  TimeDuration threshold) {
     setTimeDuration(properties::setTimeDuration, SLEEP_DEVIATION_THRESHOLD_KEY, threshold);
   }
@@ -86,6 +91,11 @@ public interface RaftServerConfigKeys {
   static TimeDuration closeThreshold(RaftProperties properties) {
     return getTimeDuration(properties.getTimeDuration(CLOSE_THRESHOLD_DEFAULT.getUnit()),
         CLOSE_THRESHOLD_KEY, CLOSE_THRESHOLD_DEFAULT, getDefaultLog());
+  }
+  /** @deprecated use {@link #setCloseThreshold(RaftProperties, TimeDuration)}. */
+  @Deprecated
+  static void setCloseThreshold(RaftProperties properties, int thresholdSec) {
+    setInt(properties::setInt, CLOSE_THRESHOLD_KEY, thresholdSec);
   }
   static void setCloseThreshold(RaftProperties properties, TimeDuration threshold) {
     setTimeDuration(properties::setTimeDuration, CLOSE_THRESHOLD_KEY, threshold);

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -77,8 +77,8 @@ public interface RaftServerConfigKeys {
     return getTimeDuration(properties.getTimeDuration(SLEEP_DEVIATION_THRESHOLD_DEFAULT.getUnit()),
         SLEEP_DEVIATION_THRESHOLD_KEY, SLEEP_DEVIATION_THRESHOLD_DEFAULT, getDefaultLog());
   }
-  static void setSleepDeviationThreshold(RaftProperties properties, int thresholdMs) {
-    setInt(properties::setInt, SLEEP_DEVIATION_THRESHOLD_KEY, thresholdMs);
+  static void setSleepDeviationThreshold(RaftProperties properties,  TimeDuration threshold) {
+    setTimeDuration(properties::setTimeDuration, SLEEP_DEVIATION_THRESHOLD_KEY, threshold);
   }
 
   String CLOSE_THRESHOLD_KEY = PREFIX + ".close.threshold";
@@ -87,8 +87,8 @@ public interface RaftServerConfigKeys {
     return getTimeDuration(properties.getTimeDuration(CLOSE_THRESHOLD_DEFAULT.getUnit()),
         CLOSE_THRESHOLD_KEY, CLOSE_THRESHOLD_DEFAULT, getDefaultLog());
   }
-  static void setCloseThreshold(RaftProperties properties, int thresholdMs) {
-    setInt(properties::setInt, CLOSE_THRESHOLD_KEY, thresholdMs);
+  static void setCloseThreshold(RaftProperties properties, TimeDuration threshold) {
+    setTimeDuration(properties::setTimeDuration, CLOSE_THRESHOLD_KEY, threshold);
   }
 
   /**

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -82,7 +82,7 @@ public interface RaftServerConfigKeys {
   static void setSleepDeviationThreshold(RaftProperties properties, int thresholdMs) {
     setInt(properties::setInt, SLEEP_DEVIATION_THRESHOLD_KEY, thresholdMs);
   }
-  static void setSleepDeviationThreshold(RaftProperties properties,  TimeDuration threshold) {
+  static void setSleepDeviationThreshold(RaftProperties properties, TimeDuration threshold) {
     setTimeDuration(properties::setTimeDuration, SLEEP_DEVIATION_THRESHOLD_KEY, threshold);
   }
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

1. parameter `int thresholdMs` in `RaftServerConfigKeys#setCloseThreshold` is misrepresented as milliseconds while the correct unit is seconds. So fix the unit to TimeDuration.
2. Also fix `setSleepDeviationThreshold` parameter unit to TimeDuration.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2061

## How was this patch tested?

manual tests : It passes the parameter verification in ozone project.

