### PR TITLE
RATIS-2150. No need for manual assembly:single execution when mvn deploy

### DIFF
--- a/dev-support/make_rc.sh
+++ b/dev-support/make_rc.sh
@@ -147,7 +147,7 @@ publish-svn() {
 
 publish-mvn(){
   cd "$projectdir"
-  mvnFun -X clean deploy assembly:single -DskipTests=true  -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}"
+  mvnFun -X clean deploy -DskipTests=true  -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}"
 }
 
 if [ "$#" -ne 1 ]; then


### PR DESCRIPTION
see [jira](https://issues.apache.org/jira/browse/RATIS-2150)