### PR TITLE
RATIS-2086. Autolink Ozone issues in PRs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,7 +24,9 @@ github:
     squash:  true
     merge:   false
     rebase:  false
-  autolink_jira: RATIS
+  autolink_jira:
+    - HDDS
+    - RATIS
 
 notifications:
   commits:      commits@ratis.apache.org


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ratis PR descriptions sometimes reference Ozone Jira issues. It would be nice to automatically link these, similar to how it is already done for RATIS.

https://issues.apache.org/jira/browse/RATIS-2086

## How was this patch tested?

Ozone has similar config:
https://github.com/apache/ozone/blob/6487de7defc87f6456e986100de07620f88b1015/.asf.yaml#L25-L29