### PR TITLE
RATIS-2089. Add CommitInfoProto in NotReplicatedException

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
@@ -398,7 +398,7 @@ public interface ClientProtoUtils {
       e = new NotLeaderException(serverMemberId, suggestedLeader, peers);
     } else if (replyProto.getExceptionDetailsCase() == NOTREPLICATEDEXCEPTION) {
       final NotReplicatedExceptionProto nre = replyProto.getNotReplicatedException();
-      e = new NotReplicatedException(nre.getCallId(), nre.getReplication(), nre.getLogIndex());
+      e = new NotReplicatedException(nre.getCallId(), nre.getReplication(), nre.getLogIndex(), replyProto.getCommitInfosList());
     } else if (replyProto.getExceptionDetailsCase().equals(STATEMACHINEEXCEPTION)) {
       e = toStateMachineException(serverMemberId, replyProto.getStateMachineException());
     } else if (replyProto.getExceptionDetailsCase().equals(DATASTREAMEXCEPTION)) {

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
@@ -398,7 +398,8 @@ public interface ClientProtoUtils {
       e = new NotLeaderException(serverMemberId, suggestedLeader, peers);
     } else if (replyProto.getExceptionDetailsCase() == NOTREPLICATEDEXCEPTION) {
       final NotReplicatedExceptionProto nre = replyProto.getNotReplicatedException();
-      e = new NotReplicatedException(nre.getCallId(), nre.getReplication(), nre.getLogIndex(), replyProto.getCommitInfosList());
+      e = new NotReplicatedException(nre.getCallId(), nre.getReplication(), nre.getLogIndex(),
+          replyProto.getCommitInfosList());
     } else if (replyProto.getExceptionDetailsCase().equals(STATEMACHINEEXCEPTION)) {
       e = toStateMachineException(serverMemberId, replyProto.getStateMachineException());
     } else if (replyProto.getExceptionDetailsCase().equals(DATASTREAMEXCEPTION)) {

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/NotReplicatedException.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/NotReplicatedException.java
@@ -17,12 +17,17 @@
  */
 package org.apache.ratis.protocol.exceptions;
 
+import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
 import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
+
+import java.util.Collection;
 
 public class NotReplicatedException extends RaftException {
   private final long callId;
   private final ReplicationLevel requiredReplication;
   private final long logIndex;
+  /** This is only populated on client-side based from the commitInfos in RaftClientReply */
+  private Collection<CommitInfoProto> commitInfos;
 
   public NotReplicatedException(long callId, ReplicationLevel requiredReplication, long logIndex) {
     super("Request with call Id " + callId + " and log index " + logIndex
@@ -30,6 +35,12 @@ public class NotReplicatedException extends RaftException {
     this.callId = callId;
     this.requiredReplication = requiredReplication;
     this.logIndex = logIndex;
+  }
+
+  public NotReplicatedException(long callId, ReplicationLevel requiredReplication, long logIndex,
+                                Collection<CommitInfoProto> commitInfos) {
+    this(callId, requiredReplication, logIndex);
+    this.commitInfos = commitInfos;
   }
 
   public long getCallId() {
@@ -42,5 +53,9 @@ public class NotReplicatedException extends RaftException {
 
   public long getLogIndex() {
     return logIndex;
+  }
+
+  public Collection<CommitInfoProto> getCommitInfos() {
+    return commitInfos;
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/NotReplicatedException.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/NotReplicatedException.java
@@ -26,7 +26,7 @@ public class NotReplicatedException extends RaftException {
   private final long callId;
   private final ReplicationLevel requiredReplication;
   private final long logIndex;
-  /** This is only populated on client-side based from the commitInfos in RaftClientReply */
+  /** This is only populated on client-side since RaftClientReply already has commitInfos */
   private Collection<CommitInfoProto> commitInfos;
 
   public NotReplicatedException(long callId, ReplicationLevel requiredReplication, long logIndex) {

--- a/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
@@ -559,5 +559,6 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
     Assert.assertNotNull(nre);
     Assert.assertEquals(logIndex, nre.getLogIndex());
     Assert.assertEquals(replication, nre.getRequiredReplication());
+    Assert.assertNotNull((nre.getCommitInfos()));
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
@@ -559,6 +559,6 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
     Assert.assertNotNull(nre);
     Assert.assertEquals(logIndex, nre.getLogIndex());
     Assert.assertEquals(replication, nre.getRequiredReplication());
-    Assert.assertNotNull((nre.getCommitInfos()));
+    Assert.assertNotNull(nre.getCommitInfos());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Ozone's XceiverClientRatis#watchForCommit, there are two watch commits request with different ReplicationLevel

1. Watch for ALL_COMMITTED 
2. Watch for MAJORITY_COMMITTED (If the previous watch threw an exception)

Based on the second watch request, the client will remove some failed datanode UUID from the commitInfoMap.

The second watch might not be necessary since the entries in AbstractCommitWatcher.commitIndexMap implies that the PutBlock request has been committed to the majority of the servers. Therefore, another MAJORITY_COMMITTED watch might not be necessary. From my understanding, the second MAJORITY_COMMITTED only serves to gain information to remove entries from commitInfoMap.

If the first watch failed with NotReplicatedException, we might be able to remove the need to a second watch request. Since NotReplicatedException is a Raft server exception, we can include the CommitInfoProtos in the NotReplicatedException. The client can use this CommitInfoProtos to remove the entry from commitInfoMap without sending another WATCH request. 

This CommitInfoProto is returned for every RaftClientReply (RaftClientReply.commitInfos), but if there is an exception, it seems the RaftClientReply is not accessible to the client.

However, if the exception is a client exception (e.g. due to Raft client watch timeout configuration), the client might have no choice but to send another watch request.

So in this patch, I propose to include CommitInfoProto into NotReplicatedException. 

This only introduces a client-side change by reusing the commitInfos in RaftClientReply.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2089

## How was this patch tested?

Add a unit test to ensure commitInfoProto is not null during NotReplicateException.