### PR TITLE
RATIS-2197. Clean remote stream to resolve direct memory leak

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -153,6 +153,9 @@ public class DataStreamClientImpl implements DataStreamClient {
 
     private CompletableFuture<DataStreamReply> writeAsyncImpl(Object data, long length, Iterable<WriteOption> options) {
       if (isClosed()) {
+        if (data instanceof ByteBuf) {
+          ((ByteBuf) data).release();
+        }
         return JavaUtils.completeExceptionally(new AlreadyClosedException(
             clientId + ": stream already closed, request=" + header));
       }

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -462,7 +462,6 @@ public class DataStreamManagement {
       remoteWrites = Collections.emptyList();
     } else if (request.getType() == Type.STREAM_DATA) {
       if (close && request.getDataLength() == 0) {
-        info.getLocal().cleanUp();
         localWrite = CompletableFuture.completedFuture(0L);
       } else {
         localWrite = info.getLocal().write(request.slice(), request.getWriteOptionList(), writeExecutor);
@@ -486,6 +485,8 @@ public class DataStreamManagement {
       try {
         if (exception != null) {
           replyDataStreamException(server, exception, info.getRequest(), request, ctx);
+        }
+        if (close || exception != null) {
           final StreamInfo removed = removeDataStream(key);
           if (removed != null) {
             Preconditions.assertSame(info, removed, "removed");

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -390,8 +390,13 @@ public class DataStreamManagement {
   void cleanUp(Set<ClientInvocationId> ids) {
     for (ClientInvocationId clientInvocationId : ids) {
       Optional.ofNullable(streams.remove(clientInvocationId))
-          .map(StreamInfo::getLocal)
-          .ifPresent(LocalStream::cleanUp);
+          .ifPresent(streamInfo -> {
+            streamInfo.getDivision()
+                .getDataStreamMap()
+                .remove(clientInvocationId);
+            streamInfo.getLocal().cleanUp();
+            streamInfo.applyToRemotes(out -> out.out.closeAsync());
+          });
     }
   }
 
@@ -423,6 +428,7 @@ public class DataStreamManagement {
     if (info != null) {
       info.getDivision().getDataStreamMap().remove(invocationId);
       info.getLocal().cleanUp();
+      info.applyToRemotes(out -> out.out.closeAsync());
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

During perssure test using ratis streaming, we found direct memory leak.

After days of debugging, we found it's caused by uncleaned remote stream.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2197

## How was this patch tested?

Local performance test.
