### PR TITLE
RATIS-2117. No need for manual assembly:single execution

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -44,7 +44,7 @@ jobs:
           distribution: 'temurin'
           java-version: 8
       - name: Run a full build
-        run: ./dev-support/checks/build.sh -Prelease assembly:single
+        run: ./dev-support/checks/build.sh -Prelease
       - name: Store binaries for tests
         uses: actions/upload-artifact@v4
         with:

--- a/dev-support/make_rc.sh
+++ b/dev-support/make_rc.sh
@@ -106,7 +106,7 @@ prepare-src() {
 
   #grep -r SNAPSHOT --include=pom.xml
 
-  mvnFun clean install assembly:single -DskipTests=true  -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}"
+  mvnFun clean install -DskipTests=true  -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}"
 }
 
 prepare-bin() {
@@ -118,7 +118,7 @@ prepare-bin() {
   mv "apache-ratis-${RATISVERSION}-src" "apache-ratis-${RATISVERSION}"
   cd "apache-ratis-${RATISVERSION}"
 
-  mvnFun clean install assembly:single -DskipTests=true  -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}"
+  mvnFun clean install -DskipTests=true  -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}"
 }
 
 assembly() {

--- a/ratis-assembly/pom.xml
+++ b/ratis-assembly/pom.xml
@@ -142,7 +142,7 @@
             </configuration>
           </execution>
           <execution>
-            <id>default-cli</id>
+            <id>bin</id>
             <phase>package</phase>
             <goals>
               <goal>single</goal>


### PR DESCRIPTION
## What changes were proposed in this pull request?

RATIS-1660 added explicit executions of `maven-assembly-plugin` to build binary and source tarballs.  Since they are bound to the `package` phase, we no longer need to manually include `assembly:single` in the command to build Ratis.

https://issues.apache.org/jira/browse/RATIS-2117

## How was this patch tested?

Verified that both source and binary tarballs are still created:

https://github.com/adoroszlai/ratis/actions/runs/9660881857/job/26647380234#step:5:1950
https://github.com/adoroszlai/ratis/actions/runs/9660881857/job/26647380234#step:5:1964

Additional validation by `compile` check, which builds Ratis using contents from the source tarball.