### PR TITLE
RATIS-2131: Surround with [] only if hostName is a IPv6 string

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/NetUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/NetUtils.java
@@ -17,6 +17,8 @@
  */
 package org.apache.ratis.util;
 
+import org.apache.ratis.thirdparty.com.google.common.net.InetAddresses;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -145,8 +147,12 @@ public interface NetUtils {
     if (address == null) {
       return null;
     }
-    final StringBuilder b = new StringBuilder(address.getHostName());
-    if (address.getAddress() instanceof Inet6Address) {
+    String hostName = address.getHostName();
+    final StringBuilder b = new StringBuilder(hostName);
+    // Surround with '[', ']' only if it is a IPv6 ip - not for a IPv6 host
+    if (address.getAddress() instanceof Inet6Address &&
+        InetAddresses.isInetAddress(hostName) &&
+        InetAddresses.forString(hostName).getAddress().length == 16) {
       b.insert(0, '[').append(']');
     }
     return b.append(':').append(address.getPort()).toString();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, if the address is IPv6, NetUtils.address2String always surrounds it with '[]'.
This should be done only when the input is an IP string, and not for hostnames (which have an IPv6 address)

## What is the link to the Apache JIRA

RATIS-2131

## How was this patch tested?

Manual testing