### PR TITLE
RATIS-2087. Remove workaround for GitHub reverse DNS issue

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -143,11 +143,6 @@ jobs:
           - misc
       fail-fast: false
     steps:
-        # TEMPORARY WHILE GITHUB FIXES https://github.com/actions/virtual-environments/issues/3185
-        - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
-          run: |
-            echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-        # REMOVE CODE ABOVE WHEN ISSUE IS ADDRESSED!
         - name: Checkout project
           uses: actions/checkout@v4
         - name: Cache for maven dependencies


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the temporary workaround added in RATIS-1361.

https://issues.apache.org/jira/browse/RATIS-2087

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis/actions/runs/9033512372