### PR TITLE
RATIS-2106. Add configuration reference for RaftClient

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/RaftClientConfigKeys.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/RaftClientConfigKeys.java
@@ -42,7 +42,7 @@ public interface RaftClientConfigKeys {
     String PREFIX = RaftClientConfigKeys.PREFIX + ".rpc";
 
     String REQUEST_TIMEOUT_KEY = PREFIX + ".request.timeout";
-    TimeDuration REQUEST_TIMEOUT_DEFAULT = TimeDuration.valueOf(3000, TimeUnit.MILLISECONDS);
+    TimeDuration REQUEST_TIMEOUT_DEFAULT = TimeDuration.valueOf(3, TimeUnit.SECONDS);
     static TimeDuration requestTimeout(RaftProperties properties) {
       return getTimeDuration(properties.getTimeDuration(REQUEST_TIMEOUT_DEFAULT.getUnit()),
           REQUEST_TIMEOUT_KEY, REQUEST_TIMEOUT_DEFAULT, getDefaultLog());
@@ -52,8 +52,7 @@ public interface RaftClientConfigKeys {
     }
 
     String WATCH_REQUEST_TIMEOUT_KEY = PREFIX + ".watch.request.timeout";
-    TimeDuration WATCH_REQUEST_TIMEOUT_DEFAULT =
-        TimeDuration.valueOf(10000, TimeUnit.MILLISECONDS);
+    TimeDuration WATCH_REQUEST_TIMEOUT_DEFAULT = TimeDuration.valueOf(10, TimeUnit.SECONDS);
     static TimeDuration watchRequestTimeout(RaftProperties properties) {
       return getTimeDuration(properties.getTimeDuration(WATCH_REQUEST_TIMEOUT_DEFAULT.getUnit()),
           WATCH_REQUEST_TIMEOUT_KEY, WATCH_REQUEST_TIMEOUT_DEFAULT, getDefaultLog());
@@ -125,7 +124,7 @@ public interface RaftClientConfigKeys {
     }
 
     String REQUEST_TIMEOUT_KEY = PREFIX + ".request.timeout";
-    TimeDuration REQUEST_TIMEOUT_DEFAULT = TimeDuration.valueOf(10000, TimeUnit.MILLISECONDS);
+    TimeDuration REQUEST_TIMEOUT_DEFAULT = TimeDuration.valueOf(10, TimeUnit.SECONDS);
     static TimeDuration requestTimeout(RaftProperties properties) {
       return getTimeDuration(properties.getTimeDuration(REQUEST_TIMEOUT_DEFAULT.getUnit()),
           REQUEST_TIMEOUT_KEY, REQUEST_TIMEOUT_DEFAULT, getDefaultLog());

--- a/ratis-docs/src/site/markdown/configurations.md
+++ b/ratis-docs/src/site/markdown/configurations.md
@@ -676,3 +676,72 @@ For examples,
 
 - Note also that adding 1 new member to an 1-member group is always allowed,
   although it is a majority-add.
+
+
+## Client Configurations
+
+Client configurations are located at `RaftClientConfigKeys`.
+
+### RPC - Configurations related to Client RPC timeout.
+
+| **Property**    | `raft.client.rpc.request.timeout` |
+|:----------------|:----------------------------------|
+| **Description** | timeout for AppendEntries RPC     |
+| **Type**        | TimeDuration                      |
+| **Default**     | 3000ms                            |
+
+| **Property**    | `raft.client.rpc.watch.request.timeout`      |
+|:----------------|:---------------------------------------------|
+| **Description** | timeout for watch request on the client side |
+| **Type**        | TimeDuration                                 |
+| **Default**     | 10000ms                                      |
+
+### Async - Configurations related to async requests.
+
+| **Property**    | `raft.client.async.outstanding-requests.max` |
+|:----------------|:---------------------------------------------|
+| **Description** | maximum number of outstanding async requests |
+| **Type**        | int                                          |
+| **Default**     | 100                                          |
+
+#### Experimental - Configurations related to experimental features.
+
+| **Property**    | `raft.client.async.experimental.send-dummy-request`    |
+|:----------------|:-------------------------------------------------------|
+| **Description** | send a dummy watch request to establish the connection |
+| **Type**        | boolean                                                |
+| **Default**     | true                                                   |
+
+### DataStream - Configurations related to DataStream Api.
+
+| **Property**    | `raft.client.data-stream.outstanding-requests.max` |
+|:----------------|:---------------------------------------------------|
+| **Description** | maximum number of outstanding data stream requests |
+| **Type**        | int                                                |
+| **Default**     | 100                                                |
+
+| **Property**    | `raft.client.data-stream.flush.request.count.min`                |
+|:----------------|:-----------------------------------------------------------------|
+| **Description** | minimum number of requests before data stream flush would happen |
+| **Type**        | int                                                              |
+| **Default**     | 0                                                                |
+
+| **Property**    | `raft.client.data-stream.flush.request.bytes.min`             |
+|:----------------|:--------------------------------------------------------------|
+| **Description** | minimum number of bytes before data stream flush would happen |
+| **Type**        | SizeInBytes                                                   |
+| **Default**     | 1MB                                                           |
+
+| **Property**    | `raft.client.data-stream.request.timeout` |
+|:----------------|:------------------------------------------|
+| **Description** | timeout for data stream request           |
+| **Type**        | TimeDuration                              |
+| **Default**     | 10000ms                                   |
+
+### MessageStream - Configurations related to MessageStream Api.
+
+| **Property**    | `raft.client.message-stream.submessage-size` |
+|:----------------|:---------------------------------------------|
+| **Description** | maximum size of a sub message                |
+| **Type**        | SizeInBytes                                  |
+| **Default**     | 1MB                                          |

--- a/ratis-docs/src/site/markdown/configurations.md
+++ b/ratis-docs/src/site/markdown/configurations.md
@@ -684,17 +684,17 @@ Client configurations are located at `RaftClientConfigKeys`.
 
 ### RPC - Configurations related to Client RPC timeout.
 
-| **Property**    | `raft.client.rpc.request.timeout` |
-|:----------------|:----------------------------------|
-| **Description** | timeout for AppendEntries RPC     |
-| **Type**        | TimeDuration                      |
-| **Default**     | 3000ms                            |
+| **Property**    | `raft.client.rpc.request.timeout`         |
+|:----------------|:------------------------------------------|
+| **Description** | client side timeout for sending a request |
+| **Type**        | TimeDuration                              |
+| **Default**     | 3s                                        |
 
-| **Property**    | `raft.client.rpc.watch.request.timeout`      |
-|:----------------|:---------------------------------------------|
-| **Description** | timeout for watch request on the client side |
-| **Type**        | TimeDuration                                 |
-| **Default**     | 10000ms                                      |
+| **Property**    | `raft.client.rpc.watch.request.timeout`         |
+|:----------------|:------------------------------------------------|
+| **Description** | client side timeout for sending a watch request |
+| **Type**        | TimeDuration                                    |
+| **Default**     | 10s                                             |
 
 ### Async - Configurations related to async requests.
 
@@ -703,14 +703,6 @@ Client configurations are located at `RaftClientConfigKeys`.
 | **Description** | maximum number of outstanding async requests |
 | **Type**        | int                                          |
 | **Default**     | 100                                          |
-
-#### Experimental - Configurations related to experimental features.
-
-| **Property**    | `raft.client.async.experimental.send-dummy-request`    |
-|:----------------|:-------------------------------------------------------|
-| **Description** | send a dummy watch request to establish the connection |
-| **Type**        | boolean                                                |
-| **Default**     | true                                                   |
 
 ### DataStream - Configurations related to DataStream Api.
 
@@ -736,7 +728,7 @@ Client configurations are located at `RaftClientConfigKeys`.
 |:----------------|:------------------------------------------|
 | **Description** | timeout for data stream request           |
 | **Type**        | TimeDuration                              |
-| **Default**     | 10000ms                                   |
+| **Default**     | 10s                                       |
 
 ### MessageStream - Configurations related to MessageStream Api.
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add config doc for `RaftClient`. Like what RATIS-1732 did for `RaftServer`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2106

## How was this patch tested?

- n/a