### PR TITLE
RATIS-2094. Avoid corruptions from TransactionContext's stateMachineLogEntry and stateMachineContext.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * A reference-counted object can be retained for later use
@@ -150,6 +151,10 @@ public interface ReferenceCountedObject<T> {
         return delegated.release();
       }
     };
+  }
+
+  default <V> ReferenceCountedObject<V> map(Function<T, V> mapper) {
+    return delegate(mapper.apply(get()));
   }
 
   /**

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
@@ -153,8 +153,11 @@ public interface ReferenceCountedObject<T> {
     };
   }
 
-  default <V> ReferenceCountedObject<V> map(Function<T, V> mapper) {
-    return delegate(mapper.apply(get()));
+  /**
+   * @return a {@link ReferenceCountedObject} by apply the given function to this object.
+   */
+  default <V> ReferenceCountedObject<V> apply(Function<T, V> function) {
+    return delegate(function.apply(get()));
   }
 
   /**

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
@@ -115,11 +115,12 @@ public class FileStoreStateMachine extends BaseStateMachine {
 
   @Override
   public TransactionContext startTransaction(LogEntryProto entry, RaftProtos.RaftPeerRole role) {
+    ByteString copied = ByteString.copyFrom(entry.getStateMachineLogEntry().getLogData().asReadOnlyByteBuffer());
     return TransactionContext.newBuilder()
         .setStateMachine(this)
         .setLogEntry(entry)
         .setServerRole(role)
-        .setStateMachineContext(getProto(entry))
+        .setStateMachineContext(getProto(copied))
         .build();
   }
 
@@ -147,14 +148,14 @@ public class FileStoreStateMachine extends BaseStateMachine {
         return proto;
       }
     }
-    return getProto(entry);
+    return getProto(entry.getStateMachineLogEntry().getLogData());
   }
 
-  static FileStoreRequestProto getProto(LogEntryProto entry) {
+  static FileStoreRequestProto getProto(ByteString bytes) {
     try {
-      return FileStoreRequestProto.parseFrom(entry.getStateMachineLogEntry().getLogData());
+      return FileStoreRequestProto.parseFrom(bytes);
     } catch (InvalidProtocolBufferException e) {
-      throw new IllegalArgumentException("Failed to parse data, entry=" + entry, e);
+      throw new IllegalArgumentException("Failed to parse data", e);
     }
   }
 

--- a/ratis-server-api/src/main/java/org/apache/ratis/statemachine/TransactionContext.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/statemachine/TransactionContext.java
@@ -60,8 +60,8 @@ public interface TransactionContext {
   /**
    * Returns the data from the {@link StateMachine}
    * @return the data from the {@link StateMachine}
-   * @deprecated access StateMachineLogEntry via @{@link TransactionContext#getLogEntryRef()} or
-   * @{@link TransactionContext#getLogEntryUnsafe}
+   * @deprecated access StateMachineLogEntry via {@link TransactionContext#getLogEntryRef()} or
+   * {@link TransactionContext#getLogEntryUnsafe()}
    */
   @Deprecated
   StateMachineLogEntryProto getStateMachineLogEntry();

--- a/ratis-server-api/src/main/java/org/apache/ratis/statemachine/TransactionContext.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/statemachine/TransactionContext.java
@@ -60,7 +60,10 @@ public interface TransactionContext {
   /**
    * Returns the data from the {@link StateMachine}
    * @return the data from the {@link StateMachine}
+   * @deprecated access StateMachineLogEntry via @{@link TransactionContext#getLogEntryRef()} or
+   * @{@link TransactionContext#getLogEntryUnsafe}
    */
+  @Deprecated
   StateMachineLogEntryProto getStateMachineLogEntry();
 
   /** Set exception in case of failure. */

--- a/ratis-test/src/test/java/org/apache/ratis/statemachine/TestStateMachine.java
+++ b/ratis-test/src/test/java/org/apache/ratis/statemachine/TestStateMachine.java
@@ -92,7 +92,7 @@ public class TestStateMachine extends BaseTest implements MiniRaftClusterWithSim
     public CompletableFuture<Message> applyTransaction(TransactionContext trx) {
       try {
         assertNotNull(trx.getLogEntryUnsafe());
-        assertNotNull(trx.getStateMachineLogEntry());
+        assertNotNull(trx.getLogEntryUnsafe().getStateMachineLogEntry());
         Object context = trx.getStateMachineContext();
         if (isLeader.get()) {
           assertNotNull(trx.getClientRequest());


### PR DESCRIPTION

## What changes were proposed in this pull request?

As discuss in RATIS-2094, the usage of TransactionContext's `getStateMachineLogEntry` and `getStateMachineContext` may cause corruptions when zero-copy is enabled.
1. For stateMachineContext, when TransactionContext is created from `startTransaction(LogEntryProto)`, the `stateMachineContext` should  not be created/parsed directly from the LogEntryProto's content (as it would directly refer to the zero-copy buffer without reference count). We should copy `logData` to create this context object. The change in `FileStoreStateMachine` demonstrate this.
2. For `stateMachineLogEntry`, it should be used internally in TransactionContextImpl to form the LogEntryProto. Any subsequent access to `stateMachineLogEntry` should happen via the logEntry, aka via `TransactionContext.getLogEntryRef`. Hence, the API `getStateMachineContext` is deprecated. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2094

## How was this patch tested?

CI
