### PR TITLE
RATIS-2152. GrpcLogAppender stucks while sending an installSnapshot notification request

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/AwaitForSignal.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/AwaitForSignal.java
@@ -17,8 +17,6 @@
  */
 package org.apache.ratis.util;
 
-import org.apache.ratis.thirdparty.com.google.common.base.Supplier;
-
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -74,33 +72,6 @@ public class AwaitForSignal {
   public void signal() {
     lock.lock();
     try {
-      signaled.getAndSet(new AtomicBoolean()).set(true);
-      condition.signalAll();
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  public <T extends Boolean> boolean await(Supplier<T> supplier)
-      throws InterruptedException {
-    lock.lock();
-    try {
-      if (supplier.get().booleanValue()) {
-        return true;
-      }
-      for (final AtomicBoolean s = signaled.get(); !s.get(); ) {
-        condition.await();
-      }
-      return supplier.get().booleanValue();
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  public void signal(Runnable runnable) {
-    lock.lock();
-    try {
-      runnable.run();
       signaled.getAndSet(new AtomicBoolean()).set(true);
       condition.signalAll();
     } finally {

--- a/ratis-common/src/main/java/org/apache/ratis/util/AwaitForSignal.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/AwaitForSignal.java
@@ -17,6 +17,8 @@
  */
 package org.apache.ratis.util;
 
+import org.apache.ratis.thirdparty.com.google.common.base.Supplier;
+
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -72,6 +74,33 @@ public class AwaitForSignal {
   public void signal() {
     lock.lock();
     try {
+      signaled.getAndSet(new AtomicBoolean()).set(true);
+      condition.signalAll();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  public <T extends Boolean> boolean await(Supplier<T> supplier)
+      throws InterruptedException {
+    lock.lock();
+    try {
+      if (supplier.get().booleanValue()) {
+        return true;
+      }
+      for (final AtomicBoolean s = signaled.get(); !s.get(); ) {
+        condition.await();
+      }
+      return supplier.get().booleanValue();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  public void signal(Runnable runnable) {
+    lock.lock();
+    try {
+      runnable.run();
       signaled.getAndSet(new AtomicBoolean()).set(true);
       condition.signalAll();
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `GrpcLogAppender`, it waits for signal at the end of `notifyInstallSnapshot` as following.

https://github.com/apache/ratis/blob/3e38e6da1053c1b522d51123b8ac88ea15e60f94/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java#L825-L831

However, checking whether the `InstallSnapshotResponseHandler` is done and the call `AwaitForSignal.await()` are not atomic. This creates a potential race condition where InstallSnapshotResponseHandler.close() could finish after the check but before the wait, causing that `GrpcLogAppender` is still waiting even though `InstallSnapshotResponseHandler` has already completed, leading to timeout. 

Things change in the patch:
Move the done check inside the lock in AwaitForSignal to ensure atomicity.

## What is the link to the Apache JIRA

[RATIS-2152](https://issues.apache.org/jira/browse/RATIS-2152)

## How was this patch tested?

CI:
https://github.com/chungen0126/ratis/actions/runs/10771583301

