### PR TITLE
RATIS-2165. Do not include RaftClientRequest Message in ReadIndexRequest

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
@@ -207,10 +207,10 @@ public interface ClientProtoUtils {
     return toRaftClientRequestProto(request, true);
   }
 
-  static RaftClientRequestProto toRaftClientRequestProto(RaftClientRequest request, boolean with_msg) {
+  static RaftClientRequestProto toRaftClientRequestProto(RaftClientRequest request, boolean withMsg) {
     final RaftClientRequestProto.Builder b = RaftClientRequestProto.newBuilder()
         .setRpcRequest(toRaftRpcRequestProtoBuilder(request));
-    if (with_msg && request.getMessage() != null) {
+    if (withMsg && request.getMessage() != null) {
       b.setMessage(toClientMessageEntryProtoBuilder(request.getMessage()));
     }
 

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
@@ -204,9 +204,13 @@ public interface ClientProtoUtils {
   }
 
   static RaftClientRequestProto toRaftClientRequestProto(RaftClientRequest request) {
+    return toRaftClientRequestProto(request, true);
+  }
+
+  static RaftClientRequestProto toRaftClientRequestProto(RaftClientRequest request, boolean with_msg) {
     final RaftClientRequestProto.Builder b = RaftClientRequestProto.newBuilder()
         .setRpcRequest(toRaftRpcRequestProtoBuilder(request));
-    if (request.getMessage() != null) {
+    if (with_msg && request.getMessage() != null) {
       b.setMessage(toClientMessageEntryProtoBuilder(request.getMessage()));
     }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
@@ -114,7 +114,7 @@ final class ServerProtoUtils {
       RaftClientRequest clientRequest, RaftGroupMemberId requestorId, RaftPeerId replyId) {
     return ReadIndexRequestProto.newBuilder()
         .setServerRequest(ClientProtoUtils.toRaftRpcRequestProtoBuilder(requestorId, replyId))
-        .setClientRequest(ClientProtoUtils.toRaftClientRequestProto(clientRequest))
+        .setClientRequest(ClientProtoUtils.toRaftClientRequestProto(clientRequest, false))
         .build();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

For the readIndexRequestProto, we don't need to set message member 
In readIndex, we did not use clientRequest.message, so we do not need to serialize the message

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2165
