### PR TITLE
RATIS-2120. Bump version after 3.1.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <artifactId>ratis</artifactId>
   <groupId>org.apache.ratis</groupId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.2.0-SNAPSHOT</version>
   <name>Apache Ratis</name>
   <packaging>pom</packaging>
   <description>

--- a/ratis-assembly/pom.xml
+++ b/ratis-assembly/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-assembly</artifactId>

--- a/ratis-client/pom.xml
+++ b/ratis-client/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-client</artifactId>

--- a/ratis-common/pom.xml
+++ b/ratis-common/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-common</artifactId>

--- a/ratis-docs/pom.xml
+++ b/ratis-docs/pom.xml
@@ -20,7 +20,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-docs</artifactId>

--- a/ratis-examples/pom.xml
+++ b/ratis-examples/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-examples</artifactId>

--- a/ratis-experiments/pom.xml
+++ b/ratis-experiments/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-experiments</artifactId>

--- a/ratis-grpc/pom.xml
+++ b/ratis-grpc/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-grpc</artifactId>

--- a/ratis-metrics-api/pom.xml
+++ b/ratis-metrics-api/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-metrics-api</artifactId>

--- a/ratis-metrics-default/pom.xml
+++ b/ratis-metrics-default/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-metrics-default</artifactId>

--- a/ratis-metrics-dropwizard3/pom.xml
+++ b/ratis-metrics-dropwizard3/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-metrics-dropwizard3</artifactId>

--- a/ratis-netty/pom.xml
+++ b/ratis-netty/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-netty</artifactId>

--- a/ratis-proto/pom.xml
+++ b/ratis-proto/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-proto</artifactId>

--- a/ratis-replicated-map/pom.xml
+++ b/ratis-replicated-map/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-replicated-map</artifactId>

--- a/ratis-resource-bundle/pom.xml
+++ b/ratis-resource-bundle/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ratis-server-api/pom.xml
+++ b/ratis-server-api/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-server-api</artifactId>

--- a/ratis-server/pom.xml
+++ b/ratis-server/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-server</artifactId>

--- a/ratis-shell/pom.xml
+++ b/ratis-shell/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-shell</artifactId>

--- a/ratis-test/pom.xml
+++ b/ratis-test/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-test</artifactId>

--- a/ratis-tools/pom.xml
+++ b/ratis-tools/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>ratis</artifactId>
     <groupId>org.apache.ratis</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratis-tools</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ratis 3.1.0 was released, we should bump version on `master` to `3.2.0-SNAPSHOT`.

https://issues.apache.org/jira/browse/RATIS-2120

## How was this patch tested?

```
$ mvn -DskipTests clean package
...
[INFO] Reactor Summary for Apache Ratis 3.2.0-SNAPSHOT:
[INFO] 
[INFO] Apache Ratis ....................................... SUCCESS [  0.748 s]
[INFO] Apache Ratis Documentation ......................... SUCCESS [  0.223 s]
[INFO] Apache Ratis Protocols ............................. SUCCESS [  2.723 s]
[INFO] Apache Ratis Common ................................ SUCCESS [  1.623 s]
[INFO] Apache Ratis Client ................................ SUCCESS [  0.667 s]
[INFO] Apache Ratis Server API ............................ SUCCESS [  0.643 s]
[INFO] Apache Ratis Metrics API ........................... SUCCESS [  0.345 s]
[INFO] Apache Ratis Metrics Default Implementation ........ SUCCESS [  0.646 s]
[INFO] Apache Ratis Server ................................ SUCCESS [  2.229 s]
[INFO] Apache Ratis - Resource Bundle ..................... SUCCESS [  0.042 s]
[INFO] Apache Ratis gRPC Support .......................... SUCCESS [  1.027 s]
[INFO] Apache Ratis Netty Support ......................... SUCCESS [  0.864 s]
[INFO] Apache Ratis Shell ................................. SUCCESS [  0.779 s]
[INFO] Apache Ratis Test .................................. SUCCESS [  1.266 s]
[INFO] Apache Ratis Tools ................................. SUCCESS [  0.316 s]
[INFO] Apache Ratis Examples .............................. SUCCESS [  2.821 s]
[INFO] Apache Ratis Replicated Map ........................ SUCCESS [  0.049 s]
[INFO] Apache Ratis Metrics Dropwizard 3 Implementation ... SUCCESS [  0.615 s]
[INFO] Apache Ratis Project Assembly ...................... SUCCESS [  1.667 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```