### PR TITLE
RATIS-2191. Add ResourceLeakDetector to Netty tests

### DIFF
--- a/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreStreamingBaseTest.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreStreamingBaseTest.java
@@ -27,9 +27,6 @@ import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RoutingTable;
 import org.apache.ratis.server.impl.MiniRaftCluster;
 import org.apache.ratis.statemachine.StateMachine;
-import org.apache.ratis.thirdparty.io.netty.buffer.ByteBufUtil;
-import org.apache.ratis.thirdparty.io.netty.util.ResourceLeakDetector;
-import org.apache.ratis.thirdparty.io.netty.util.ResourceLeakDetector.Level;
 import org.apache.ratis.util.LogUtils;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.function.CheckedSupplier;
@@ -59,8 +56,7 @@ public abstract class FileStoreStreamingBaseTest <CLUSTER extends MiniRaftCluste
         FileStoreStateMachine.class, StateMachine.class);
     ConfUtils.setFile(p::setFile, FileStoreCommon.STATEMACHINE_DIR_KEY,
         new File(getClassTestDir(), "filestore"));
-    ResourceLeakDetector.setLevel(Level.PARANOID);
-    ByteBufUtil.setLeakListener(DataStreamTestUtils.LEAK_LISTENER);
+    DataStreamTestUtils.enableResourceLeakDetector();
   }
 
   static final int NUM_PEERS = 3;

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreStreamingBaseTest.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreStreamingBaseTest.java
@@ -27,6 +27,9 @@ import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RoutingTable;
 import org.apache.ratis.server.impl.MiniRaftCluster;
 import org.apache.ratis.statemachine.StateMachine;
+import org.apache.ratis.thirdparty.io.netty.buffer.ByteBufUtil;
+import org.apache.ratis.thirdparty.io.netty.util.ResourceLeakDetector;
+import org.apache.ratis.thirdparty.io.netty.util.ResourceLeakDetector.Level;
 import org.apache.ratis.util.LogUtils;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.function.CheckedSupplier;
@@ -56,6 +59,8 @@ public abstract class FileStoreStreamingBaseTest <CLUSTER extends MiniRaftCluste
         FileStoreStateMachine.class, StateMachine.class);
     ConfUtils.setFile(p::setFile, FileStoreCommon.STATEMACHINE_DIR_KEY,
         new File(getClassTestDir(), "filestore"));
