### PR TITLE
RATIS-2154.  The old leader may send appendEntries after term changed,

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -620,7 +620,7 @@ class LeaderStateImpl implements LeaderState {
       List<LogEntryProto> entries, TermIndex previous, long callId) {
     final boolean initializing = !isCaughtUp(follower);
     final RaftPeerId targetId = follower.getId();
-    return ServerProtoUtils.toAppendEntriesRequestProto(server.getMemberId(), targetId, getCurrentTerm(), entries,
+    return ServerProtoUtils.toAppendEntriesRequestProto(server.getMemberId(), targetId, currentTerm, entries,
         ServerImplUtils.effectiveCommitIndex(raftLog.getLastCommittedIndex(), previous, entries.size()),
         initializing, previous, server.getCommitInfos(), callId);
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -620,7 +620,7 @@ class LeaderStateImpl implements LeaderState {
       List<LogEntryProto> entries, TermIndex previous, long callId) {
     final boolean initializing = !isCaughtUp(follower);
     final RaftPeerId targetId = follower.getId();
-    return ServerProtoUtils.toAppendEntriesRequestProto(server.getMemberId(), targetId, currentTerm, entries,
+    return ServerProtoUtils.toAppendEntriesRequestProto(server.getMemberId(), targetId, getCurrentTerm(), entries,
         ServerImplUtils.effectiveCommitIndex(raftLog.getLastCommittedIndex(), previous, entries.size()),
         initializing, previous, server.getCommitInfos(), callId);
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -572,11 +572,10 @@ class RaftServerImpl implements RaftServer.Division,
       boolean allowListener,
       Object reason) {
     final RaftPeerRole old = role.getCurrentRole();
-    final boolean metadataUpdated = state.updateCurrentTerm(newTerm);
     if (old == RaftPeerRole.LISTENER && !allowListener) {
       throw new IllegalStateException("Unexpected role " + old);
     }
-
+    boolean metadataUpdated;
     if ((old != RaftPeerRole.FOLLOWER || force) && old != RaftPeerRole.LISTENER) {
       setRole(RaftPeerRole.FOLLOWER, reason);
       if (old == RaftPeerRole.LEADER) {
@@ -597,8 +596,11 @@ class RaftServerImpl implements RaftServer.Division,
       } else if (old == RaftPeerRole.FOLLOWER) {
         role.shutdownFollowerState();
       }
+      metadataUpdated = state.updateCurrentTerm(newTerm);
       role.startFollowerState(this, reason);
       setFirstElection(reason);
+    } else {
+      metadataUpdated = state.updateCurrentTerm(newTerm);
     }
     return metadataUpdated;
   }


### PR DESCRIPTION
Previous PR see https://github.com/apache/ratis/pull/1133 
issue see https://issues.apache.org/jira/browse/RATIS-2138

This PR is the follow-up to 2138
This PR related issue: https://issues.apache.org/jira/browse/RATIS-2154