### PR TITLE
RATIS-2100. The `closeFuture` never completed while closing from the `NEW` state

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDaemon.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDaemon.java
@@ -108,8 +108,11 @@ class LogAppenderDaemon {
   };
 
   public CompletableFuture<State> tryToClose() {
-    if (lifeCycle.transition(TRY_TO_CLOSE) == CLOSING) {
+    State state = lifeCycle.transition(TRY_TO_CLOSE);
+    if (state == CLOSING) {
       daemon.interrupt();
+    } else if (state == CLOSED) {
+      closeFuture.complete(state);
     }
     return closeFuture;
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDaemon.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDaemon.java
@@ -108,7 +108,7 @@ class LogAppenderDaemon {
   };
 
   public CompletableFuture<State> tryToClose() {
-    State state = lifeCycle.transition(TRY_TO_CLOSE);
+    final State state = lifeCycle.transition(TRY_TO_CLOSE);
     if (state == CLOSING) {
       daemon.interrupt();
     } else if (state == CLOSED) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the closeFuture only completes after the LogAppenderDaemon has started. However, when closing from the NEW state, the transition is NEW -> CLOSED, and the LogAppenderDaemon was not started.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2100

## How was this patch tested?
