### PR TITLE
RATIS-2133. Ignore http proxy for grpc client & server

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
@@ -128,6 +128,8 @@ public class GrpcClientProtocolClient implements Closeable {
       SizeInBytes flowControlWindow, SizeInBytes maxMessageSize) {
     NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forTarget(address);
+    // ignore any http proxy for grpc
+    channelBuilder.proxyDetector(uri -> null);
 
     if (tlsConf != null) {
       SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -78,6 +78,8 @@ public class GrpcServerProtocolClient implements Closeable {
       GrpcTlsConfig tlsConfig) {
     NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forTarget(target.getAddress());
+    // ignore any http proxy for grpc
+    channelBuilder.proxyDetector(uri -> null);
 
     if (tlsConfig!= null) {
       SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Referring to this [comment ](https://github.com/apache/ratis-thirdparty/pull/53#issuecomment-2262233350) , Ratis should not use http proxy while setting up grpc/netty clients if configured.

Reference : https://github.com/grpc/grpc-java/issues/5600#issuecomment-486680942

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2133

## How was this patch tested?
Verified by building & replacing the ratis-grpc jar and trying out an Ozone  write  with jvm args set for http proxy. 

Also verified via unit test using  
```
mvn -Dtest=TestLeaderElectionWithGrpc \
    -Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=8080 -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=8080 -Djava.net.useSystemProxies=true \
    clean test
```
Before the fix: 
```bash
incubator-ratis % cat ratis-test/target/surefire-reports/org.apache.ratis.grpc.TestLeaderElectionWithGrpc-output.txt | grep "NoClass" | head -n 1

Caused by: java.lang.NoClassDefFoundError: org/apache/ratis/thirdparty/io/netty/handler/proxy/HttpProxyHandler
```
After the fix:
```bash
incubator-ratis % cat ratis-test/target/surefire-reports/org.apache.ratis.grpc.TestLeaderElectionWithGrpc-output.txt | grep "NoClass" | head -n 1

incubator-ratis %
```

