### PR TITLE
RATIS-2159. TestRaftWithSimulatedRpc could "fail to retain".

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -306,9 +306,13 @@ public final class SegmentedRaftLog extends RaftLogBase {
     }
     final ReferenceCountedObject<LogEntryProto> entry = segment.getEntryFromCache(record.getTermIndex());
     if (entry != null) {
-      getRaftLogMetrics().onRaftLogCacheHit();
-      entry.retain();
-      return entry;
+      try {
+        entry.retain();
+        getRaftLogMetrics().onRaftLogCacheHit();
+        return entry;
+      } catch (IllegalStateException ignore) {
+        // the entry could be removed from the cache and released.
+      }
     }
 
     // the entry is not in the segment's cache. Load the cache without holding the lock.

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -310,8 +310,9 @@ public final class SegmentedRaftLog extends RaftLogBase {
         entry.retain();
         getRaftLogMetrics().onRaftLogCacheHit();
         return entry;
-      } catch (IllegalStateException ignore) {
-        // the entry could be removed from the cache and released.
+      } catch (IllegalStateException ignored) {
+        // The entry could be removed from the cache and released.
+        // The exception can be safely ignored since it is the same as cache miss.
       }
     }
 


### PR DESCRIPTION
RATIS-2159

In SegmentedRaftLog.retainLog(..),

1. it gets an entry from the cache, and then
2. calls `retain()`.

The entry could be removed and released in between (1) and (2). It leads to the "fail to retain" failure.

