### PR TITLE
RATIS-2084. Follower reply ALREADY_INSTALLED when install old snapshots from leader

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ConfigurationManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ConfigurationManager.java
@@ -26,7 +26,6 @@ import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.StringUtils;
 
 import java.util.*;
-import java.util.function.LongSupplier;
 
 /**
  * Maintain the mappings between log index and corresponding raft configuration.

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ConfigurationManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ConfigurationManager.java
@@ -26,6 +26,8 @@ import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.StringUtils;
 
 import java.util.*;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 /**
  * Maintain the mappings between log index and corresponding raft configuration.
@@ -61,10 +63,10 @@ public class ConfigurationManager {
     }
   }
 
-  synchronized void addConfiguration(RaftConfiguration conf, long commitIndex) {
+  synchronized void addConfiguration(RaftConfiguration conf, LongSupplier commitIndex) {
     final long logIndex = conf.getLogEntryIndex();
     final RaftConfiguration found = configurations.get(logIndex);
-    if (found != null && logIndex <= commitIndex) {
+    if (found != null && logIndex <= commitIndex.getAsLong()) {
       Preconditions.assertTrue(found.equals(conf));
       return;
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ConfigurationManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ConfigurationManager.java
@@ -61,10 +61,10 @@ public class ConfigurationManager {
     }
   }
 
-  synchronized void addConfiguration(RaftConfiguration conf) {
+  synchronized void addConfiguration(RaftConfiguration conf, long commitIndex) {
     final long logIndex = conf.getLogEntryIndex();
     final RaftConfiguration found = configurations.get(logIndex);
-    if (found != null) {
+    if (found != null && logIndex <= commitIndex) {
       Preconditions.assertTrue(found.equals(conf));
       return;
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ConfigurationManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ConfigurationManager.java
@@ -27,7 +27,6 @@ import org.apache.ratis.util.StringUtils;
 
 import java.util.*;
 import java.util.function.LongSupplier;
-import java.util.function.Supplier;
 
 /**
  * Maintain the mappings between log index and corresponding raft configuration.
@@ -63,10 +62,10 @@ public class ConfigurationManager {
     }
   }
 
-  synchronized void addConfiguration(RaftConfiguration conf, LongSupplier commitIndex) {
+  synchronized void addConfiguration(RaftConfiguration conf, long commitIndex) {
     final long logIndex = conf.getLogEntryIndex();
     final RaftConfiguration found = configurations.get(logIndex);
-    if (found != null && logIndex <= commitIndex.getAsLong()) {
+    if (found != null && logIndex <= commitIndex) {
       Preconditions.assertTrue(found.equals(conf));
       return;
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ConfigurationManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ConfigurationManager.java
@@ -61,10 +61,10 @@ public class ConfigurationManager {
     }
   }
 
-  synchronized void addConfiguration(RaftConfiguration conf, long commitIndex) {
+  synchronized void addConfiguration(RaftConfiguration conf) {
     final long logIndex = conf.getLogEntryIndex();
     final RaftConfiguration found = configurations.get(logIndex);
-    if (found != null && logIndex <= commitIndex) {
+    if (found != null) {
       Preconditions.assertTrue(found.equals(conf));
       return;
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1853,6 +1853,7 @@ class RaftServerImpl implements RaftServer.Division,
   void notifyTruncatedLogEntry(LogEntryProto logEntry) {
     if (logEntry.hasStateMachineLogEntry()) {
       getTransactionManager().remove(TermIndex.valueOf(logEntry));
+      getState().truncate(logEntry.getIndex());
 
       final ClientInvocationId invocationId = ClientInvocationId.valueOf(logEntry.getStateMachineLogEntry());
       final CacheEntry cacheEntry = getRetryCache().getIfPresent(invocationId);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1851,9 +1851,9 @@ class RaftServerImpl implements RaftServer.Division,
    * @param logEntry the log entry being truncated
    */
   void notifyTruncatedLogEntry(LogEntryProto logEntry) {
+    Optional.ofNullable(getState()).ifPresent(s -> s.truncate(logEntry.getIndex()));
     if (logEntry.hasStateMachineLogEntry()) {
       getTransactionManager().remove(TermIndex.valueOf(logEntry));
-      Optional.ofNullable(getState()).ifPresent(s -> s.truncate(logEntry.getIndex()));
 
       final ClientInvocationId invocationId = ClientInvocationId.valueOf(logEntry.getStateMachineLogEntry());
       final CacheEntry cacheEntry = getRetryCache().getIfPresent(invocationId);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1853,7 +1853,7 @@ class RaftServerImpl implements RaftServer.Division,
   void notifyTruncatedLogEntry(LogEntryProto logEntry) {
     if (logEntry.hasStateMachineLogEntry()) {
       getTransactionManager().remove(TermIndex.valueOf(logEntry));
-      getState().truncate(logEntry.getIndex());
+      Optional.ofNullable(getState()).ifPresent(s -> s.truncate(logEntry.getIndex()));
 
       final ClientInvocationId invocationId = ClientInvocationId.valueOf(logEntry.getStateMachineLogEntry());
       final CacheEntry cacheEntry = getRetryCache().getIfPresent(invocationId);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -377,7 +377,7 @@ class ServerState {
   }
 
   void setRaftConf(RaftConfiguration conf) {
-    final long lastCommittedIndex = conf.getLogEntryIndex() > 0 ?
+    final long lastCommittedIndex = server.getState().log.isInitialized() ?
         server.getRaftLog().getLastCommittedIndex() : RaftLog.INVALID_LOG_INDEX;
     configurationManager.addConfiguration(conf, lastCommittedIndex);
     server.getServerRpc().addRaftPeers(conf.getAllPeers());

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -377,7 +377,7 @@ class ServerState {
   }
 
   void setRaftConf(RaftConfiguration conf) {
-    configurationManager.addConfiguration(conf, server.getRaftLog().getLastCommittedIndex());
+    configurationManager.addConfiguration(conf, () -> server.getRaftLog().getLastCommittedIndex());
     server.getServerRpc().addRaftPeers(conf.getAllPeers());
     final Collection<RaftPeer> listeners = conf.getAllPeers(RaftPeerRole.LISTENER);
     if (!listeners.isEmpty()) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -377,7 +377,7 @@ class ServerState {
   }
 
   void setRaftConf(RaftConfiguration conf) {
-    configurationManager.addConfiguration(conf);
+    configurationManager.addConfiguration(conf, server.getRaftLog().getLastCommittedIndex());
     server.getServerRpc().addRaftPeers(conf.getAllPeers());
     final Collection<RaftPeer> listeners = conf.getAllPeers(RaftPeerRole.LISTENER);
     if (!listeners.isEmpty()) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -377,9 +377,7 @@ class ServerState {
   }
 
   void setRaftConf(RaftConfiguration conf) {
-    final long lastCommittedIndex = server.getState().log.isInitialized() ?
-        server.getRaftLog().getLastCommittedIndex() : RaftLog.INVALID_LOG_INDEX;
-    configurationManager.addConfiguration(conf, lastCommittedIndex);
+    configurationManager.addConfiguration(conf);
     server.getServerRpc().addRaftPeers(conf.getAllPeers());
     final Collection<RaftPeer> listeners = conf.getAllPeers(RaftPeerRole.LISTENER);
     if (!listeners.isEmpty()) {
@@ -387,6 +385,10 @@ class ServerState {
     }
     LOG.info("{}: set configuration {}", getMemberId(), conf);
     LOG.trace("{}: {}", getMemberId(), configurationManager);
+  }
+
+  void truncate(long logIndex) {
+    configurationManager.removeConfigurations(logIndex);
   }
 
   void updateConfiguration(List<LogEntryProto> entries) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -377,7 +377,9 @@ class ServerState {
   }
 
   void setRaftConf(RaftConfiguration conf) {
-    configurationManager.addConfiguration(conf, () -> server.getRaftLog().getLastCommittedIndex());
+    final long lastCommittedIndex = conf.getLogEntryIndex() > 0 ?
+        server.getRaftLog().getLastCommittedIndex() : RaftLog.INVALID_LOG_INDEX;
+    configurationManager.addConfiguration(conf, lastCommittedIndex);
     server.getServerRpc().addRaftPeers(conf.getAllPeers());
     final Collection<RaftPeer> listeners = conf.getAllPeers(RaftPeerRole.LISTENER);
     if (!listeners.isEmpty()) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -133,6 +133,7 @@ class SnapshotInstallationHandler {
       if (request.hasLastRaftConfigurationLogEntryProto()) {
         // Set the configuration included in the snapshot
         final LogEntryProto proto = request.getLastRaftConfigurationLogEntryProto();
+        state.truncate(proto.getIndex());
         if (!state.getRaftConf().equals(LogProtoUtils.toRaftConfiguration(proto))) {
           LOG.info("{}: set new configuration {} from snapshot", getMemberId(), proto);
           state.setRaftConf(proto);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -175,9 +175,10 @@ class SnapshotInstallationHandler {
         // Check and append the snapshot chunk. We simply put this in lock
         // considering a follower peer requiring a snapshot installation does not
         // have a lot of requests
-        Preconditions.assertTrue(state.getLog().getLastCommittedIndex() < lastIncludedIndex,
-            "%s log's commit index is %s, last included index in snapshot is %s",
-            getMemberId(), state.getLog().getLastCommittedIndex(), lastIncludedIndex);
+        if (state.getLog().getLastCommittedIndex() >= lastIncludedIndex) {
+          return toInstallSnapshotReplyProto(leaderId, getMemberId(),
+              currentTerm, snapshotChunkRequest.getRequestIndex(), InstallSnapshotResult.ALREADY_INSTALLED);
+        }
 
         //TODO: We should only update State with installed snapshot once the request is done.
         state.installSnapshot(request);

--- a/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
@@ -513,6 +513,20 @@ public interface RaftTestUtil {
     Thread.sleep(3 * maxTimeout.toLong(TimeUnit.MILLISECONDS));
   }
 
+  static void isolate(MiniRaftCluster cluster, RaftPeerId id) {
+    try {
+      BlockRequestHandlingInjection.getInstance().blockReplier(id.toString());
+      cluster.setBlockRequestsFrom(id.toString(), true);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  static void deIsolate(MiniRaftCluster cluster, RaftPeerId id) {
+    BlockRequestHandlingInjection.getInstance().unblockReplier(id.toString());
+    cluster.setBlockRequestsFrom(id.toString(), false);
+  }
+
   static Thread sendMessageInNewThread(MiniRaftCluster cluster, RaftPeerId leaderId, SimpleMessage... messages) {
     Thread t = new Thread(() -> {
       try (final RaftClient client = cluster.createClient(leaderId)) {

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -122,12 +122,12 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
     final TimeDuration maxTimeout = RaftServerConfigKeys.Rpc.timeoutMax(getProperties());
     final RaftServer.Division leader = waitForLeader(cluster);
     try {
-      isolate(cluster, leader.getId());
+      RaftTestUtil.isolate(cluster, leader.getId());
       maxTimeout.sleep();
       maxTimeout.sleep();
       RaftServerTestUtil.assertLostMajorityHeartbeatsRecently(leader);
     } finally {
-      deIsolate(cluster, leader.getId());
+      RaftTestUtil.deIsolate(cluster, leader.getId());
     }
   }
 
@@ -164,12 +164,12 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
     final RaftServer.Division listener = cluster.getListeners().get(0);
     final RaftPeerId listenerId = listener.getId();
     try {
-      isolate(cluster, listenerId);
+      RaftTestUtil.isolate(cluster, listenerId);
       maxTimeout.sleep();
       maxTimeout.sleep();
       Assertions.assertEquals(RaftProtos.RaftPeerRole.LISTENER, listener.getInfo().getCurrentRole());
     } finally {
-      deIsolate(cluster, listener.getId());
+      RaftTestUtil.deIsolate(cluster, listener.getId());
     }
   }
 
@@ -247,7 +247,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         RaftServer.Division newLeader = followers.get(0);
 
         // isolate new leader, so that transfer leadership will timeout
-        isolate(cluster, newLeader.getId());
+        RaftTestUtil.isolate(cluster, newLeader.getId());
 
         List<RaftPeer> peers = cluster.getPeers();
 
@@ -287,7 +287,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         Assertions.assertEquals(leader.getId().toString(), reply.getReplierId());
         Assertions.assertTrue(reply.isSuccess());
 
-        deIsolate(cluster, newLeader.getId());
+        RaftTestUtil.deIsolate(cluster, newLeader.getId());
       }
 
       cluster.shutdown();
@@ -364,30 +364,16 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
       try (RaftClient client = cluster.createClient(leader.getId())) {
         client.io().send(new RaftTestUtil.SimpleMessage("message"));
         Thread.sleep(1000);
-        isolate(cluster, leader.getId());
+        RaftTestUtil.isolate(cluster, leader.getId());
         RaftClientReply reply = client.io().send(new RaftTestUtil.SimpleMessage("message"));
         Assertions.assertNotEquals(reply.getReplierId(), leader.getId().toString());
         Assertions.assertTrue(reply.isSuccess());
       } finally {
-        deIsolate(cluster, leader.getId());
+        RaftTestUtil.deIsolate(cluster, leader.getId());
       }
 
       cluster.shutdown();
     }
-  }
-
-  private void isolate(MiniRaftCluster cluster, RaftPeerId id) {
-    try {
-      BlockRequestHandlingInjection.getInstance().blockReplier(id.toString());
-      cluster.setBlockRequestsFrom(id.toString(), true);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-  }
-
-  private void deIsolate(MiniRaftCluster cluster, RaftPeerId id) {
-    BlockRequestHandlingInjection.getInstance().unblockReplier(id.toString());
-    cluster.setBlockRequestsFrom(id.toString(), false);
   }
 
   @Test
@@ -570,7 +556,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         assertEquals(followers.size(), 2);
 
         RaftServer.Division follower = followers.get(0);
-        isolate(cluster, follower.getId());
+        RaftTestUtil.isolate(cluster, follower.getId());
         // send message so that the isolated follower's log lag the others
         RaftClientReply reply = client.io().send(new RaftTestUtil.SimpleMessage("message"));
         Assertions.assertTrue(reply.isSuccess());
@@ -578,7 +564,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         final long savedTerm = leader.getInfo().getCurrentTerm();
         LOG.info("Wait follower {} timeout and trigger pre-vote", follower.getId());
         Thread.sleep(2000);
-        deIsolate(cluster, follower.getId());
+        RaftTestUtil.deIsolate(cluster, follower.getId());
         Thread.sleep(2000);
         // with pre-vote leader will not step down
         RaftServer.Division newleader = waitForLeader(cluster);
@@ -668,14 +654,14 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
       Assertions.assertTrue(leader.getInfo().isLeaderReady());
       RaftServerTestUtil.assertLeaderLease(leader, true);
 
-      isolate(cluster, leader.getId());
+      RaftTestUtil.isolate(cluster, leader.getId());
       Thread.sleep(leaseTimeoutMs);
 
       Assertions.assertTrue(leader.getInfo().isLeader());
       Assertions.assertTrue(leader.getInfo().isLeaderReady());
       RaftServerTestUtil.assertLeaderLease(leader, false);
     } finally {
-      deIsolate(cluster, leader.getId());
+      RaftTestUtil.deIsolate(cluster, leader.getId());
     }
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLeaderInstallSnapshot.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLeaderInstallSnapshot.java
@@ -46,4 +46,10 @@ implements MiniRaftClusterWithGrpc.FactoryGet {
         super.testSeparateSnapshotInstallPath();
     }
 
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testInstallSnapshotLeaderSwitch(Boolean separateHeartbeat) throws Exception {
+        GrpcConfigKeys.Server.setHeartbeatChannel(getProperties(), separateHeartbeat);
+        super.testInstallSnapshotLeaderSwitch();
+    }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Follower reply ALREADY_INSTALLED when install old snapshots from leader.
2. Configuration Manager now will replace the original conf with new conf if they share the same (uncommitted) index.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/projects/RATIS/issues/RATIS-2084?filter=allopenissues

## How was this patch tested?
New unit tests. Before the patch the IllegalStateException can be 100% reproduced in the unit test.
<img width="1622" alt="image" src="https://github.com/apache/ratis/assets/48054931/8bf74f55-8662-486a-b66b-cf1b1abd32bd">

