### PR TITLE
RATIS-2151. TestRaftWithGrpc keeps failing with zero-copy.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/DataBlockingQueue.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/DataBlockingQueue.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import java.util.function.ToLongFunction;
 
 /**
@@ -45,6 +46,8 @@ public class DataBlockingQueue<E> extends DataQueue<E> {
   private final Lock lock = new ReentrantLock();
   private final Condition notFull  = lock.newCondition();
   private final Condition notEmpty = lock.newCondition();
+
+  private boolean closed = false;
 
   public DataBlockingQueue(Object name, SizeInBytes byteLimit, int elementLimit, ToLongFunction<E> getNumBytes) {
     super(name, byteLimit, elementLimit, getNumBytes);
@@ -72,10 +75,34 @@ public class DataBlockingQueue<E> extends DataQueue<E> {
     }
   }
 
+  /** Apply the given handler to each element and then {@link #clear()}. */
+  public void clear(Consumer<E> handler) {
+    try(AutoCloseableLock auto = AutoCloseableLock.acquire(lock)) {
+      for(E e : this) {
+        handler.accept(e);
+      }
+      super.clear();
+    }
+  }
+
+  /**
+   * Close this queue to stop accepting new elements, i.e. the offer(…) methods always return false.
+   * Note that closing the queue will not clear the existing elements.
+   * The existing elements can be peeked, polled or cleared after close.
+   */
+  public void close() {
+    try(AutoCloseableLock ignored = AutoCloseableLock.acquire(lock)) {
+      closed = true;
+    }
+  }
+
   @Override
   public boolean offer(E element) {
     Objects.requireNonNull(element, "element == null");
     try(AutoCloseableLock auto = AutoCloseableLock.acquire(lock)) {
+      if (closed) {
+        return false;
+      }
       if (super.offer(element)) {
         notEmpty.signal();
         return true;
@@ -95,6 +122,9 @@ public class DataBlockingQueue<E> extends DataQueue<E> {
     long nanos = timeout.toLong(TimeUnit.NANOSECONDS);
     try(AutoCloseableLock auto = AutoCloseableLock.acquire(lock)) {
       for(;;) {
+        if (closed) {
+          return false;
+        }
         if (super.offer(element)) {
           notEmpty.signal();
           return true;

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -51,6 +51,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -242,10 +243,11 @@ class SegmentedRaftLogWorker {
   }
 
   void close() {
+    queue.close();
     this.running = false;
+    ConcurrentUtils.shutdownAndWait(TimeDuration.ONE_MINUTE, workerThreadExecutor,
+        timeout -> LOG.warn("{}: shutdown timeout in {}", name, timeout));
     Optional.ofNullable(flushExecutor).ifPresent(ExecutorService::shutdown);
-    ConcurrentUtils.shutdownAndWait(TimeDuration.ONE_SECOND.multiply(3),
-        workerThreadExecutor, timeout -> LOG.warn("{}: shutdown timeout in " + timeout, name));
     IOUtils.cleanup(LOG, out);
     PlatformDependent.freeDirectBuffer(writeBuffer);
     LOG.info("{} close()", name);
@@ -341,7 +343,7 @@ class SegmentedRaftLogWorker {
         LOG.info(Thread.currentThread().getName()
             + " was interrupted, exiting. There are " + queue.getNumElements()
             + " tasks remaining in the queue.");
-        return;
+        break;
       } catch (Exception e) {
         if (!running) {
           LOG.info("{} got closed and hit exception",
@@ -352,6 +354,8 @@ class SegmentedRaftLogWorker {
         }
       }
     }
+
+    queue.clear(Task::discard);
   }
 
   private boolean shouldFlush() {
@@ -494,7 +498,7 @@ class SegmentedRaftLogWorker {
     private final LogEntryProto entry;
     private final CompletableFuture<?> stateMachineFuture;
     private final CompletableFuture<Long> combined;
-    private final ReferenceCountedObject<LogEntryProto> ref;
+    private final AtomicReference<ReferenceCountedObject<LogEntryProto>> ref = new AtomicReference<>();
 
     WriteLog(ReferenceCountedObject<LogEntryProto> entryRef, LogEntryProto removedStateMachineData,
         TransactionContext context) {
@@ -512,7 +516,7 @@ class SegmentedRaftLogWorker {
           this.stateMachineFuture = null;
         }
         entryRef.retain();
-        this.ref = entryRef;
+        this.ref.set(entryRef);
       } else {
         try {
           // this.entry != origEntry if it has state machine data
@@ -522,7 +526,6 @@ class SegmentedRaftLogWorker {
               + ", entry=" + LogProtoUtils.toLogEntryString(origEntry, stateMachine::toStateMachineLogEntryString), e);
           throw e;
         }
-        this.ref = null;
       }
       this.combined = stateMachineFuture == null? super.getFuture()
           : super.getFuture().thenCombine(stateMachineFuture, (index, stateMachineResult) -> index);
@@ -532,6 +535,7 @@ class SegmentedRaftLogWorker {
     void failed(IOException e) {
       stateMachine.event().notifyLogFailed(e, entry);
       super.failed(e);
+      discard();
     }
 
     @Override
@@ -547,15 +551,14 @@ class SegmentedRaftLogWorker {
     @Override
     void done() {
       writeTasks.offerOrCompleteFuture(this);
-      if (ref != null) {
-        ref.release();
-      }
+      discard();
     }
 
     @Override
     void discard() {
-      if (ref != null) {
-        ref.release();
+      final ReferenceCountedObject<LogEntryProto> entryRef = ref.getAndSet(null);
+      if (entryRef != null) {
+        entryRef.release();
       }
     }
 


### PR DESCRIPTION
RATIS-2151

This is to fix the following problems described in https://github.com/apache/ratis/pull/1156
3. `GrpcClientProtocolService.UnorderedRequestStreamObserver.processClientRequest(..)` should use try-finally.
4. `GrpcLogAppender.appendLog(..)` calls `release()` incorrectly for exception.
6. `LogSegment` cache can release an entry multiple times.
7. `LogSegment.loadCache(..)` should call `retain()` for cache hit.
8. `SegmentedRaftLog.retainLog(..)`: between getting the entry and calling `retain()`, the entry can be released.  The "fail to retain" exception, if there is any, can be ignored since It is the same as a cache miss.  See #1153
9. `SegmentedRaftLog.retainEntryWithData(..)` should release for exception.
10. Test bug: the log entries stored in `SimpleStateMachine4Testing` can be released.
11. `LogSegment`: New entries can be added after EntryCache is closed.
13. `SegmentedRaftLogWorker` should clean up unfinished tasks in the queue after stopped running.