### PR TITLE
RATIS-2112. Improve repeat-test workflow

### DIFF
--- a/.github/workflows/repeat-test.yml
+++ b/.github/workflows/repeat-test.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: result-${{ env.TEST_CLASS }}-split-${{ matrix.split }}
+          name: result-${{ github.run_number }}-${{ github.run_id }}-split-${{ matrix.split }}
           path: target/unit
   count-failures:
     if: ${{ failure() }}

--- a/.github/workflows/repeat-test.yml
+++ b/.github/workflows/repeat-test.yml
@@ -114,12 +114,12 @@ jobs:
         if: ${{ !cancelled() }}
       - name: Archive build results
         uses: actions/upload-artifact@v4
-        if: always()
+        if: ${{ failure() }}
         with:
           name: result-${{ env.TEST_CLASS }}-split-${{ matrix.split }}
           path: target/unit
   count-failures:
-    if: ${{ always() }}
+    if: ${{ failure() }}
     needs: test
     runs-on: ubuntu-20.04
     steps:

--- a/dev-support/checks/unit.sh
+++ b/dev-support/checks/unit.sh
@@ -65,6 +65,12 @@ for i in $(seq 1 ${ITERATIONS}); do
   fi
 
   if [[ ${ITERATIONS} -gt 1 ]]; then
+    if ! grep -q "Running .*Test" "${REPORT_DIR}/output.log"; then
+      echo "No tests were run" >> "${REPORT_DIR}/summary.txt"
+      irc=1
+      FAIL_FAST=true
+    fi
+
     if [[ ${irc} == 0 ]]; then
       rm -fr "${REPORT_DIR}"
     fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve `repeat-test` workflow:
* Skip artifact upload if all iterations passed
* Rename artifact using run number/ID
* Fail fast if no tests were run (e.g. due to workflow triggered for non-existent test class)

https://issues.apache.org/jira/browse/RATIS-2112

## How was this patch tested?

`repeat-test` run without failures:
https://github.com/adoroszlai/ratis/actions/runs/9486024280

`repeat-test` run with non-existent test class:
https://github.com/adoroszlai/ratis/actions/runs/9486291646