### PR TITLE
RATIS-2123. Remove old releases from website

### DIFF
--- a/content/post/2.0.0.md
+++ b/content/post/2.0.0.md
@@ -2,7 +2,7 @@
 title: Release 2.0.0 is available
 date: 2021-03-24
 type: release
-linked: true
+linked: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/post/2.1.0.md
+++ b/content/post/2.1.0.md
@@ -2,7 +2,7 @@
 title: Release 2.1.0 is available
 date: 2021-07-19
 type: release
-linked: true
+linked: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/post/2.2.0.md
+++ b/content/post/2.2.0.md
@@ -2,7 +2,7 @@
 title: Release 2.2.0 is available
 date: 2021-10-20
 type: release
-linked: true
+linked: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/post/2.3.0.md
+++ b/content/post/2.3.0.md
@@ -2,7 +2,7 @@
 title: Release 2.3.0 is available
 date: 2022-05-19
 type: release
-linked: true
+linked: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/post/2.4.0.md
+++ b/content/post/2.4.0.md
@@ -2,7 +2,7 @@
 title: Release 2.4.0 is available
 date: 2022-10-18
 type: release
-linked: true
+linked: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/post/2.4.1.md
+++ b/content/post/2.4.1.md
@@ -2,7 +2,7 @@
 title: Release 2.4.1 is available
 date: 2022-11-26
 type: release
-linked: true
+linked: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/post/2.5.0.md
+++ b/content/post/2.5.0.md
@@ -2,7 +2,7 @@
 title: Release 2.5.0 is available
 date: 2023-04-10
 type: release
-linked: true
+linked: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/post/2.5.1.md
+++ b/content/post/2.5.1.md
@@ -2,7 +2,7 @@
 title: Release 2.5.1 is available
 date: 2023-05-05
 type: release
-linked: false
+linked: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/post/2.5.1.md
+++ b/content/post/2.5.1.md
@@ -2,7 +2,7 @@
 title: Release 2.5.1 is available
 date: 2023-05-05
 type: release
-linked: true
+linked: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/post/3.0.0.md
+++ b/content/post/3.0.0.md
@@ -2,7 +2,7 @@
 title: Release 3.0.0 is available
 date: 2023-11-21
 type: release
-linked: true
+linked: false
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/post/3.1.0.md
+++ b/content/post/3.1.0.md
@@ -18,7 +18,8 @@ linked: true
 
 [Download](https://ratis.apache.org/downloads.html)
 
-This is a maintenance release with multiple improvements and bugfixes. See the [changes between 3.0.1 and 3.1.0](https://github.com/apache/ratis/compare/ratis-3.0.1...ratis-3.1.0) releases.
+This is a minor release with multiple improvements and bugfixes.
+See the [changes between 3.0.1 and 3.1.0](https://github.com/apache/ratis/compare/ratis-3.0.1...ratis-3.1.0) releases.
 
 It has been tested with [Apache Ozone](https://ozone.apache.org) and [Apache IoTDB](https://iotdb.apache.org),
 where Apache Ratis is used to replicate raw data and to provide high availability.


### PR DESCRIPTION
## What changes were proposed in this pull request?

List only 3.0.1 and 3.1.0 in [Downloads](https://ratis.apache.org/downloads.html) page.

https://issues.apache.org/jira/browse/RATIS-2123

## How was this patch tested?

```
hugo serve
open http://localhost:1313
```