### PR TITLE
RATIS-2204. Avoid downloads from repository.apache.org

### DIFF
--- a/dev-support/checks/build.sh
+++ b/dev-support/checks/build.sh
@@ -20,7 +20,7 @@ source "${DIR}/../find_maven.sh"
 
 : ${WITH_COVERAGE:="false"}
 
-MAVEN_OPTIONS='-V -B -Dmaven.javadoc.skip=true -DskipTests --no-transfer-progress'
+MAVEN_OPTIONS='-V -B -Dmaven.javadoc.skip=true -DskipTests'
 
 if [[ "${WITH_COVERAGE}" != "true" ]]; then
   MAVEN_OPTIONS="${MAVEN_OPTIONS} -Djacoco.skip"

--- a/dev-support/checks/checkstyle.sh
+++ b/dev-support/checks/checkstyle.sh
@@ -23,7 +23,7 @@ REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../target/checkstyle"}
 mkdir -p "$REPORT_DIR"
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-MAVEN_OPTIONS='-B -fae --no-transfer-progress -Dcheckstyle.failOnViolation=false'
+MAVEN_OPTIONS='-B -fae -Dcheckstyle.failOnViolation=false'
 
 declare -i rc
 ${MVN} ${MAVEN_OPTIONS} checkstyle:check | tee  "${REPORT_DIR}/output.log"

--- a/dev-support/checks/coverage.sh
+++ b/dev-support/checks/coverage.sh
@@ -29,7 +29,7 @@ mkdir -p "$REPORT_DIR"
 JACOCO_VERSION=$(${MVN} help:evaluate -Dexpression=jacoco.version -q -DforceStdout)
 
 #Install jacoco cli
-${MVN} --non-recursive --no-transfer-progress \
+${MVN} --non-recursive \
   org.apache.maven.plugins:maven-dependency-plugin:3.6.1:copy \
   -Dartifact=org.jacoco:org.jacoco.cli:${JACOCO_VERSION}:jar:nodeps
 

--- a/dev-support/checks/findbugs.sh
+++ b/dev-support/checks/findbugs.sh
@@ -20,7 +20,7 @@ source "${DIR}/../find_maven.sh"
 
 : ${WITH_COVERAGE:="false"}
 
-MAVEN_OPTIONS='-B -fae --no-transfer-progress'
+MAVEN_OPTIONS='-B -fae'
 
 if ! type unionBugs >/dev/null 2>&1 || ! type convertXmlToText >/dev/null 2>&1; then
   #shellcheck disable=SC2086

--- a/dev-support/checks/rat.sh
+++ b/dev-support/checks/rat.sh
@@ -23,7 +23,7 @@ mkdir -p "$REPORT_DIR"
 
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-${MVN} -B -fn --no-transfer-progress org.apache.rat:apache-rat-plugin:0.13:check
+${MVN} -B -fn org.apache.rat:apache-rat-plugin:0.13:check
 
 cd "$DIR/../.." || exit 1
 

--- a/dev-support/checks/repro.sh
+++ b/dev-support/checks/repro.sh
@@ -20,7 +20,7 @@ source "${DIR}/../find_maven.sh"
 
 : ${WITH_COVERAGE:="false"}
 
-MAVEN_OPTIONS='-V -B -Dmaven.javadoc.skip=true -DskipTests --no-transfer-progress'
+MAVEN_OPTIONS='-V -B -Dmaven.javadoc.skip=true -DskipTests'
 
 if [[ "${WITH_COVERAGE}" != "true" ]]; then
   MAVEN_OPTIONS="${MAVEN_OPTIONS} -Djacoco.skip"

--- a/dev-support/checks/sonar.sh
+++ b/dev-support/checks/sonar.sh
@@ -23,7 +23,7 @@ if [ ! "$SONAR_TOKEN" ]; then
   exit 1
 fi
 
-${MVN} -B verify -DskipShade -DskipTests --no-transfer-progress \
+${MVN} -B verify -DskipShade -DskipTests \
   org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar \
   -Dsonar.coverage.jacoco.xmlReportPaths="$(pwd)/target/coverage/all.xml" \
   -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache-ratis

--- a/dev-support/checks/unit.sh
+++ b/dev-support/checks/unit.sh
@@ -34,7 +34,7 @@ REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../target/unit"}
 mkdir -p "$REPORT_DIR"
 
 export MAVEN_OPTS="-Xmx4096m"
-MAVEN_OPTIONS='-V -B --no-transfer-progress'
+MAVEN_OPTIONS='-V -B'
 
 if [[ "${FAIL_FAST}" == "true" ]]; then
   MAVEN_OPTIONS="${MAVEN_OPTIONS} --fail-fast -Dsurefire.skipAfterFailureCount=1"

--- a/pom.xml
+++ b/pom.xml
@@ -1098,7 +1098,7 @@
               <execution>
                 <phase>package</phase>
                 <goals>
-                  <goal>makeAggregateBom</goal>
+                  <goal>makeBom</goal>
                 </goals>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,9 @@
       <id>${distMgmtSnapshotsId}</id>
       <name>${distMgmtSnapshotsName}</name>
       <url>${distMgmtSnapshotsUrl}</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
     </repository>
     <repository>
       <id>repository.jboss.org</id>
@@ -90,13 +93,6 @@
     <module>ratis-shell</module>
     <module>ratis-assembly</module>
   </modules>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>apache.snapshots</id>
-      <url>https://repository.apache.org/snapshots/</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <scm>
     <connection>scm:git:git://git.apache.org/ratis.git</connection>


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Avoid looking for release artifacts in `apache.snapshots.https` repo.
2. Remove `apache.snapshots` plugin repo (not using snapshot plugins; I think regular repository is used for plugin downloads anyway)
3. Generate non-aggregate BOM (`makeBom`) for the root module as a workaround for https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/410.
4. Enable logging transfer progress in build scripts.  This helps understanding any CI check runs stuck in downloading artifacts (which is a problem recently).  We may revert this part of the change in the future, if we find that problems related to repositories are resolved.

https://issues.apache.org/jira/browse/RATIS-2204

## How was this patch tested?

Verified that CI checks download most artifacts from `central` ([example](https://github.com/adoroszlai/ratis/actions/runs/12254198850/job/34184581147#step:4:8)):

```
[INFO] Downloading from repository.jboss.org: https://repository.jboss.org/nexus/content/groups/public/org/apache/apache/25/apache-25.pom
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/25/apache-25.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/25/apache-25.pom (21 kB at 685 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/kr/motd/maven/os-maven-plugin/1.5.0.Final/os-maven-plugin-1.5.0.Final.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/kr/motd/maven/os-maven-plugin/1.5.0.Final/os-maven-plugin-1.5.0.Final.pom (6.4 kB at 1.1 MB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom (6.6 kB at 1.1 MB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.2.1/maven-plugin-api-3.2.1.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.2.1/maven-plugin-api-3.2.1.pom (3.4 kB at 846 kB/s)
...
```

CI:
https://github.com/adoroszlai/ratis/actions/runs/12254198850