### PR TITLE
RATIS-1840. Avoid including build timestamp in artifacts

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -92,6 +92,8 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Run a full build
         run: ./dev-support/checks/build.sh -Djavac.version=${{ matrix.java }}
+      - name: Test reproducibility
+        run: ./dev-support/checks/repro.sh -Djavac.version=${{ matrix.java }}
   rat:
     name: rat
     runs-on: ubuntu-20.04

--- a/dev-support/checks/repro.sh
+++ b/dev-support/checks/repro.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR/../.." || exit 1
+
+source "${DIR}/../find_maven.sh"
+
+: ${WITH_COVERAGE:="false"}
+
+MAVEN_OPTIONS='-V -B -Dmaven.javadoc.skip=true -DskipTests --no-transfer-progress'
+
+if [[ "${WITH_COVERAGE}" != "true" ]]; then
+  MAVEN_OPTIONS="${MAVEN_OPTIONS} -Djacoco.skip"
+fi
+
+export MAVEN_OPTS="-Xmx4096m"
+${MVN} ${MAVEN_OPTIONS} clean verify artifact:compare "$@"
+exit $?

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
     <maven-pdf-plugin.version>1.6.1</maven-pdf-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <wagon-ssh.version>3.5.3</wagon-ssh.version>
+    <hadoop-maven-plugins.version>3.3.6</hadoop-maven-plugins.version>
 
 
     <!-- org.codehaus.mojo -->
@@ -454,6 +455,11 @@
 
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-maven-plugins</artifactId>
+          <version>${hadoop-maven-plugins.version}</version>
+        </plugin>
         <plugin>
           <groupId>org.xolstice.maven.plugins</groupId>
           <artifactId>protobuf-maven-plugin</artifactId>
@@ -782,6 +788,24 @@
         <extensions>true</extensions>
       </plugin>
       <plugin>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-maven-plugins</artifactId>
+        <executions>
+          <execution>
+            <id>version-info</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>version-info</goal>
+            </goals>
+            <configuration>
+              <source>
+                <directory>${project.basedir}</directory>
+              </source>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>${maven-checkstyle-plugin.version}</version>
@@ -801,24 +825,6 @@
           </outputDirectory>
           <includeReports>false</includeReports>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>1.4</version>
-        <executions>
-          <execution>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>create-metadata</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>target/classes</outputDirectory>
-              <outputName>ratis-version.properties</outputName>
-              <revisionOnScmFailure>Unknown</revisionOnScmFailure>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -865,6 +871,19 @@
         </executions>
       </plugin>
     </plugins>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+        <filtering>false</filtering>
+      </resource>
+      <resource>
+        <directory>${project.basedir}/../src/main/resources</directory>
+        <includes>
+          <include>ratis-version.properties</include>
+        </includes>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
   </build>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <maven-pdf-plugin.version>1.6.1</maven-pdf-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <wagon-ssh.version>3.5.3</wagon-ssh.version>
-    <hadoop-maven-plugins.version>3.3.6</hadoop-maven-plugins.version>
+    <hadoop-maven-plugins.version>3.4.0</hadoop-maven-plugins.version>
 
 
     <!-- org.codehaus.mojo -->

--- a/src/main/resources/ratis-version.properties
+++ b/src/main/resources/ratis-version.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name=${project.name}
+version=${project.version}
+revision=${version-info.scm.commit}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`buildnumber-maven-plugin`'s `create-metadata` goal generates a properties file similar to:

```
#Created by build system. Do not modify
#Fri Dec 29 09:18:39 CET 2023
version=3.0.1
revision=Unknown
name=Apache Ratis Common
timestamp=1703837919371
```

Time of build should be omitted, because it makes builds non-reproducible.  The same set of sources and build instructions result in different output each time.

However, `buildnumber-maven-plugin` doesn't seem to have any way to configure the properties to be included/omitted.  We can replace it with a custom properties file.  `hadoop-maven-plugins` is used to get the SCM revision.

https://issues.apache.org/jira/browse/RATIS-1840

## How was this patch tested?

Added a step in `compile` check to verify build is reproducible.

CI:
https://github.com/adoroszlai/ratis/actions/runs/9659530041