### PR TITLE
RATIS-2077. Timedout StateMachine retainRead is released twice

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
@@ -271,14 +271,11 @@ public abstract class LogAppenderBase implements LogAppender {
       return null;
     }
 
+    final List<LogEntryProto> protos;
     try {
-      final List<LogEntryProto> protos = buffer.pollList(getHeartbeatWaitTimeMs(), EntryWithData::getEntry,
-          (entry, time, exception) -> LOG.warn("Failed to get " + entry
-              + " in " + time.toString(TimeUnit.MILLISECONDS, 3), exception));
-      assertProtos(protos, followerNext, previous, snapshotIndex);
-      AppendEntriesRequestProto appendEntriesProto =
-          leaderState.newAppendEntriesRequestProto(follower, protos, previous, callId);
-      return ReferenceCountedObject.delegateFrom(offered.values(), appendEntriesProto);
+      protos = buffer.pollList(getHeartbeatWaitTimeMs(), EntryWithData::getEntry,
+          (entry, time, exception) -> LOG.warn("Failed to get {} in {}",
+              entry, time.toString(TimeUnit.MILLISECONDS, 3), exception));
     } finally {
       for (EntryWithData entry : buffer) {
         // Release remaining entries.
@@ -286,6 +283,10 @@ public abstract class LogAppenderBase implements LogAppender {
       }
       buffer.clear();
     }
+    assertProtos(protos, followerNext, previous, snapshotIndex);
+    AppendEntriesRequestProto appendEntriesProto =
+        leaderState.newAppendEntriesRequestProto(follower, protos, previous, callId);
+    return ReferenceCountedObject.delegateFrom(offered.values(), appendEntriesProto);
   }
 
   private void assertProtos(List<LogEntryProto> protos, long nextIndex, TermIndex previous, long snapshotIndex) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -500,13 +500,11 @@ public abstract class RaftLogBase implements RaftLog {
         if (timeout.compareTo(stateMachineDataReadTimeout) > 0) {
           getRaftLogMetrics().onStateMachineDataReadTimeout();
         }
-        discardData();
         throw t;
       } catch (Exception e) {
         if (e instanceof InterruptedException) {
           Thread.currentThread().interrupt();
         }
-        discardData();
         final String err = getName() + ": Failed readStateMachineData for " + this;
         LOG.error(err, e);
         throw new RaftLogIOException(err, JavaUtils.unwrapCompletionException(e));
@@ -516,18 +514,9 @@ public abstract class RaftLogBase implements RaftLog {
       if (LogProtoUtils.isStateMachineDataEmpty(entryProto)) {
         final String err = getName() + ": State machine data not set for " + this;
         LOG.error(err);
-        data.release();
         throw new RaftLogIOException(err);
       }
       return entryProto;
-    }
-
-    private void discardData() {
-      future.whenComplete((r, ex) -> {
-        if (r != null) {
-          r.release();
-        }
-      });
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

When getEntry gets timed out, the StateMachine reference count is released twice.
We should not release the reference inside getEntry.

See RATIS-2077.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2077

## How was this patch tested?

CI
