### PR TITLE
RATIS-2090. Bump ratis-thirdparty to 1.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <maven.min.version>3.3.9</maven.min.version>
 
     <!-- Contains all shaded thirdparty dependencies -->
-    <ratis.thirdparty.version>1.0.5</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.6</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
     <shaded.protobuf.version>3.24.4</shaded.protobuf.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump `ratis-thirdparty` to 1.0.6.

https://issues.apache.org/jira/browse/RATIS-2090

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis/actions/runs/9077754904