### PR TITLE
RATIS-2066. RaftServerProxy supports close callback

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -263,12 +263,16 @@ public interface StateMachine extends Closeable {
     default void notifySnapshotInstalled(InstallSnapshotResult result, long snapshotIndex,  RaftPeer peer) {}
 
     /**
-     * Notify the {@link StateMachine} that a raft server has step down.
+     * Notify the {@link StateMachine} that the server for this division has been shut down.
+     * @Deprecated please use/override {@link #notifyServerShutdown(RoleInfoProto, boolean)} instead
      */
-    default void notifyServerShutdown(RoleInfoProto roleInfo) {}
+    @Deprecated
+    default void notifyServerShutdown(RoleInfoProto roleInfo) {
+      notifyServerShutdown(roleInfo, false);
+    }
 
     /**
-     * Notify the {@link StateMachine} that a raft server has been shutdown down.
+     * Notify the {@link StateMachine} that either the server for this division or all the servers have been shut down.
      * @param roleInfo roleInfo this server
      * @param allServer whether all raft servers will be shutdown at this time
      */

--- a/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -266,6 +266,13 @@ public interface StateMachine extends Closeable {
      * Notify the {@link StateMachine} that a raft server has step down.
      */
     default void notifyServerShutdown(RoleInfoProto roleInfo) {}
+
+    /**
+     * Notify the {@link StateMachine} that a raft server has been shutdown down.
+     * @param roleInfo roleInfo this server
+     * @param allServer whether all raft servers will be shutdown at this time
+     */
+    default void notifyServerShutdown(RoleInfoProto roleInfo, boolean allServer) {}
   }
 
   /**

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -334,7 +334,7 @@ class LeaderElection implements Runnable {
         case NOT_IN_CONF:
         case SHUTDOWN:
           server.close();
-          server.getStateMachine().event().notifyServerShutdown(server.getRoleInfoProto());
+          server.getStateMachine().event().notifyServerShutdown(server.getRoleInfoProto(), false);
           return false;
         case TIMEOUT:
           return false; // should retry

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -138,6 +138,7 @@ class RaftServerProxy implements RaftServer {
       } catch (Throwable t) {
         LOG.warn("{}: Failed to close the division for {}", getId(), groupId, t);
       }
+      impl.getStateMachine().event().notifyServerShutdown(impl.getRoleInfoProto(), true);
     }
 
     synchronized List<RaftGroupId> getGroupIds() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently there is no way for application to get notified once the RaftServerProxy is close.

This task is to add a close callback support to RaftServerProxy. 

Motivated by HDDS-10749. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2066

## How was this patch tested?
integration test with Ozone. 

