### PR TITLE
RATIS-2177. Delete segmentLog from small to large according to logIndex

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -151,8 +151,8 @@ public class SegmentedRaftLogCache {
       if (toTruncate != null) {
         max = toTruncate.endIndex;
       }
-      for(SegmentFileInfo d : toDelete) {
-        max = Math.max(max, d.endIndex);
+      if (toDelete != null && toDelete.length > 0) {
+        max = Math.max(max, toDelete[0].endIndex);
       }
       return max;
     }
@@ -359,7 +359,7 @@ public class SegmentedRaftLogCache {
       try (AutoCloseableLock writeLock = writeLock()) {
         int segmentIndex = binarySearch(index);
         List<LogSegment> list = new LinkedList<>();
-
+        LOG.info("purgeLog are: {}", segments);
         if (segmentIndex == -segments.size() - 1) {
           list.addAll(segments);
           segments.clear();
@@ -383,6 +383,7 @@ public class SegmentedRaftLogCache {
         list.forEach(LogSegment::evictCache);
         List<SegmentFileInfo> toDelete = list.stream().map(SegmentFileInfo::newClosedSegmentFileInfo)
             .collect(Collectors.toList());
+        LOG.info("final toDelete: {}", toDelete);
         return list.isEmpty() ? null : new TruncationSegments("purge(" + index + ")", null, toDelete);
       }
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -151,8 +151,8 @@ public class SegmentedRaftLogCache {
       if (toTruncate != null) {
         max = toTruncate.endIndex;
       }
-      if (toDelete != null && toDelete.length > 0) {
-        max = Math.max(max, toDelete[0].endIndex);
+      for(SegmentFileInfo d : toDelete) {
+        max = Math.max(max, d.endIndex);
       }
       return max;
     }
@@ -359,7 +359,7 @@ public class SegmentedRaftLogCache {
       try (AutoCloseableLock writeLock = writeLock()) {
         int segmentIndex = binarySearch(index);
         List<LogSegment> list = new LinkedList<>();
-        LOG.info("purgeLog are: {}", segments);
+
         if (segmentIndex == -segments.size() - 1) {
           list.addAll(segments);
           segments.clear();
@@ -383,7 +383,6 @@ public class SegmentedRaftLogCache {
         list.forEach(LogSegment::evictCache);
         List<SegmentFileInfo> toDelete = list.stream().map(SegmentFileInfo::newClosedSegmentFileInfo)
             .collect(Collectors.toList());
-        LOG.info("final toDelete: {}", toDelete);
         return list.isEmpty() ? null : new TruncationSegments("purge(" + index + ")", null, toDelete);
       }
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -694,9 +694,7 @@ class SegmentedRaftLogWorker {
 
       if (segments.getToDelete() != null && segments.getToDelete().length > 0) {
         long minStart = segments.getToDelete()[0].getStartIndex();
-        SegmentFileInfo[] toDelete = segments.getToDelete();
-        for (int i = toDelete.length - 1; i >= 0; i--) {
-          final SegmentFileInfo del = toDelete[i];
+        for (SegmentFileInfo del : segments.getToDelete()) {
           final File delFile = del.getFile(storage);
           Preconditions.assertTrue(delFile.exists(),
               "File %s to be deleted does not exist", delFile);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -482,9 +482,10 @@ class SegmentedRaftLogWorker {
     void execute() throws IOException {
       if (segments.getToDelete() != null) {
         try(UncheckedAutoCloseable ignored = raftLogMetrics.startPurgeTimer()) {
-          for (SegmentFileInfo fileInfo : segments.getToDelete()) {
-            final Path deleted = FileUtils.deleteFile(fileInfo.getFile(storage));
-            LOG.info("{}: Purged RaftLog segment: info={}, path={}", name, fileInfo, deleted);
+          SegmentFileInfo[] toDeletes = segments.getToDelete();
+          for (int i = toDeletes.length - 1; i >= 0; i--) {
+            final Path deleted = FileUtils.deleteFile(toDeletes[i].getFile(storage));
+            LOG.info("{}: Purged RaftLog segment: info={}, path={}", name, toDeletes[i], deleted);
           }
         }
       }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -482,10 +482,9 @@ class SegmentedRaftLogWorker {
     void execute() throws IOException {
       if (segments.getToDelete() != null) {
         try(UncheckedAutoCloseable ignored = raftLogMetrics.startPurgeTimer()) {
-          SegmentFileInfo[] toDeletes = segments.getToDelete();
-          for (int i = toDeletes.length - 1; i >= 0; i--) {
-            final Path deleted = FileUtils.deleteFile(toDeletes[i].getFile(storage));
-            LOG.info("{}: Purged RaftLog segment: info={}, path={}", name, toDeletes[i], deleted);
+          for (SegmentFileInfo fileInfo : segments.getToDelete()) {
+            final Path deleted = FileUtils.deleteFile(fileInfo.getFile(storage));
+            LOG.info("{}: Purged RaftLog segment: info={}, path={}", name, fileInfo, deleted);
           }
         }
       }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -695,7 +695,9 @@ class SegmentedRaftLogWorker {
 
       if (segments.getToDelete() != null && segments.getToDelete().length > 0) {
         long minStart = segments.getToDelete()[0].getStartIndex();
-        for (SegmentFileInfo del : segments.getToDelete()) {
+        SegmentFileInfo[] toDelete = segments.getToDelete();
+        for (int i = toDelete.length - 1; i >= 0; i--) {
+          final SegmentFileInfo del = toDelete[i];
           final File delFile = del.getFile(storage);
           Preconditions.assertTrue(delFile.exists(),
               "File %s to be deleted does not exist", delFile);


### PR DESCRIPTION
see #RATIS-2177

In addition, I made some improvements to TruncateSegment.maxEndIndex (), because segments are sorted by index from largest to smallest, so returning the endIndex of the first segment is enough.