### PR TITLE
RATIS-2167. Add default value in TermIndex

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/TermIndex.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/TermIndex.java
@@ -58,6 +58,8 @@ public interface TermIndex extends Comparable<TermIndex> {
     return Optional.ofNullable(proto).map(p -> valueOf(p.getTerm(), p.getIndex())).orElse(null);
   }
 
+  static final TermIndex DEFAULT_TERMINDEX = valueOf(0, -1);
+
   /** @return a {@link TermIndex} object. */
   static TermIndex valueOf(long term, long index) {
     return new TermIndex() {

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/TermIndex.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/TermIndex.java
@@ -19,12 +19,25 @@ package org.apache.ratis.server.protocol;
 
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.proto.RaftProtos.TermIndexProto;
+import org.apache.ratis.server.raftlog.RaftLog;
 
 import java.util.Comparator;
 import java.util.Optional;
 
 /** The term and the log index defined in the Raft consensus algorithm. */
 public interface TermIndex extends Comparable<TermIndex> {
+  /**
+   * The initial value.
+   * When a new Raft group starts,
+   * all the servers has term 0 and index -1 (= {@link RaftLog#INVALID_LOG_INDEX}).
+   * Note that term is incremented during leader election
+   * and index is incremented when writing to the {@link RaftLog}.
+   * The least term and index possibly written to the {@link RaftLog}
+   * are respectively 1 and 0 (= {@link RaftLog#LEAST_VALID_LOG_INDEX}).
+   */
+  TermIndex INITIAL_VALUE = valueOf(0, RaftLog.INVALID_LOG_INDEX);
+
+  /** An empty {@link TermIndex} array. */
   TermIndex[] EMPTY_ARRAY = {};
 
   /** @return the term. */
@@ -57,8 +70,6 @@ public interface TermIndex extends Comparable<TermIndex> {
   static TermIndex valueOf(LogEntryProto proto) {
     return Optional.ofNullable(proto).map(p -> valueOf(p.getTerm(), p.getIndex())).orElse(null);
   }
-
-  static final TermIndex DEFAULT_TERMINDEX = valueOf(0, -1);
 
   /** @return a {@link TermIndex} object. */
   static TermIndex valueOf(long term, long index) {

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
@@ -59,7 +59,7 @@ public class BaseStateMachine implements StateMachine, StateMachine.DataApi,
   private final SortedMap<Long, CompletableFuture<Void>> transactionFutures = new TreeMap<>();
 
   public BaseStateMachine() {
-    setLastAppliedTermIndex(TermIndex.valueOf(0, -1));
+    setLastAppliedTermIndex(TermIndex.DEFAULT_TERMINDEX);
   }
 
   public RaftPeerId getId() {

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
@@ -59,7 +59,7 @@ public class BaseStateMachine implements StateMachine, StateMachine.DataApi,
   private final SortedMap<Long, CompletableFuture<Void>> transactionFutures = new TreeMap<>();
 
   public BaseStateMachine() {
-    setLastAppliedTermIndex(TermIndex.DEFAULT_TERMINDEX);
+    setLastAppliedTermIndex(TermIndex.INITIAL_VALUE);
   }
 
   public RaftPeerId getId() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the Ratis project and other projects, the default value of TermIndex is used. Here we create a default value for TermIndex.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2167

## How was this patch tested?
Make sure UT passes.
