### PR TITLE
RATIS-2101. Move TermIndex.PRIVATE_CACHE to Util.CACHE

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/TermIndex.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/TermIndex.java
@@ -29,11 +29,14 @@ import java.util.concurrent.TimeUnit;
 
 /** The term and the log index defined in the Raft consensus algorithm. */
 public interface TermIndex extends Comparable<TermIndex> {
-  /** An LRU Cache for {@link TermIndex} instances */
-  Cache<TermIndex, TermIndex> PRIVATE_CACHE = CacheBuilder.newBuilder()
-      .maximumSize(1 << 16)
-      .expireAfterAccess(1, TimeUnit.MINUTES)
-      .build();
+  class Util {
+    /** An LRU Cache for {@link TermIndex} instances */
+    private static final Cache<TermIndex, TermIndex> CACHE = CacheBuilder.newBuilder()
+          .maximumSize(1 << 16)
+          .expireAfterAccess(1, TimeUnit.MINUTES)
+          .build();
+  }
+  TermIndex[] EMPTY_ARRAY = {};
 
   /** @return the term. */
   long getTerm();
@@ -107,7 +110,7 @@ public interface TermIndex extends Comparable<TermIndex> {
       }
     };
     try {
-      return PRIVATE_CACHE.get(key, () -> key);
+      return Util.CACHE.get(key, () -> key);
     } catch (ExecutionException e) {
       throw new IllegalStateException("Failed to valueOf(" + term + ", " + index + "), key=" + key, e);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

See [RATIS-2101](https://issues.apache.org/jira/browse/RATIS-2101).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2101

## How was this patch tested?

No additional tests needed.
