### PR TITLE
RATIS-2110. Publish SBOM artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,7 @@
 
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
     <copy-rename-maven-plugin.version>1.0</copy-rename-maven-plugin.version>
+    <cyclonedx.version>2.8.0</cyclonedx.version>
 
     <spotbugs.version>4.2.1</spotbugs.version>
     <spotbugs-plugin.version>4.2.0</spotbugs-plugin.version>
@@ -724,6 +725,11 @@
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${jacoco.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>${cyclonedx.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -1051,6 +1057,18 @@
                 <id>check-licenses</id>
                 <goals>
                   <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>makeAggregateBom</goal>
                 </goals>
               </execution>
             </executions>

--- a/ratis-assembly/src/main/assembly/bin.xml
+++ b/ratis-assembly/src/main/assembly/bin.xml
@@ -63,6 +63,16 @@
       </includes>
       <fileMode>0644</fileMode>
     </fileSet>
+    <!-- aggregate BOM from root module -->
+    <fileSet>
+      <directory>${project.basedir}/../target</directory>
+      <outputDirectory>.</outputDirectory>
+      <includes>
+        <include>bom.json</include>
+        <include>bom.xml</include>
+      </includes>
+      <fileMode>0644</fileMode>
+    </fileSet>
     <fileSet>
       <directory>${project.basedir}/../ratis-docs/target/classes/docs
       </directory>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create and publish Software Bill of Materials (SBOM) for Ratis.

https://cwiki.apache.org/confluence/display/SECURITY/Software+Bill+of+Materials+SBOM

https://issues.apache.org/jira/browse/RATIS-2110

## How was this patch tested?

```
$ mvn -DskipTests -Prelease clean package
...
[INFO] --- cyclonedx-maven-plugin:2.8.0:makeAggregateBom (default) @ ratis ---
[INFO] CycloneDX: Resolving Aggregated Dependencies
[INFO] CycloneDX: Creating BOM version 1.5 with 30 component(s)
[INFO] CycloneDX: Writing and validating BOM (XML): target/bom.xml
[INFO]            attaching as ratis-3.1.0-SNAPSHOT-cyclonedx.xml
[INFO] CycloneDX: Writing and validating BOM (JSON): target/bom.json
[INFO]            attaching as ratis-3.1.0-SNAPSHOT-cyclonedx.json
...

$ tar tzvf ratis-assembly/target/apache-ratis-3.1.0-SNAPSHOT-bin.tar.gz | grep bom
-rw-r--r-- root/root     59288 2023-11-19 15:23 apache-ratis-3.1.0-SNAPSHOT-bin/bom.json
-rw-r--r-- root/root     55180 2023-11-19 15:23 apache-ratis-3.1.0-SNAPSHOT-bin/bom.xml
```

CI:
https://github.com/adoroszlai/ratis/actions/runs/9427249769/job/25971132804#step:5:112