### PR TITLE
RATIS-2144 SegmentedRaftLogWorker should close the stream before releasing the buffer.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -246,8 +246,8 @@ class SegmentedRaftLogWorker {
     Optional.ofNullable(flushExecutor).ifPresent(ExecutorService::shutdown);
     ConcurrentUtils.shutdownAndWait(TimeDuration.ONE_SECOND.multiply(3),
         workerThreadExecutor, timeout -> LOG.warn("{}: shutdown timeout in " + timeout, name));
-    PlatformDependent.freeDirectBuffer(writeBuffer);
     IOUtils.cleanup(LOG, out);
+    PlatformDependent.freeDirectBuffer(writeBuffer);
     LOG.info("{} close()", name);
   }
 


### PR DESCRIPTION
see [jira](https://issues.apache.org/jira/browse/RATIS-2144)