### PR TITLE
RATIS-2164. LeakDetector has a race condition.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
@@ -20,7 +20,7 @@ package org.apache.ratis.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -49,7 +49,7 @@ public final class ReferenceCountedLeakDetector {
   private ReferenceCountedLeakDetector() {
   }
 
-  static synchronized void enable(boolean advanced) {
+  public static synchronized void enable(boolean advanced) {
     FACTORY.set(advanced ? Mode.ADVANCED : Mode.SIMPLE);
   }
 
@@ -108,6 +108,10 @@ public final class ReferenceCountedLeakDetector {
       return value;
     }
 
+    final int getCount() {
+      return count.get();
+    }
+
     @Override
     public V retain() {
       // n <  0: exception
@@ -138,85 +142,221 @@ public final class ReferenceCountedLeakDetector {
   }
 
   private static class SimpleTracing<T> extends Impl<T> {
-    private final UncheckedAutoCloseable leakTracker;
+    private final LeakDetector leakDetector;
+    private final Class<?> valueClass;
+    private String valueString = null;
+    private Runnable removeMethod = null;
 
     SimpleTracing(T value, Runnable retainMethod, Consumer<Boolean> releaseMethod, LeakDetector leakDetector) {
       super(value, retainMethod, releaseMethod);
-      final Class<?> clazz = value.getClass();
-      this.leakTracker = leakDetector.track(this,
-          () -> LOG.warn("LEAK: A {} is not released properly", clazz.getName()));
+      this.valueClass = value.getClass();
+      this.leakDetector = leakDetector;
+    }
+
+    String getTraceString(int count) {
+      return "(" + valueClass + ", count=" + count + ", value=" + valueString + ")";
+    }
+
+    /** @return the leak message if there is a leak; return null if there is no leak. */
+    String logLeakMessage() {
+      final int count = getCount();
+      if (count == 0) { // never retain
+        return null;
+      }
+      final String message = "LEAK: " + getTraceString(count);
+      LOG.warn(message);
+      return message;
     }
 
     @Override
-    public boolean release() {
-      boolean released = super.release();
+    public synchronized T get() {
+      try {
+        return super.get();
+      } catch (Exception e) {
+        throw new IllegalStateException("Failed to get: " + getTraceString(getCount()), e);
+      }
+    }
+
+    @Override
+    public synchronized T retain() {
+      final T value;
+      try {
+        value = super.retain();
+      } catch (Exception e) {
+        throw new IllegalStateException("Failed to retain: " + getTraceString(getCount()), e);
+      }
+      if (getCount() == 1) { // this is the first retain
+        this.removeMethod = leakDetector.track(this, this::logLeakMessage);
+        this.valueString = value.toString();
+      }
+      return value;
+    }
+
+    @Override
+    public synchronized boolean release() {
+      final boolean released;
+      try {
+        released = super.release();
+      } catch (Exception e) {
+        throw new IllegalStateException("Failed to release: " + getTraceString(getCount()), e);
+      }
+
       if (released) {
-        leakTracker.close();
+        Preconditions.assertNotNull(removeMethod, () -> "Not yet retained (removeMethod == null): " + valueClass);
+        removeMethod.run();
       }
       return released;
     }
   }
 
-  private static class AdvancedTracing<T> extends Impl<T> {
-    private final UncheckedAutoCloseable leakTracker;
-    private final List<StackTraceElement[]> retainsTraces;
-    private final List<StackTraceElement[]> releaseTraces;
+  private static class AdvancedTracing<T> extends SimpleTracing<T> {
+    enum Op {CREATION, RETAIN, RELEASE, CURRENT}
+
+    static class Counts {
+      private final int refCount;
+      private final int retainCount;
+      private final int releaseCount;
+
+      Counts() {
+        this.refCount = 0;
+        this.retainCount = 0;
+        this.releaseCount = 0;
+      }
+
+      Counts(Op op, Counts previous) {
+        if (op == Op.RETAIN) {
+          this.refCount = previous.refCount + 1;
+          this.retainCount = previous.retainCount + 1;
+          this.releaseCount = previous.releaseCount;
+        } else if (op == Op.RELEASE) {
+          this.refCount = previous.refCount - 1;
+          this.retainCount = previous.retainCount;
+          this.releaseCount = previous.releaseCount + 1;
+        } else {
+          throw new IllegalStateException("Unexpected op: " + op);
+        }
+      }
+
+      @Override
+      public String toString() {
+        return "refCount=" + refCount
+            + ", retainCount=" + retainCount
+            + ", releaseCount=" + releaseCount;
+      }
+    }
+
+    static class TraceInfo {
+      private final int id;
+      private final Op op;
+      private final int previousRefCount;
+      private final Counts counts;
+
+      private final String threadInfo;
+      private final StackTraceElement[] stackTraces;
+      private final int newTraceElementIndex;
+
+      TraceInfo(int id, Op op, TraceInfo previous, int previousRefCount) {
+        this.id = id;
+        this.op = op;
+        this.previousRefCount = previousRefCount;
+        this.counts = previous == null? new Counts()
+            : op == Op.CURRENT ? previous.counts
+            : new Counts(op, previous.counts);
+
+        final Thread thread = Thread.currentThread();
+        this.threadInfo = "Thread_" + thread.getId() + ":" + thread.getName();
+        this.stackTraces = thread.getStackTrace();
+        this.newTraceElementIndex = previous == null? stackTraces.length - 1
+            : findFirstUnequalFromTail(this.stackTraces, previous.stackTraces);
+      }
+
+      static <T> int findFirstUnequalFromTail(T[] current, T[] previous) {
+        int c = current.length - 1;
+        for(int p = previous.length - 1; p >= 0; p--, c--) {
+          if (!previous[p].equals(current[c])) {
+            return c;
+          }
+        }
+        return -1;
+      }
+
+      private StringBuilder appendTo(StringBuilder b) {
+        b.append(op).append("_").append(id)
+            .append(": previousRefCount=").append(previousRefCount)
+            .append(", ").append(counts)
+            .append(", ").append(threadInfo).append("\n");
+        final int n = newTraceElementIndex + 1;
+        int line = 3;
+        for (; line <= n && line < stackTraces.length; line++) {
+          b.append("    ").append(stackTraces[line]).append("\n");
+        }
+        if (line < stackTraces.length) {
+          b.append("    ...\n");
+        }
+        return b;
+      }
+
+      @Override
+      public String toString() {
+        return appendTo(new StringBuilder()).toString();
+      }
+    }
+
+    private final List<TraceInfo> traceInfos = new ArrayList<>();
+    private TraceInfo previous;
 
     AdvancedTracing(T value, Runnable retainMethod, Consumer<Boolean> releaseMethod, LeakDetector leakDetector) {
-      super(value, retainMethod, releaseMethod);
+      super(value, retainMethod, releaseMethod, leakDetector);
+      addTraceInfo(Op.CREATION, -1);
+    }
 
-      StackTraceElement[] createStrace = Thread.currentThread().getStackTrace();
-      final Class<?> clazz = value.getClass();
-      final List<StackTraceElement[]> localRetainsTraces = new LinkedList<>();
-      final List<StackTraceElement[]> localReleaseTraces = new LinkedList<>();
+    private synchronized TraceInfo addTraceInfo(Op op, int previousRefCount) {
+      final TraceInfo current = new TraceInfo(traceInfos.size(), op, previous, previousRefCount);
+      traceInfos.add(current);
+      previous = current;
+      return current;
+    }
 
-      this.leakTracker = leakDetector.track(this, () ->
-          LOG.warn("LEAK: A {} is not released properly.\nCreation trace:\n{}\n" +
-              "Retain traces({}):\n{}\nRelease traces({}):\n{}",
-              clazz.getName(), formatStackTrace(createStrace, 3),
-              localRetainsTraces.size(), formatStackTraces(localRetainsTraces, 2),
-              localReleaseTraces.size(), formatStackTraces(localReleaseTraces, 2)));
 
-      this.retainsTraces = localRetainsTraces;
-      this.releaseTraces = localReleaseTraces;
+    @Override
+    public synchronized T retain() {
+      final int previousRefCount = getCount();
+      final T retained = super.retain();
+      final TraceInfo info = addTraceInfo(Op.RETAIN, previousRefCount);
+      Preconditions.assertSame(getCount(), info.counts.refCount, "refCount");
+      return retained;
     }
 
     @Override
-    public T retain() {
-      T retain = super.retain();
-      retainsTraces.add(Thread.currentThread().getStackTrace());
-      return retain;
-    }
-
-    @Override
-    public boolean release() {
-      boolean released = super.release();
-      if (released) {
-        leakTracker.close();
-      }
-      releaseTraces.add(Thread.currentThread().getStackTrace());
+    public synchronized boolean release() {
+      final int previousRefCount = getCount();
+      final boolean released = super.release();
+      final TraceInfo info = addTraceInfo(Op.RELEASE, previousRefCount);
+      final int count = getCount();
+      final int expected = count == -1? 0 : count;
+      Preconditions.assertSame(expected, info.counts.refCount, "refCount");
       return released;
     }
-  }
 
-  private static String formatStackTrace(StackTraceElement[] stackTrace, int startIdx) {
-    final StringBuilder sb = new StringBuilder();
-    for (int line = startIdx; line < stackTrace.length; line++) {
-      sb.append(stackTrace[line]).append("\n");
+    @Override
+    synchronized String getTraceString(int count) {
+      return super.getTraceString(count) + getTraceInfosString();
     }
-    return sb.toString();
-  }
 
-  private static String formatStackTraces(List<StackTraceElement[]> stackTraces, int startIdx) {
-    final StringBuilder sb = new StringBuilder();
-    stackTraces.forEach(stackTrace -> {
-      if (sb.length() > 0) {
-        sb.append("\n");
+    private String getTraceInfosString() {
+      final int n = traceInfos.size();
+      final StringBuilder b = new StringBuilder(n << 10).append(" #TraceInfos=").append(n);
+      TraceInfo last = null;
+      for (TraceInfo info : traceInfos) {
+        info.appendTo(b.append("\n"));
+        last = info;
       }
-      for (int line = startIdx; line < stackTrace.length; line++) {
-        sb.append(stackTrace[line]).append("\n");
-      }
-    });
-    return sb.toString();
+
+      // append current track info
+      final TraceInfo current = new TraceInfo(n, Op.CURRENT, last, getCount());
+      current.appendTo(b.append("\n"));
+
+      return b.toString();
+    }
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedObject.java
@@ -182,13 +182,4 @@ public interface ReferenceCountedObject<T> {
   static <V> ReferenceCountedObject<V> wrap(V value, Runnable retainMethod, Runnable releaseMethod) {
     return wrap(value, retainMethod, ignored -> releaseMethod.run());
   }
-
-  static void enableLeakDetection() {
-    ReferenceCountedLeakDetector.enable(false);
-  }
-
-  static void enableAdvancedLeakDetection() {
-    ReferenceCountedLeakDetector.enable(true);
-  }
-
 }

--- a/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
+++ b/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
@@ -32,7 +32,7 @@ import org.apache.ratis.server.impl.DelayLocalExecutionInjection;
 import org.apache.ratis.server.impl.MiniRaftCluster;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.util.NetUtils;
-import org.apache.ratis.util.ReferenceCountedObject;
+import org.apache.ratis.util.ReferenceCountedLeakDetector;
 import org.junit.Assert;
 
 import java.util.Optional;
@@ -51,7 +51,8 @@ public class MiniRaftClusterWithGrpc extends MiniRaftCluster.RpcBase {
   };
 
   static {
-    ReferenceCountedObject.enableLeakDetection();
+    // TODO move it to MiniRaftCluster for detecting non-gRPC cases
+    ReferenceCountedLeakDetector.enable(false);
   }
 
   public interface FactoryGet extends Factory.Get<MiniRaftClusterWithGrpc> {


### PR DESCRIPTION
RATIS-2164

This is mainly fixing the first two problem mentioned in https://github.com/apache/ratis/pull/1156

1. `LeakDetector`: asserted allLeaks is non-empty but printed "allLeaks.size = 0"
    - Another bug: Trackers can be considered as a leak without calling `retain()`. Without calling `retain()` at all, it is not a leak.
2. `SimpleTracing` and `AdvancedTracing`: the methods should be synchronized.
    - Minor presentation problem: `AdvancedTracing` should have a single track list instead of two lists: `retainsTraces` and `releaseTraces`.