### PR TITLE
RATIS-2211. publish-mvn fails with: ... did not assign a file to the build artifact

### DIFF
--- a/dev-support/make_rc.sh
+++ b/dev-support/make_rc.sh
@@ -121,6 +121,11 @@ mvnFun() {
   mvnFun clean verify -DskipTests=true  -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}"
 }
 
+3-publish-mvn() {
+  cd "$projectdir"
+  mvnFun verify artifact:compare deploy:deploy -DdeployAtEnd=true -DskipTests=true -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}" "$@"
+}
+
 4-assembly() {
   cd "$SVNDISTDIR"
   RCDIR="$SVNDISTDIR/${RATISVERSION}/${RC#-}"
@@ -143,11 +148,6 @@ mvnFun() {
 6-publish-svn() {
    cd "${SVNDISTDIR}"
   svn commit -m "Publish proposed version of the next Ratis release ${RATISVERSION}${RC}"
-}
-
-3-publish-mvn(){
-  cd "$projectdir"
-  mvnFun verify artifact:compare deploy:deploy -DdeployAtEnd=true -DskipTests=true -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}" "$@"
 }
 
 if [ "$#" -lt 1 ]; then

--- a/dev-support/make_rc.sh
+++ b/dev-support/make_rc.sh
@@ -91,7 +91,7 @@ mvnFun() {
   MAVEN_OPTS="${mvnopts}" ${MVN} -Dmaven.repo.local="${repodir}" "$@"
 }
 
-prepare-src() {
+1-prepare-src() {
   cd "$projectdir"
   git reset --hard
   git clean -fdx
@@ -109,7 +109,7 @@ prepare-src() {
   mvnFun clean install -DskipTests=true  -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}"
 }
 
-prepare-bin() {
+2-verify-bin() {
   echo "Cleaning up workingdir $WORKINGDIR"
   rm -rf "$WORKINGDIR"
   mkdir -p "$WORKINGDIR"
@@ -121,7 +121,7 @@ prepare-bin() {
   mvnFun clean verify -DskipTests=true  -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}"
 }
 
-assembly() {
+4-assembly() {
   cd "$SVNDISTDIR"
   RCDIR="$SVNDISTDIR/${RATISVERSION}/${RC#-}"
   mkdir -p "$RCDIR"
@@ -135,40 +135,40 @@ assembly() {
   svn add "${RATISVERSION}" || svn add "${RATISVERSION}/${RC#-}"
 }
 
-publish-git(){
+5-publish-git(){
   cd "$projectdir"
   git push apache "ratis-${RATISVERSION}${RC}"
 }
 
-publish-svn() {
+6-publish-svn() {
    cd "${SVNDISTDIR}"
   svn commit -m "Publish proposed version of the next Ratis release ${RATISVERSION}${RC}"
 }
 
-publish-mvn(){
+3-publish-mvn(){
   cd "$projectdir"
-  mvnFun deploy:deploy
+  mvnFun verify artifact:compare deploy:deploy -DdeployAtEnd=true -DskipTests=true -Prelease -Papache-release -Dgpg.keyname="${CODESIGNINGKEY}" "$@"
 }
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -lt 1 ]; then
   cat << EOF
 
-Please choose from available phases (eg. make_rc.sh prepare-src):
+Please choose from available phases (eg. make_rc.sh 1-prepare-src):
 
-   1. prepare-src: This is the first step. It modifies the mvn version, creates the git tag and
+   1-prepare-src:  This is the first step. It modifies the mvn version, creates the git tag and
                    builds the project to create the source artifacts.
                    IT INCLUDES A GIT RESET + CLEAN. ALL THE LOCAL CHANGES WILL BE LOST!
 
-   2. prepare-bin: The source artifact is copied to the $WORKINGDIR and the binary artifact is created from the source.
+   2-verify-bin:   The source artifact is copied to the $WORKINGDIR and the binary artifact is created from the source.
                    This is an additional check as the the released source artifact should be enough to build the whole project.
 
-   3. assembly :   This step copies all the required artifacts to the svn directory and ($SVNDISTDIR) creates the signatures/checksum files.
+   3-publish-mvn:  Performs the final build, and uploads the artifacts to the maven staging repository
 
-   4. publish-git: The first remote step, only do it if everything is fine. It pushes the rc tag to the repository.
+   4-assembly:     This step copies all the required artifacts to the svn directory and ($SVNDISTDIR) creates the signatures/checksum files.
 
-   5. publish-svn: Uploads the artifacts to the apache dev staging area to start the vote.
+   5-publish-git:  Only do it if everything is fine. It pushes the rc tag to the repository.
 
-   6. publish-mvn: Uploads the artifacts to the maven staging repository
+   6-publish-svn:  Uploads the artifacts to the apache dev staging area to start the vote.
 
 The next steps of the release process are not scripted:
 
@@ -189,5 +189,7 @@ The next steps of the release process are not scripted:
 EOF
 else
   set -x
-  eval "$1"
+  func="$1"
+  shift
+  eval "$func" "$@"
 fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

RATIS-2206 introduced a problem in the release process: plain `deploy:deploy` fails for modules with `packaging=jar`.  Previous test has not revealed this, because the first module is a `pom`, deployment was attempted, and it was expected to fail due to lack of authentication.

It turns out we cannot skip re-build of the project.  However, we can reorder steps to ensure items published to Maven and Subversions are consistent.
(Alternatively we could publish files one-by-one using `deploy:deploy-file`, but it's error-prone.)

I think it is safe to publish to the Maven staging repo before adding files to Subversion locally, since it can be discarded if needed.  So the order is now:

1. `prepare-src`
2. `verify-bin` (renamed from `prepare-bin` to better reflect its purpose)
3. `publish-mvn`
4. `assembly`
5. `publish-git`
6. `publish-svn`

Artifacts published to Maven and Subversion are both produced by the `publish-mvn` step.

Also added numeric prefix to the step names to avoid accidental usage in the old order.

Added `-DdeployAtEnd=true` flag to avoid partially published repo in case any module fails to re-build.

https://issues.apache.org/jira/browse/RATIS-2211

## How was this patch tested?

Performed release steps.  Deployed to local dir, to allow testing full deployment without authentication.

```
$ git checkout -b RATIS-2211-test

$ export RATISVERSION="3.2.0"  RC="-test-RATIS-2211"  CODESIGNINGKEY="..."

$ ./dev-support/make_rc.sh 1-prepare-src

$ ./dev-support/make_rc.sh 2-verify-bin

$ ./dev-support/make_rc.sh 3-publish-mvn -DaltDeploymentRepository=local::default::file:///tmp/ratis.staging-repo
...
[INFO] --- deploy:2.8.2:deploy (default-cli) @ ratis-assembly ---
[INFO] Using alternate deployment repository local::default::file:///tmp/ratis.staging-repo
Uploading to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis/3.2.0/ratis-3.2.0.pom
Uploaded to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis/3.2.0/ratis-3.2.0.pom (42 kB at 21 MB/s)
Downloading from local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis/maven-metadata.xml
Uploading to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis/maven-metadata.xml
Uploaded to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis/maven-metadata.xml (301 B at 301 kB/s)
...
Uploading to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis-server/3.2.0/ratis-server-3.2.0-sources.jar
Uploaded to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis-server/3.2.0/ratis-server-3.2.0-sources.jar (222 kB at 222 MB/s)
Uploading to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis-server/3.2.0/ratis-server-3.2.0-tests.jar
Uploaded to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis-server/3.2.0/ratis-server-3.2.0-tests.jar (329 kB at 165 MB/s)
Uploading to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis-server/3.2.0/ratis-server-3.2.0-test-sources.jar
Uploaded to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis-server/3.2.0/ratis-server-3.2.0-test-sources.jar (142 kB at 142 MB/s)
Uploading to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis-server/3.2.0/ratis-server-3.2.0-javadoc.jar
Uploaded to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis-server/3.2.0/ratis-server-3.2.0-javadoc.jar (299 kB at 150 MB/s)
...
Uploading to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis-assembly/3.2.0/ratis-assembly-3.2.0-src.tar.gz
Uploaded to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis-assembly/3.2.0/ratis-assembly-3.2.0-src.tar.gz (807 kB at 161 MB/s)
Uploading to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis-assembly/3.2.0/ratis-assembly-3.2.0-bin.tar.gz
Uploaded to local: file:///tmp/ratis.staging-repo/org/apache/ratis/ratis-assembly/3.2.0/ratis-assembly-3.2.0-bin.tar.gz (38 MB at 197 MB/s)
...
[INFO] BUILD SUCCESS
...
[INFO] Total time:  42.592 s

$ ./dev-support/make_rc.sh 4-assembly
```