### PR TITLE
RATIS-2153. ratis-version.properties missing from src bundle

### DIFF
--- a/ratis-assembly/src/main/assembly/src.xml
+++ b/ratis-assembly/src/main/assembly/src.xml
@@ -103,6 +103,7 @@
         <include>README.md</include>
         <include>mvnw.cmd</include>
         <include>pom.xml</include>
+        <include>src/**</include>
         <include>start-build-env.sh</include>
       </includes>
       <fileMode>0644</fileMode>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ratis-version.properties` added in RATIS-1840 needs to be included in the `src` assembly.

https://issues.apache.org/jira/browse/RATIS-2153

## How was this patch tested?

```
$ mvn -DskipTests clean verify
...

$ tar tzvf ratis-assembly/target/ratis-assembly-*-src.tar.gz | grep 'src/src'
drwxr-xr-x root/root         0 2023-11-19 15:23 apache-ratis-3.2.0-SNAPSHOT-src/src/
drwxr-xr-x root/root         0 2023-11-19 15:23 apache-ratis-3.2.0-SNAPSHOT-src/src/main/
drwxr-xr-x root/root         0 2023-11-19 15:23 apache-ratis-3.2.0-SNAPSHOT-src/src/main/resources/
-rw-r--r-- root/root       873 2023-11-19 15:23 apache-ratis-3.2.0-SNAPSHOT-src/src/main/resources/ratis-version.properties
```

CI:
https://github.com/adoroszlai/ratis/actions/runs/10778262480