### PR TITLE
RATIS-2185. Improve gRPC log messages debugability.

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
@@ -190,7 +190,7 @@ public interface GrpcUtil {
   }
 
   static void warn(Logger log, Supplier<String> message, Throwable t) {
-    LogUtils.warn(log, message, unwrapThrowable(t), StatusRuntimeException.class, ServerNotReadyException.class);
+    LogUtils.warn(log, message, unwrapThrowable(t), ServerNotReadyException.class);
   }
 
   class StatusRuntimeExceptionMetadataBuilder {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Log StatusRuntimeException full stack trace.
I think part of the problem we saw in RATIS-2135 as well as some other related issues is that StatusRuntimeException only logs the exception messages. Therefore it "hides" the severity of the issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2185

## How was this patch tested?

No test. This is a logging only change.