### PR TITLE
RATIS-2134.  `logMetadata` could miss appending the `metadataEntry` with the lastCommitIndex

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -984,8 +984,9 @@ class LeaderStateImpl implements LeaderState {
   }
 
   private void logMetadata(long commitIndex) {
-    raftLog.appendMetadata(currentTerm, commitIndex);
-    notifySenders();
+    if (raftLog.appendMetadata(currentTerm, commitIndex) != RaftLog.INVALID_LOG_INDEX) {
+      notifySenders();
+    }
   }
 
   private void checkAndUpdateConfiguration() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -961,7 +961,7 @@ class LeaderStateImpl implements LeaderState {
         lastCommitIndex = entry.getIndex();
       }
     }
-    if (logMetadataEnabled) {
+    if (logMetadataEnabled && lastCommitIndex != RaftLog.INVALID_LOG_INDEX) {
       logMetadata(lastCommitIndex);
     }
     commitIndexChanged();

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -244,13 +244,10 @@ public abstract class RaftLogBase implements RaftLog {
     if (newCommitIndex <= 0) {
       // do not log the first conf entry
       return false;
-    } else if (Optional.ofNullable(lastMetadataEntry.get())
-        .filter(e -> e.getMetadataEntry().getCommitIndex() >= newCommitIndex)
-        .isPresent()) {
-      // do not log entries with a smaller commit index.
-      return false;
     }
-    return true;
+    final LogEntryProto last = lastMetadataEntry.get();
+    // do not log entries with a smaller commit index.
+    return newCommitIndex > last.getMetadataEntry().getCommitIndex();
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -230,9 +230,6 @@ public abstract class RaftLogBase implements RaftLog {
     final long nextIndex;
     try(AutoCloseableLock writeLock = writeLock()) {
       nextIndex = getNextIndex();
-      if (nextIndex - 1 != newCommitIndex) {
-        return INVALID_LOG_INDEX;
-      }
       entry = LogProtoUtils.toLogEntryProto(newCommitIndex, term, nextIndex);
       appendEntry(entry);
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -244,10 +244,7 @@ public abstract class RaftLogBase implements RaftLog {
     }
     final LogEntryProto last = lastMetadataEntry.get();
     // do not log entries with a smaller commit index.
-    if (last == null) {
-      return false;
-    }
-    return newCommitIndex > last.getMetadataEntry().getCommitIndex();
+    return last == null || newCommitIndex > last.getMetadataEntry().getCommitIndex();
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -244,6 +244,9 @@ public abstract class RaftLogBase implements RaftLog {
     }
     final LogEntryProto last = lastMetadataEntry.get();
     // do not log entries with a smaller commit index.
+    if (last == null) {
+      return false;
+    }
     return newCommitIndex > last.getMetadataEntry().getCommitIndex();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now, RaftLog appends a metadata entry with the lastCommitIndex and checks whether the entry at the lastCommitIndex is neither a metadata entry nor an entry with a smaller commit index.

However, RaftLog doesn't always log metadata entries in order. Sometimes, it misses some commit indexes. For example:

STATEMACHINELOGENTRY(1, 1)
STATEMACHINELOGENTRY(1, 2)
METADATAENTRY(commitIndex: 1)

A METADATAENTRY is lost.
The lastCommitIndex in the METADATAENTRY and  is a metadata entry, RaftLog won't append it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2134

## How was this patch tested?

CI:
https://github.com/chungen0126/ratis/actions/runs/10233933768
