### PR TITLE
RATIS-2216. Bump maven-shade-plugin to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
     <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
     <maven-clover2-plugin.version>4.0.6</maven-clover2-plugin.version>
     <maven-pdf-plugin.version>1.6.1</maven-pdf-plugin.version>
+    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <wagon-ssh.version>3.5.3</wagon-ssh.version>
     <hadoop-maven-plugins.version>3.4.0</hadoop-maven-plugins.version>
@@ -493,6 +494,11 @@
               <additionalJOption>-Xdoclint:-missing</additionalJOption>
             </additionalJOptions>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>${maven-shade-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>com.github.spotbugs</groupId>

--- a/ratis-examples/pom.xml
+++ b/ratis-examples/pom.xml
@@ -150,7 +150,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/ratis-experiments/pom.xml
+++ b/ratis-experiments/pom.xml
@@ -120,7 +120,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <filters>
                 <filter>


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Bump `maven-shade-plugin` from 3.2.4 to 3.6.0 (current latest), since versions before 3.5.3 may have non-reproducible output:

```bash
$ mvn artifact:check-buildplan
...
[INFO] --- artifact:3.5.3:check-buildplan (default-cli) @ ratis-examples ---
[ERROR] plugin with non-reproducible output: org.apache.maven.plugins:maven-shade-plugin:3.2.4, require minimum 3.5.3
```

2. Disable creation of `dependency-reduced-pom.xml` (affects the `ratis-examples` and `ratis-experiments` modules).  These files are written to `dependencyReducedPomLocation`.  The problem is that

> setting a value for this parameter with a directory other than `${basedir}` will change the value of `${basedir}` for all executions that come after the shade execution. This is often not what you want. This is considered an open issue with this plugin. ([source](https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html#dependencyReducedPomLocation))

Using new version of `maven-shade-plugin` upgrades some other plugin dependencies, which changes the behavior of `maven-assembly-plugin`.  The end result is that the assembly does not find `ratis-examples` and creates tarballs without that module.  ([CI build fails](https://github.com/adoroszlai/ratis/actions/runs/12411463434/job/34649283536#step:6:16) when only `maven-shade-plugin` version is [bumped](https://github.com/adoroszlai/ratis/commit/95c787972a8f414df4f86e31ec22990de7447d0b).)

One possible workaround for the plugin issue is to use the default value of `${basedir}/dependency-reduced-pom.xml`.  However, this creates the file in the module root dir, failing the `apache-rat-plugin` check on next build.

My assumption is that `ratis-examples` and `ratis-experiments` modules are not used as dependencies in third-party projects (which is where the dependency-reduced POM would be useful).

https://issues.apache.org/jira/browse/RATIS-2216

## How was this patch tested?

Built both current `master` and the patch.  Checked `ratis-assembly` tarballs for differences.