+    ResourceLeakDetector.setLevel(Level.PARANOID);
+    ByteBufUtil.setLeakListener(DataStreamTestUtils.LEAK_LISTENER);
   }
 
   static final int NUM_PEERS = 3;

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyDataStreamUtils.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyDataStreamUtils.java
@@ -102,7 +102,7 @@ public interface NettyDataStreamUtils {
   static void encodeDataStreamRequestHeader(DataStreamRequest request, Consumer<Object> out,
       ByteBufAllocator allocator) {
     final ByteBuffer headerBuf = getDataStreamRequestHeaderProtoByteBuffer(request);
-
+    final ByteBuf leak = allocator.directBuffer(10);
     final ByteBuf headerBodyLenBuf = allocator.directBuffer(DataStreamPacketHeader.getSizeOfHeaderBodyLen());
     headerBodyLenBuf.writeLong(headerBuf.remaining() + request.getDataLength());
     out.accept(headerBodyLenBuf);
@@ -151,6 +151,7 @@ public interface NettyDataStreamUtils {
 
   static void encodeDataStreamReplyByteBuffer(DataStreamReplyByteBuffer reply, Consumer<ByteBuf> out,
       ByteBufAllocator allocator) {
+    final ByteBuf leak = allocator.directBuffer(10);
     ByteBuffer headerBuf = getDataStreamReplyHeaderProtoByteBuf(reply);
     final ByteBuf headerLenBuf = allocator.directBuffer(DataStreamPacketHeader.getSizeOfHeaderLen());
     headerLenBuf.writeInt(headerBuf.remaining());

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyDataStreamUtils.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyDataStreamUtils.java
@@ -102,7 +102,7 @@ public interface NettyDataStreamUtils {
   static void encodeDataStreamRequestHeader(DataStreamRequest request, Consumer<Object> out,
       ByteBufAllocator allocator) {
     final ByteBuffer headerBuf = getDataStreamRequestHeaderProtoByteBuffer(request);
-    final ByteBuf leak = allocator.directBuffer(10);
+
     final ByteBuf headerBodyLenBuf = allocator.directBuffer(DataStreamPacketHeader.getSizeOfHeaderBodyLen());
     headerBodyLenBuf.writeLong(headerBuf.remaining() + request.getDataLength());
     out.accept(headerBodyLenBuf);
@@ -151,7 +151,6 @@ public interface NettyDataStreamUtils {
 
   static void encodeDataStreamReplyByteBuffer(DataStreamReplyByteBuffer reply, Consumer<ByteBuf> out,
       ByteBufAllocator allocator) {
-    final ByteBuf leak = allocator.directBuffer(10);
     ByteBuffer headerBuf = getDataStreamReplyHeaderProtoByteBuf(reply);
     final ByteBuf headerLenBuf = allocator.directBuffer(DataStreamPacketHeader.getSizeOfHeaderLen());
     headerLenBuf.writeInt(headerBuf.remaining());

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamClusterTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamClusterTests.java
@@ -32,9 +32,6 @@ import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.server.RaftServer;
-import org.apache.ratis.thirdparty.io.netty.buffer.ByteBufUtil;
-import org.apache.ratis.thirdparty.io.netty.util.ResourceLeakDetector;
-import org.apache.ratis.thirdparty.io.netty.util.ResourceLeakDetector.Level;
 import org.apache.ratis.util.CollectionUtils;
 import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.Timestamp;
@@ -55,8 +52,7 @@ public abstract class DataStreamClusterTests<CLUSTER extends MiniRaftCluster> ex
     implements MiniRaftCluster.Factory.Get<CLUSTER> {
   {
     setStateMachine(MultiDataStreamStateMachine.class);
-    ResourceLeakDetector.setLevel(Level.PARANOID);
-    ByteBufUtil.setLeakListener(DataStreamTestUtils.LEAK_LISTENER);
+    DataStreamTestUtils.enableResourceLeakDetector();
   }
 
   public static final int NUM_SERVERS = 3;

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamClusterTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamClusterTests.java
@@ -32,6 +32,9 @@ import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.thirdparty.io.netty.buffer.ByteBufUtil;
+import org.apache.ratis.thirdparty.io.netty.util.ResourceLeakDetector;
+import org.apache.ratis.thirdparty.io.netty.util.ResourceLeakDetector.Level;
 import org.apache.ratis.util.CollectionUtils;
 import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.Timestamp;
@@ -52,6 +55,8 @@ public abstract class DataStreamClusterTests<CLUSTER extends MiniRaftCluster> ex
     implements MiniRaftCluster.Factory.Get<CLUSTER> {
   {
     setStateMachine(MultiDataStreamStateMachine.class);
+    ResourceLeakDetector.setLevel(Level.PARANOID);
+    ByteBufUtil.setLeakListener(DataStreamTestUtils.LEAK_LISTENER);
   }
 
   public static final int NUM_SERVERS = 3;

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamTestUtils.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamTestUtils.java
@@ -423,8 +423,7 @@ public interface DataStreamTestUtils {
   }
 
   ResourceLeakDetector.LeakListener LEAK_LISTENER = (resourceType, records) -> {
-    throw new IllegalStateException("Leak detected for resource type: " + resourceType +
-        ", records: " + records);
+    throw new IllegalStateException("Leak detected for resource type: " + resourceType + records);
   };
 
   static void enableResourceLeakDetector() {

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamTestUtils.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamTestUtils.java
@@ -46,7 +46,9 @@ import org.apache.ratis.statemachine.StateMachine.DataStream;
 import org.apache.ratis.statemachine.TransactionContext;
 import org.apache.ratis.statemachine.impl.BaseStateMachine;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.io.netty.buffer.ByteBufUtil;
 import org.apache.ratis.thirdparty.io.netty.util.ResourceLeakDetector;
+import org.apache.ratis.thirdparty.io.netty.util.ResourceLeakDetector.Level;
 import org.apache.ratis.util.CollectionUtils;
 import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.JavaUtils;
@@ -420,8 +422,13 @@ public interface DataStreamTestUtils {
     Assertions.assertEquals(entryFromStream, entryFromLog);
   }
 
-  static ResourceLeakDetector.LeakListener LEAK_LISTENER = (resourceType, records) -> {
+  ResourceLeakDetector.LeakListener LEAK_LISTENER = (resourceType, records) -> {
     throw new IllegalStateException("Leak detected for resource type: " + resourceType +
         ", records: " + records);
   };
+
+  static void enableResourceLeakDetector() {
+    ResourceLeakDetector.setLevel(Level.PARANOID);
+    ByteBufUtil.setLeakListener(DataStreamTestUtils.LEAK_LISTENER);
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamTestUtils.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamTestUtils.java
@@ -46,6 +46,7 @@ import org.apache.ratis.statemachine.StateMachine.DataStream;
 import org.apache.ratis.statemachine.TransactionContext;
 import org.apache.ratis.statemachine.impl.BaseStateMachine;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.io.netty.util.ResourceLeakDetector;
 import org.apache.ratis.util.CollectionUtils;
 import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.JavaUtils;
@@ -418,4 +419,9 @@ public interface DataStreamTestUtils {
     final LogEntryProto entryFromLog = searchLogEntry(ClientInvocationId.valueOf(request), division.getRaftLog());
     Assertions.assertEquals(entryFromStream, entryFromLog);
   }
+
+  static ResourceLeakDetector.LeakListener LEAK_LISTENER = (resourceType, records) -> {
+    throw new IllegalStateException("Leak detected for resource type: " + resourceType +
+        ", records: " + records);
+  };
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similar to LeakDetector#assertNoLeaks in MiniRaftCluster, we can also add the Netty leak detector in tests as specified in https://netty.io/wiki/reference-counted-objects.html#wiki-h2-9 to ensure that all ByteBuf are released.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2191

## How was this patch tested?

Intentionally add leak add check that `IllegalStateException` is thrown: https://github.com/ivandika3/ratis/actions/runs/11871018319/job/33121223662
