### PR TITLE
RATIS-2073. Enable Surefire process checkers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
     <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
     <maven-clover2-plugin.version>4.0.6</maven-clover2-plugin.version>
     <maven-pdf-plugin.version>1.6.1</maven-pdf-plugin.version>
-    <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <wagon-ssh.version>3.5.3</wagon-ssh.version>
 
 
@@ -634,6 +634,7 @@
             <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
             <reuseForks>false</reuseForks>
             <trimStackTrace>false</trimStackTrace>
+            <enableProcessChecker>all</enableProcessChecker>
             <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
             <!-- @argLine is filled by jacoco maven plugin. @{} means late evaluation -->
             <argLine>-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError @{argLine}</argLine>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ratis build sets Surefire fork timeout to 10 minutes:

https://github.com/apache/ratis/blob/58671923e78a10d5c6a7d49a06e2d95690d5e9bb/pom.xml#L637

Yet, sometimes Surefire fork is not killed, check runs until Github workflow is cancelled:

```
Tue, 12 Mar 2024 19:43:11 GMT [INFO] Running org.apache.ratis.netty.TestRaftWithNetty
Wed, 13 Mar 2024 01:40:25 GMT Error: The operation was canceled.
```

The problem is that:

> Since 3.0.0-M4 the process checkers are disabled. ([doc](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#enableProcessChecker))

Changes in this PR (and links to similar change in Ozone):

1. Enable process checkers to apply the fork timeout ([HDDS-10174](https://issues.apache.org/jira/browse/HDDS-10174))
2. Downgrade to Surefire 3.0.0-M4 due to: [SUREFIRE-1722](https://issues.apache.org/jira/browse/SUREFIRE-1722) (affects M6 and newer), [SUREFIRE-1815](https://issues.apache.org/jira/browse/SUREFIRE-1815) (affects M5) ([HDDS-10522](https://issues.apache.org/jira/browse/HDDS-10522))

https://issues.apache.org/jira/browse/RATIS-2073

## How was this patch tested?

Created a small repro to test various Surefire versions, see https://github.com/apache/ozone/pull/6075 for details.

Regular CI:
https://github.com/adoroszlai/ratis/actions/runs/8972109715