### PR TITLE
RATIS-2189. Use ByteBufAllocator#ioBuffer in NettyDataStreamUtils

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyDataStreamUtils.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyDataStreamUtils.java
@@ -103,11 +103,11 @@ public interface NettyDataStreamUtils {
       ByteBufAllocator allocator) {
     final ByteBuffer headerBuf = getDataStreamRequestHeaderProtoByteBuffer(request);
 
-    final ByteBuf headerBodyLenBuf = allocator.directBuffer(DataStreamPacketHeader.getSizeOfHeaderBodyLen());
+    final ByteBuf headerBodyLenBuf = allocator.ioBuffer(DataStreamPacketHeader.getSizeOfHeaderBodyLen());
     headerBodyLenBuf.writeLong(headerBuf.remaining() + request.getDataLength());
     out.accept(headerBodyLenBuf);
 
-    final ByteBuf headerLenBuf = allocator.directBuffer(DataStreamPacketHeader.getSizeOfHeaderLen());
+    final ByteBuf headerLenBuf = allocator.ioBuffer(DataStreamPacketHeader.getSizeOfHeaderLen());
     headerLenBuf.writeInt(headerBuf.remaining());
     out.accept(headerLenBuf);
 
@@ -152,7 +152,7 @@ public interface NettyDataStreamUtils {
   static void encodeDataStreamReplyByteBuffer(DataStreamReplyByteBuffer reply, Consumer<ByteBuf> out,
       ByteBufAllocator allocator) {
     ByteBuffer headerBuf = getDataStreamReplyHeaderProtoByteBuf(reply);
-    final ByteBuf headerLenBuf = allocator.directBuffer(DataStreamPacketHeader.getSizeOfHeaderLen());
+    final ByteBuf headerLenBuf = allocator.ioBuffer(DataStreamPacketHeader.getSizeOfHeaderLen());
     headerLenBuf.writeInt(headerBuf.remaining());
     out.accept(headerLenBuf);
     out.accept(Unpooled.wrappedBuffer(headerBuf));


### PR DESCRIPTION
## What changes were proposed in this pull request?

See https://issues.apache.org/jira/browse/RATIS-2189

## How was this patch tested?

Checked using `jmap -histo:live` that `DirectByteBuffer` are not created when using the following arguments:

```
-Dorg.apache.ratis.thirdparty.io.netty.noPreferDirect=true -Dorg.apache.ratis.thirdparty.io.netty.noUnsafe=true -Dorg.apache.ratis.thirdparty.io.netty.allocator.numDirectArenas=0
```
