### PR TITLE
RATIS-2121. Set javac --release when compiling with JDK 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
     <shell-executable>bash</shell-executable>
 
     <!-- define the Java language version used by the compiler -->
-    <javac.version>1.8</javac.version>
+    <javac.version>8</javac.version>
     <java.min.version>${javac.version}</java.min.version>
     <maven.min.version>3.3.9</maven.min.version>
 
@@ -522,6 +522,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.2.1</version>
           <configuration>
             <rules>
               <requireMavenVersion>
@@ -574,8 +575,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>${javac.version}</source>
-            <target>${javac.version}</target>
             <fork>true</fork>
             <meminitial>512m</meminitial>
             <maxmem>2048m</maxmem>
@@ -874,6 +873,25 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>java8</id>
+      <activation>
+        <jdk>[,8]</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.source>${javac.version}</maven.compiler.source>
+        <maven.compiler.target>${javac.version}</maven.compiler.target>
+      </properties>
+    </profile>
+    <profile>
+      <id>java9-or-later</id>
+      <activation>
+        <jdk>[9,]</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>${javac.version}</maven.compiler.release> <!-- supported since Java 9 -->
+      </properties>
+    </profile>
     <profile>
       <id>experiments-build</id>
       <activation>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Java 9 introduced new [`javac` option `--release`](https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html#option-release), which helps ensure compatibility with the given Java version ([blog with great explanation](https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/)).  The goal of this change is to set this option when compiling with JDK 9+, instead of `--source` and `--target`.

`--release` expects version without the old-style `1.` prefix (i.e. `8` instead of `1.8`).  `maven-enforcer-plugin` [added support for the same](https://issues.apache.org/jira/browse/MENFORCER-440) in version 3.2.1, so we also need to bump the plugin.

https://issues.apache.org/jira/browse/RATIS-2121

## How was this patch tested?

Compiled Ratis with JDK versions 8, 11, 17, targeting versions up to that of the JDK.  Verified class file version.

```
for target in 8 11 17; do
  major=$(( target + 44 ))
  for jdk in 8 11 17; do
    if [[ $jdk -lt $target ]]; then break; fi
    JAVA_HOME=/usr/lib/jvm/java-${jdk}-openjdk-amd64 mvn -B -V -DskipTests clean package -Djavac.version=${target}
    javap -verbose ratis-common/target/classes/org/apache/ratis/RaftConfigKeys.class | grep "major version: $major"
  done
done
```

CI:
https://github.com/adoroszlai/ratis/actions/runs/9722037600