### PR TITLE
RATIS-2069. RaftMetaConf command sets incorrect peerAddress pattern.

### DIFF
--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/local/RaftMetaConfCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/local/RaftMetaConfCommand.java
@@ -91,7 +91,7 @@ public class RaftMetaConfCommand extends AbstractCommand {
       }
       InetSocketAddress inetSocketAddress = parseInetSocketAddress(
           peerIdWithAddressArray[peerIdWithAddressArray.length - 1]);
-      String addressString = inetSocketAddress.toString();
+      String addressString = inetSocketAddress.getHostString() + ":" + inetSocketAddress.getPort();
       if (addresses.contains(addressString)) {
         printf("Found duplicated address: %s. Please make sure the address of peer have no duplicated value.",
             addressString);

--- a/ratis-test/src/test/java/org/apache/ratis/shell/cli/sh/LocalCommandIntegrationTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/shell/cli/sh/LocalCommandIntegrationTest.java
@@ -78,11 +78,11 @@ public class LocalCommandIntegrationTest {
     int index = 1;
     generateRaftConf(tempDir.resolve(RAFT_META_CONF), index);
 
-     String[] testPeersListArray = {"peer1_ID|host1:9872,peer2_ID|host2:9872,peer3_ID|host3:9872",
+     String[] testPeersListArray = {"peer1_ID|localhost:9872,peer2_ID|host2:9872,peer3_ID|host3:9872",
       "host1:9872,host2:9872,host3:9872"};
 
     for (String peersListStr : testPeersListArray) {
-      generateRaftConf(tempDir, index);
+      generateRaftConf(tempDir.resolve(RAFT_META_CONF), index);
       StringPrintStream out = new StringPrintStream();
       RatisShell shell = new RatisShell(out.getPrintStream());
       int ret = shell.run("local", "raftMetaConf", "-peers", peersListStr, "-path", tempDir.toString());
@@ -98,6 +98,11 @@ public class LocalCommandIntegrationTest {
       }
 
       Assertions.assertEquals(index + 1, indexFromNewConf);
+
+      String addressRegex = "^[a-zA-Z0-9.-]+:\\d+$";
+      Pattern pattern = Pattern.compile(addressRegex);
+      peers.forEach(p -> Assertions.assertTrue(
+          pattern.matcher(p.getAddress()).matches()));
 
       String peersListStrFromNewMetaConf;
       if (containsPeerId(peersListStr)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
[RATIS-2040](https://issues.apache.org/jira/browse/RATIS-2040) made some changes in the command to add an option to provide peerID. While doing so , it updated the address string to be of pattern "hostname/ip:port" which was previously hostname:port. This PR sets it back to "host:port" pattern.

This causes connectionRefused messages in the application as the wrong address string is used.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2069

## How was this patch tested?
Unit test added
