### PR TITLE
RATIS-2199. Release once on exception

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -476,13 +476,17 @@ public class DataStreamManagement {
           }
           return null;
         }, requestExecutor)).whenComplete((v, exception) -> {
+      boolean released = false;
       try {
         if (exception != null) {
           replyDataStreamException(server, exception, info.getRequest(), request, ctx);
           removeDataStream(key, info);
+          released = true;
         }
       } finally {
-        request.release();
+        if (!released) {
+          request.release();
+        }
         channels.remove(channelId, key);
       }
     });


### PR DESCRIPTION
## What changes were proposed in this pull request?

On exception, the resource is released once in replyDataStreamException.

And it will be released again in "finally".

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2199

## How was this patch tested?

Local pressure tests.
