### PR TITLE
RATIS-2166. Update nextChunkIndex when snapshot is ALREADY_INSTALLED

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -193,8 +193,11 @@ class SnapshotInstallationHandler {
         //TODO: We should only update State with installed snapshot once the request is done.
         state.installSnapshot(request);
 
-        int idx = nextChunkIndex.getAndIncrement();
-        Preconditions.assertEquals(snapshotChunkRequest.getRequestIndex(), idx, "nextChunkIndex");
+        final int expectedChunkIndex = nextChunkIndex.getAndIncrement();
+        if (expectedChunkIndex != snapshotChunkRequest.getRequestIndex()) {
+          throw new IOException("Unexpected request chunk index: " + snapshotChunkRequest.getRequestIndex()
+              + " (the expected index is " + expectedChunkIndex + ")");
+        }
         // update the committed index
         // re-load the state machine if this is the last chunk
         if (snapshotChunkRequest.getDone()) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -185,6 +185,7 @@ class SnapshotInstallationHandler {
         // considering a follower peer requiring a snapshot installation does not
         // have a lot of requests
         if (state.getLog().getLastCommittedIndex() >= lastIncludedIndex) {
+          nextChunkIndex.set(snapshotChunkRequest.getRequestIndex() + 1);
           return toInstallSnapshotReplyProto(leaderId, getMemberId(),
               currentTerm, snapshotChunkRequest.getRequestIndex(), InstallSnapshotResult.ALREADY_INSTALLED);
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix legacy problems with #1145 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2166