### PR TITLE
RATIS-2114. Corruption due to SegmentedRaftLogWorker queues LogEntry without reference counter

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -101,6 +101,9 @@ public final class SegmentedRaftLog extends RaftLogBase {
       completeFuture();
     }
 
+    void discard() {
+    }
+
     final void completeFuture() {
       final boolean completed = future.complete(getEndIndex());
       Preconditions.assertTrue(completed,


### PR DESCRIPTION

## What changes were proposed in this pull request?

`SegmentedRaftLogWorker` can queue LogEntries without retaining a reference counter. This is caught during testing zero-copy with Apache Ozone. Datanode crashes to corruption caused by SegmentedRaftLogWorker threads.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2114

## How was this patch tested?

CI.
