### PR TITLE
RATIS-2070. Skip push build for dependabot

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -14,8 +14,12 @@
 # limitations under the License.
 name: build-branch
 on:
-  - push
-  - pull_request
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    tags:
+      - '**'
+  pull_request:
 env:
   WITH_COVERAGE: true
 jobs:


### PR DESCRIPTION
## What changes were proposed in this pull request?

dependabot pushes dependency version bumps to the main repo instead of its own fork. It then creates a pull request without waiting for the push workflow to succeed. Thus both workflows test the same state of code, which is unnecessary.

Example: [PR](https://github.com/apache/ratis/pull/1076), [push workflow](https://github.com/apache/ratis/actions/runs/8944621294/job/24571916137?pr=1076), [PR workflow](https://github.com/apache/ratis/actions/runs/8944621510/job/24571916496?pr=1076).

With this change, checks will not be triggered by `push` to branches prefixed with `dependabot/`, which matches dependabot naming convention.  PR checks will still be run.

https://issues.apache.org/jira/browse/RATIS-2070

## How was this patch tested?

Pushed the same commit in my fork to:

- branch [`RATIS-2070`](https://github.com/adoroszlai/ratis/tree/RATIS-2070), workflow [executed](https://github.com/adoroszlai/ratis/actions/runs/8949606196)
- branch [`dependabot/test/branch`](https://github.com/adoroszlai/ratis/tree/dependabot/test/branch), workflow skipped
- tag [`test-RATIS-2070`](https://github.com/adoroszlai/ratis/tree/test-RATIS-2070), workflow [executed](https://github.com/adoroszlai/ratis/actions/runs/8949604547)