### PR TITLE
RATIS-2194. FileLock didn't unlock properly

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -416,6 +416,13 @@ class RaftServerProxy implements RaftServer {
   public void close() {
     lifeCycle.checkStateAndClose(() -> {
       LOG.info("{}: close", getId());
+
+      try {
+        ConcurrentUtils.shutdownAndWait(implExecutor.get());
+      } catch (Exception ignored) {
+        LOG.warn(getId() + ": Failed to shutdown implExecutor", ignored);
+      }
+
       impls.close();
 
       try {
@@ -428,12 +435,6 @@ class RaftServerProxy implements RaftServer {
         getDataStreamServerRpc().close();
       } catch (IOException ignored) {
         LOG.warn(getId() + ": Failed to close " + SupportedDataStreamType.NETTY + " server", ignored);
-      }
-
-      try {
-        ConcurrentUtils.shutdownAndWait(implExecutor.get());
-      } catch (Exception ignored) {
-        LOG.warn(getId() + ": Failed to shutdown implExecutor", ignored);
       }
 
       try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Found OverlappingFileLockExceptio when restarting RaftServer. 

When closing `RaftServerProxy`, all `RaftServerImpl` in `implMap` should be closed. However, if there was a new `RaftServerImpl` started by `RaftServerProxy#groupManagementAsync`, it would not be closed properly. The log will say that the new `RaftServerImpl` has been closed, but its raft store is still being initialised by `implExecutor`.

Things change:
- Closing implExecutor before closing implMap prevents RaftServerImpl from starting after it is closed by implMap.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2194

## How was this patch tested?
https://github.com/chungen0126/ratis/actions/runs/12008556158
