### PR TITLE
RATIS-2102. AsyncApi#send() is not handling retry and reply correctly for replication levels higher than MAJORITY

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -832,20 +832,14 @@ class RaftServerImpl implements RaftServer.Division,
       leaderState.notifySenders();
     }
 
-    final CompletableFuture<RaftClientReply> future = pending.getFuture();
-    if (request.is(TypeCase.WRITE)) {
-      // check replication
-      final ReplicationLevel replication = request.getType().getWrite().getReplication();
-      if (replication != ReplicationLevel.MAJORITY) {
-        return future.thenCompose(reply -> waitForReplication(reply, replication));
-      }
-    }
-
-    return future;
+    return pending.getFuture();
   }
 
   /** Wait until the given replication requirement is satisfied. */
   private CompletableFuture<RaftClientReply> waitForReplication(RaftClientReply reply, ReplicationLevel replication) {
+    if (!reply.isSuccess()) {
+      return CompletableFuture.completedFuture(reply);
+    }
     final RaftClientRequest.Type type = RaftClientRequest.watchRequestType(reply.getLogIndex(), replication);
     final RaftClientRequest watch = RaftClientRequest.newBuilder()
         .setServerId(reply.getServerId())
@@ -854,7 +848,24 @@ class RaftServerImpl implements RaftServer.Division,
         .setCallId(reply.getCallId())
         .setType(type)
         .build();
-    return watchAsync(watch).thenApply(r -> reply);
+    return watchAsync(watch).thenApply(watchReply -> combineReplies(reply, watchReply));
+  }
+
+  private RaftClientReply combineReplies(RaftClientReply reply, RaftClientReply watchReply) {
+    final RaftClientReply combinedReply = RaftClientReply.newBuilder()
+        .setServerId(getMemberId())
+        // from write reply
+        .setClientId(reply.getClientId())
+        .setCallId(reply.getCallId())
+        .setMessage(reply.getMessage())
+        .setLogIndex(reply.getLogIndex())
+        // from watchReply
+        .setSuccess(watchReply.isSuccess())
+        .setException(watchReply.getException())
+        .setCommitInfos(watchReply.getCommitInfos())
+        .build();
+    LOG.debug("combinedReply={}", combinedReply);
+    return combinedReply;
   }
 
   void stepDownOnJvmPause() {
@@ -934,6 +945,19 @@ class RaftServerImpl implements RaftServer.Division,
   }
 
   private CompletableFuture<RaftClientReply> writeAsync(ReferenceCountedObject<RaftClientRequest> requestRef) {
+    final RaftClientRequest request = requestRef.get();
+    final CompletableFuture<RaftClientReply> future = writeAsyncImpl(requestRef);
+    if (request.is(TypeCase.WRITE)) {
+      // check replication
+      final ReplicationLevel replication = request.getType().getWrite().getReplication();
+      if (replication != ReplicationLevel.MAJORITY) {
+        return future.thenCompose(r -> waitForReplication(r, replication));
+      }
+    }
+    return future;
+  }
+
+  private CompletableFuture<RaftClientReply> writeAsyncImpl(ReferenceCountedObject<RaftClientRequest> requestRef) {
     final RaftClientRequest request = requestRef.get();
     final CompletableFuture<RaftClientReply> reply = checkLeaderState(request);
     if (reply != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Background: [RATIS-1994](https://issues.apache.org/jira/browse/RATIS-1994) adds a feature allowing `AsyncApi#send()` to return only when a specified replication level is reached. This was done by adding `waitForReplication()` in RaftServer.

However, two bugs are found with [RATIS-1994](https://issues.apache.org/jira/browse/RATIS-1994) when the (write) replication level is set to higher than `MAJORITY` (the default):

1. When the request is retried (e.g. when timed out), the future retrieved from cache is not correctly waited on with `waitForReplication()` again. This causes divergence in the desired behavior depending on if the request is retried or not. This is fixed by invoking waitForReplication() in `writeAsync()` rather than `appendTransaction()`.

2. `waitForReplication()`'s watch request reply was incorrectly ignored, this is fixed by combining the reply from write and watch together using `combineReplies()`.

Thanks @szetszwo for the help during debugging and making the patch.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2102

## How was this patch tested?

- Tested manually during HDDS-10108 dev. Maybe it is a good idea to add some test cases around this in Ratis.