### PR TITLE
RATIS-2104. Double shutdown in TestLeaderInstallSnapshot.

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
@@ -95,45 +95,41 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
   }
 
   private void testMultiFileInstallSnapshot(CLUSTER cluster) throws Exception {
-    try {
-      int i = 0;
-      RaftTestUtil.waitForLeader(cluster);
-      final RaftPeerId leaderId = cluster.getLeader().getId();
+    int i = 0;
+    RaftTestUtil.waitForLeader(cluster);
+    final RaftPeerId leaderId = cluster.getLeader().getId();
 
-      try (final RaftClient client = cluster.createClient(leaderId)) {
-        for (; i < SNAPSHOT_TRIGGER_THRESHOLD * 2 - 1; i++) {
-          RaftClientReply
-              reply = client.io().send(new RaftTestUtil.SimpleMessage("m" + i));
-          Assertions.assertTrue(reply.isSuccess());
-        }
-
-        client.getSnapshotManagementApi(leaderId).create(3000);
+    try (final RaftClient client = cluster.createClient(leaderId)) {
+      for (; i < SNAPSHOT_TRIGGER_THRESHOLD * 2 - 1; i++) {
+        RaftClientReply
+            reply = client.io().send(new RaftTestUtil.SimpleMessage("m" + i));
+        Assertions.assertTrue(reply.isSuccess());
       }
 
-      final SnapshotInfo snapshot = cluster.getLeader().getStateMachine().getLatestSnapshot();
-      Assertions.assertEquals(3, snapshot.getFiles().size());
-
-      // add two more peers
-      final MiniRaftCluster.PeerChanges change = cluster.addNewPeers(2, true,
-          true);
-      // trigger setConfiguration
-      cluster.setConfiguration(change.allPeersInNewConf);
-
-      RaftServerTestUtil
-          .waitAndCheckNewConf(cluster, change.allPeersInNewConf, 0, null);
-
-      // Check the installed snapshot file number on each Follower matches with the
-      // leader snapshot.
-      JavaUtils.attempt(() -> {
-        for (RaftServer.Division follower : cluster.getFollowers()) {
-          final SnapshotInfo info = follower.getStateMachine().getLatestSnapshot();
-          Assertions.assertNotNull(info);
-          Assertions.assertEquals(3, info.getFiles().size());
-        }
-      }, 10, ONE_SECOND, "check snapshot", LOG);
-    } finally {
-      cluster.shutdown();
+      client.getSnapshotManagementApi(leaderId).create(3000);
     }
+
+    final SnapshotInfo snapshot = cluster.getLeader().getStateMachine().getLatestSnapshot();
+    Assertions.assertEquals(3, snapshot.getFiles().size());
+
+    // add two more peers
+    final MiniRaftCluster.PeerChanges change = cluster.addNewPeers(2, true,
+        true);
+    // trigger setConfiguration
+    cluster.setConfiguration(change.allPeersInNewConf);
+
+    RaftServerTestUtil
+        .waitAndCheckNewConf(cluster, change.allPeersInNewConf, 0, null);
+
+    // Check the installed snapshot file number on each Follower matches with the
+    // leader snapshot.
+    JavaUtils.attempt(() -> {
+      for (RaftServer.Division follower : cluster.getFollowers()) {
+        final SnapshotInfo info = follower.getStateMachine().getLatestSnapshot();
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals(3, info.getFiles().size());
+      }
+    }, 10, ONE_SECOND, "check snapshot", LOG);
   }
 
   private void testInstallSnapshotDuringLeaderSwitch(CLUSTER cluster) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestLeaderInstallSnapshot.testInstallSnapshotLeaderSwitch` calls `cluster.shutdown` twice (one in the test method and another in `runWithNewCluster`).  The second shutdown seems to create weird problems with leak detection. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2104

## How was this patch tested?

Run the test 30 times and all green.