### PR TITLE
RATIS-2085. Compile Ratis with JDK 17/21 in CI

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -91,7 +91,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Run a full build
-        run: ./dev-support/checks/build.sh
+        run: ./dev-support/checks/build.sh -Djavac.version=${{ matrix.java }}
   rat:
     name: rat
     runs-on: ubuntu-20.04

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 11, 17, 21 ]
       fail-fast: false
     steps:
       - name: Download source tarball


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Java 17 and 21 to the _compile_ check's matrix as a basic smoketest of compatibility.

Match `javac.version` with JDK (see HDDS-7633 for a possible issue).

https://issues.apache.org/jira/browse/RATIS-2085

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis/actions/runs/9032668282