### PR TITLE
RATIS-2145. Follower hangs until the next trigger to take a snapshot.

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -444,7 +444,7 @@ public class GrpcLogAppender extends LogAppenderBase {
   }
 
   private void timeoutAppendRequest(long cid, boolean heartbeat) {
-    final AppendEntriesRequest pending = pendingRequests.handleTimeout(cid, heartbeat);
+    final AppendEntriesRequest pending = pendingRequests.remove(cid, heartbeat);
     if (pending != null) {
       final int errorCount = replyState.process(Event.TIMEOUT);
       LOG.warn("{}: Timed out {}appendEntries, errorCount={}, request={}",
@@ -963,10 +963,6 @@ public class GrpcLogAppender extends LogAppenderBase {
 
     AppendEntriesRequest remove(long cid, boolean isHeartbeat) {
       return isHeartbeat ? heartbeats.remove(cid): logRequests.remove(cid);
-    }
-
-    public AppendEntriesRequest handleTimeout(long callId, boolean heartbeat) {
-      return heartbeat ? heartbeats.remove(callId) : logRequests.get(callId);
     }
   }
 }


### PR DESCRIPTION
see: https://issues.apache.org/jira/browse/RATIS-2145