### PR TITLE
RATIS-2115. Fix flaky RetryCacheTests and InstallSnapshotFromLeaderTests.

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
@@ -23,7 +23,9 @@ import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.protocol.exceptions.RaftException;
 import org.apache.ratis.protocol.exceptions.RaftRetryFailureException;
+import org.apache.ratis.protocol.exceptions.ReconfigurationTimeoutException;
 import org.apache.ratis.retry.RetryPolicies;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
@@ -162,13 +164,16 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
     final MiniRaftCluster.PeerChanges change = cluster.addNewPeers(2, true,
         true);
     try (final RaftClient client = cluster.createClient(leaderId, RetryPolicies.noRetry())) {
-      Assertions.assertThrows(RaftRetryFailureException.class,
+      final RaftException e = Assertions.assertThrows(RaftException.class,
                () -> client.admin().setConfiguration(change.allPeersInNewConf));
+      Assertions.assertTrue( e instanceof RaftRetryFailureException
+              || e instanceof ReconfigurationTimeoutException,
+          () -> "Unexpected exception: " + e);
     }
 
     final SnapshotInfo snapshotInfo = cluster.getDivision(change.newPeers[0].getId())
          .getStateMachine().getLatestSnapshot();
-    Assertions.assertNotNull(snapshotInfo);
+    Assertions.assertNull(snapshotInfo);
 
     // recover the old followers and isolate the leader to force leader switch
     RaftTestUtil.isolate(cluster, leaderId);

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
@@ -173,7 +173,7 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
 
     final SnapshotInfo snapshotInfo = cluster.getDivision(change.newPeers[0].getId())
          .getStateMachine().getLatestSnapshot();
-    Assertions.assertNull(snapshotInfo);
+    Assertions.assertNotNull(snapshotInfo);
 
     // recover the old followers and isolate the leader to force leader switch
     RaftTestUtil.isolate(cluster, leaderId);

--- a/ratis-server/src/test/java/org/apache/ratis/RetryCacheTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RetryCacheTests.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
@@ -137,9 +138,8 @@ public abstract class RetryCacheTests<CLUSTER extends MiniRaftCluster>
       final long oldLastApplied = cluster.getLeader().getInfo().getLastAppliedIndex();
 
       // trigger the reconfiguration, make sure the original leader is kicked out
-      PeerChanges change = cluster.addNewPeers(2, true);
-      RaftPeer[] allPeers = cluster.removePeers(2, true,
-              asList(change.newPeers)).allPeersInNewConf;
+      final PeerChanges change = cluster.removePeers(2, true, Collections.emptyList());
+      final RaftPeer[] allPeers = change.allPeersInNewConf;
       // trigger setConfiguration
       RaftServerTestUtil.runWithMinorityPeers(cluster, Arrays.asList(allPeers),
           peers -> cluster.setConfiguration(peers.toArray(RaftPeer.emptyArray())));

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLeaderInstallSnapshotWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLeaderInstallSnapshotWithGrpc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Arrays;
 import java.util.Collection;
 
-public class TestLeaderInstallSnapshot
+public class TestLeaderInstallSnapshotWithGrpc
 extends InstallSnapshotFromLeaderTests<MiniRaftClusterWithGrpc>
 implements MiniRaftClusterWithGrpc.FactoryGet {
 


### PR DESCRIPTION
See RATIS-2115