### PR TITLE
RATIS-2172. RaftServer may lose FollowerState

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/CodeInjectionForTesting.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/CodeInjectionForTesting.java
@@ -68,4 +68,9 @@ public final class CodeInjectionForTesting {
     }
     return code.execute(localId, remoteId, args);
   }
+
+  /** Remove an injection point. */
+  public static void remove(String injectionPoint) {
+    INJECTION_POINTS.remove(injectionPoint);
+  }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -253,10 +253,6 @@ class LeaderElection implements Runnable {
     }
 
     try (AutoCloseable ignored = Timekeeper.start(server.getLeaderElectionMetrics().getLeaderElectionTimer())) {
-      if (!server.isRunning()) {
-        LOG.info("{}: skip since the server is not running", this);
-        return;
-      }
       for (int round = 0; shouldRun(); round++) {
         if (skipPreVote || askForVotes(Phase.PRE_VOTE, round)) {
           if (askForVotes(Phase.ELECTION, round)) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -250,6 +250,8 @@ class RaftServerImpl implements RaftServer.Division,
   private final AtomicBoolean firstElectionSinceStartup = new AtomicBoolean(true);
   private final ThreadGroup threadGroup;
 
+  private Runnable testOnlyInject = () -> {};
+
   RaftServerImpl(RaftGroup group, StateMachine stateMachine, RaftServerProxy proxy, RaftStorage.StartupOption option)
       throws IOException {
     final RaftPeerId id = proxy.getId();
@@ -401,8 +403,14 @@ class RaftServerImpl implements RaftServer.Division,
 
     jmxAdapter.registerMBean();
     state.start();
+    testOnlyInject.run();;
     startComplete.compareAndSet(false, true);
     return true;
+  }
+
+  @VisibleForTesting
+  public void setTestOnlyInject(Runnable testOnlyInject) {
+    this.testOnlyInject = testOnlyInject;
   }
 
   /**

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1924,8 +1924,4 @@ class RaftServerImpl implements RaftServer.Division,
     return startComplete.get() && lifeCycle.getCurrentState() == State.RUNNING;
   }
 
-  @VisibleForTesting
-  private boolean getCompleteState() {
-    return startComplete.get();
-  }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -403,7 +403,9 @@ class RaftServerImpl implements RaftServer.Division,
     jmxAdapter.registerMBean();
     state.start();
     CodeInjectionForTesting.execute(START_COMPLETE, getId(), null, role);
-    startComplete.compareAndSet(false, true);
+    if (startComplete.compareAndSet(false, true)) {
+      LOG.info("{}: Successfully started.", getMemberId());
+    }
     return true;
   }
 
@@ -1923,5 +1925,4 @@ class RaftServerImpl implements RaftServer.Division,
   boolean isRunning() {
     return startComplete.get() && lifeCycle.getCurrentState() == State.RUNNING;
   }
-
 }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -98,6 +98,21 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
   }
 
   @Test
+  public void testWaitServerReady() throws Exception {
+    LOG.info("Running testWaitServerReady");
+
+    final MiniRaftCluster cluster = newCluster(1);
+    cluster.start(() -> {
+        try {
+          Thread.sleep(1000);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+    });
+    Assertions.assertTrue(RaftTestUtil.waitForLeader(cluster).getId() != null);
+    cluster.shutdown();
+  }
+  @Test
   public void testChangeLeader() throws Exception {
     SegmentedRaftLogTestUtils.setRaftLogWorkerLogLevel(Level.TRACE);
     LOG.info("Running testChangeLeader");

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -171,6 +171,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
       }
     }
     cluster.shutdown();;
+    CodeInjectionForTesting.remove(RaftServerImpl.START_COMPLETE);
   }
 
   @Test

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -145,8 +145,8 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         RaftClientReply reply = client.io().send(new RaftTestUtil.SimpleMessage("message_" + i));
         Assertions.assertTrue(reply.isSuccess());
       }
-      // add 3 new servers
-      CodeInjectionForTesting.put(RaftServerImpl.START_COMPLETE, new SleepCode(1000));
+      // add 3 new servers and wait longer time
+      CodeInjectionForTesting.put(RaftServerImpl.START_COMPLETE, new SleepCode(2000));
       MiniRaftCluster.PeerChanges peerChanges = cluster.addNewPeers(2, true, false);
       LOG.info("add new 3 servers");
       LOG.info(cluster.printServers());

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -100,15 +100,16 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
   @Test
   public void testWaitServerReady() throws Exception {
     LOG.info("Running testWaitServerReady");
-
     final MiniRaftCluster cluster = newCluster(1);
     cluster.start(() -> {
-        try {
-          Thread.sleep(1000);
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
+      // For all RaftServerImpl, let the state be not ready
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
     });
+    // Leader will be elected if the server is ready
     Assertions.assertTrue(RaftTestUtil.waitForLeader(cluster).getId() != null);
     cluster.shutdown();
   }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -346,6 +346,7 @@ public abstract class MiniRaftCluster implements Closeable {
     LOG.info(".............................................................. ");
 
     initServers();
+
     startServers(servers.values());
     this.timer.updateAndGet(t -> t != null? t
         : JavaUtils.runRepeatedly(() -> LOG.info("TIMED-PRINT: " + printServers()), 10, 10, TimeUnit.SECONDS));

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -344,8 +344,10 @@ public abstract class MiniRaftCluster implements Closeable {
     LOG.info("...     Starting " + JavaUtils.getClassSimpleName(getClass()));
     LOG.info("... ");
     LOG.info(".............................................................. ");
+
     initServers();
     startServers(servers.values());
+
     this.timer.updateAndGet(t -> t != null? t
         : JavaUtils.runRepeatedly(() -> LOG.info("TIMED-PRINT: " + printServers()), 10, 10, TimeUnit.SECONDS));
   }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -344,7 +344,6 @@ public abstract class MiniRaftCluster implements Closeable {
     LOG.info("...     Starting " + JavaUtils.getClassSimpleName(getClass()));
     LOG.info("... ");
     LOG.info(".............................................................. ");
-
     initServers();
     startServers(servers.values());
     this.timer.updateAndGet(t -> t != null? t

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -347,41 +347,8 @@ public abstract class MiniRaftCluster implements Closeable {
 
     initServers();
     startServers(servers.values());
-    servers.forEach((id, s) -> {
-        try {
-            s.getImpls().forEach(impl -> impl.setTestOnlyInject(() -> {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    });
     this.timer.updateAndGet(t -> t != null? t
         : JavaUtils.runRepeatedly(() -> LOG.info("TIMED-PRINT: " + printServers()), 10, 10, TimeUnit.SECONDS));
-  }
-
-  public void start(Runnable testOnly) throws IOException {
-    LOG.info(".............................................................. ");
-    LOG.info("... ");
-    LOG.info("...     Starting " + JavaUtils.getClassSimpleName(getClass()));
-    LOG.info("... ");
-    LOG.info(".............................................................. ");
-
-    initServers();
-    servers.forEach((id, s) -> {
-      try {
-        s.getImpls().forEach(impl -> impl.setTestOnlyInject(testOnly));
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    });
-    startServers(servers.values());
-    this.timer.updateAndGet(t -> t != null? t
-            : JavaUtils.runRepeatedly(() -> LOG.info("TIMED-PRINT: " + printServers()), 10, 10, TimeUnit.SECONDS));
   }
 
   /**

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -347,9 +347,41 @@ public abstract class MiniRaftCluster implements Closeable {
 
     initServers();
     startServers(servers.values());
-
+    servers.forEach((id, s) -> {
+        try {
+            s.getImpls().forEach(impl -> impl.setTestOnlyInject(() -> {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    });
     this.timer.updateAndGet(t -> t != null? t
         : JavaUtils.runRepeatedly(() -> LOG.info("TIMED-PRINT: " + printServers()), 10, 10, TimeUnit.SECONDS));
+  }
+
+  public void start(Runnable testOnly) throws IOException {
+    LOG.info(".............................................................. ");
+    LOG.info("... ");
+    LOG.info("...     Starting " + JavaUtils.getClassSimpleName(getClass()));
+    LOG.info("... ");
+    LOG.info(".............................................................. ");
+
+    initServers();
+    servers.forEach((id, s) -> {
+      try {
+        s.getImpls().forEach(impl -> impl.setTestOnlyInject(testOnly));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+    startServers(servers.values());
+    this.timer.updateAndGet(t -> t != null? t
+            : JavaUtils.runRepeatedly(() -> LOG.info("TIMED-PRINT: " + printServers()), 10, 10, TimeUnit.SECONDS));
   }
 
   /**

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -346,7 +346,6 @@ public abstract class MiniRaftCluster implements Closeable {
     LOG.info(".............................................................. ");
 
     initServers();
-
     startServers(servers.values());
     this.timer.updateAndGet(t -> t != null? t
         : JavaUtils.runRepeatedly(() -> LOG.info("TIMED-PRINT: " + printServers()), 10, 10, TimeUnit.SECONDS));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move server.isRunning () check from LeaderElection to FollowerState to ensure that the server is ready when it becomes a candidate

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2172

