### PR TITLE
RATIS-2116. Fix the issue where RaftServerImpl.appendEntries may be blocked indefinitely

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/DataBlockingQueue.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/DataBlockingQueue.java
@@ -162,4 +162,11 @@ public class DataBlockingQueue<E> extends DataQueue<E> {
       return results;
     }
   }
+
+  @Override
+  public E peek() {
+    try(AutoCloseableLock auto = AutoCloseableLock.acquire(lock)) {
+      return super.peek();
+    }
+  }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/util/DataQueue.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/DataQueue.java
@@ -154,6 +154,11 @@ public class DataQueue<E> implements Iterable<E> {
     return polled;
   }
 
+  /** Peek the head element from this queue. */
+  public E peek() {
+    return q.peek();
+  }
+
   /** The same as {@link java.util.Collection#remove(Object)}. */
   public boolean remove(E e) {
     final boolean removed = q.remove(e);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -86,15 +86,6 @@ import org.apache.ratis.util.UncheckedAutoCloseable;
  * we may have hole when append further log.
  */
 public final class SegmentedRaftLog extends RaftLogBase {
-
-  enum TaskType {
-    START_LOG_SEGMENT,
-    FINALIZE_LOG_SEGMENT,
-    WRITE_LOG,
-    PURGE_LOG,
-    TRUNCATE_LOG
-  }
-
   /**
    * I/O task definitions.
    */
@@ -126,8 +117,6 @@ public final class SegmentedRaftLog extends RaftLogBase {
     abstract void execute() throws IOException;
 
     abstract long getEndIndex();
-
-    abstract TaskType getType();
 
     void startTimerOnEnqueue(Timekeeper queueTimer) {
       queueTimerContext = queueTimer.time();

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -86,6 +86,15 @@ import org.apache.ratis.util.UncheckedAutoCloseable;
  * we may have hole when append further log.
  */
 public final class SegmentedRaftLog extends RaftLogBase {
+
+  enum TaskType {
+    START_LOG_SEGMENT,
+    FINALIZE_LOG_SEGMENT,
+    WRITE_LOG,
+    PURGE_LOG,
+    TRUNCATE_LOG
+  }
+
   /**
    * I/O task definitions.
    */
@@ -117,6 +126,8 @@ public final class SegmentedRaftLog extends RaftLogBase {
     abstract void execute() throws IOException;
 
     abstract long getEndIndex();
+
+    abstract TaskType getType();
 
     void startTimerOnEnqueue(Timekeeper queueTimer) {
       queueTimerContext = queueTimer.time();


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request fixes the issue where RaftServerImpl.appendEntries may be blocked indefinitely.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2116

## How was this patch tested?

unit tests
