### PR TITLE
RATIS-2109. RaftLogBase#updateCommitIndex should return true only if commitIndex is increased

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -127,15 +127,13 @@ public abstract class RaftLogBase implements RaftLog {
       final long newCommitIndex = Math.min(majorityIndex, getFlushIndex());
       if (oldCommittedIndex < newCommitIndex) {
         if (!isLeader) {
-          commitIndex.updateIncreasingly(newCommitIndex, traceIndexChange);
-          return true;
+          return commitIndex.updateIncreasingly(newCommitIndex, traceIndexChange);
         }
 
         // Only update last committed index for current term. See §5.4.2 in paper for details.
         final TermIndex entry = getTermIndex(newCommitIndex);
         if (entry != null && entry.getTerm() == currentTerm) {
-          commitIndex.updateIncreasingly(newCommitIndex, traceIndexChange);
-          return true;
+          return commitIndex.updateIncreasingly(newCommitIndex, traceIndexChange);
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

RaftLogBase#updateCommitIndex returns true regardless whether commit index is actually increased (RaftLogIndex#updateIncreasingly returns true). This can cause unnecessary StateMachineUpdater notification

We can change it so that RaftLogBase#updateCommitIndex only returns true if commit index is actually increased. 

Note: For leader ServerState#updateCommitIndex is called only if there are entries to commit (i.e. majority > oldLasCommitted), so RaftLogBase#updateCommitIndex should increase the commit index of leader.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2109

## How was this patch tested?

Existing tests.