### PR TITLE
RATIS-2122. Update website with Ratis 3.1.0 release

### DIFF
--- a/content/post/3.1.0.md
+++ b/content/post/3.1.0.md
@@ -1,0 +1,24 @@
+---
+title: Release 3.1.0 is available
+date: 2024-06-29
+type: release
+linked: true
+---
+<!---
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+[Download](https://ratis.apache.org/downloads.html)
+
+This is a maintenance release with multiple improvements and bugfixes. See the [changes between 3.0.1 and 3.1.0](https://github.com/apache/ratis/compare/ratis-3.0.1...ratis-3.1.0) releases.
+
+It has been tested with [Apache Ozone](https://ozone.apache.org) and [Apache IoTDB](https://iotdb.apache.org),
+where Apache Ratis is used to replicate raw data and to provide high availability.


### PR DESCRIPTION
Update Ratis website with announcement for 3.0.1 bugfix release.

https://issues.apache.org/jira/browse/RATIS-1992