### PR TITLE
RATIS-2219. Remove duplicate test case from TestRaftWithGrpc

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
@@ -31,6 +31,7 @@ import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -52,6 +53,12 @@ public class TestRaftWithGrpc
 
   public static Collection<Boolean[]> data() {
     return Arrays.asList((new Boolean[][] {{Boolean.FALSE}, {Boolean.TRUE}}));
+  }
+
+  @Disabled
+  @Override
+  public void testWithLoad() {
+    // skip testWithLoad() from parent, called from parameterized testWithLoad(boolean)
   }
 
   @ParameterizedTest

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
@@ -33,10 +33,8 @@ import org.apache.ratis.util.TimeDuration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -51,10 +49,6 @@ public class TestRaftWithGrpc
         SimpleStateMachine4Testing.class, StateMachine.class);
   }
 
-  public static Collection<Boolean[]> data() {
-    return Arrays.asList((new Boolean[][] {{Boolean.FALSE}, {Boolean.TRUE}}));
-  }
-
   @Disabled
   @Override
   public void testWithLoad() {
@@ -62,23 +56,23 @@ public class TestRaftWithGrpc
   }
 
   @ParameterizedTest
-  @MethodSource("data")
-  public void testWithLoad(Boolean separateHeartbeat) throws Exception {
+  @ValueSource(booleans = {true, false})
+  public void testWithLoad(boolean separateHeartbeat) throws Exception {
     GrpcConfigKeys.Server.setHeartbeatChannel(getProperties(), separateHeartbeat);
     super.testWithLoad();
     BlockRequestHandlingInjection.getInstance().unblockAll();
   }
 
   @ParameterizedTest
-  @MethodSource("data")
-  public void testRequestTimeout(Boolean separateHeartbeat) throws Exception {
+  @ValueSource(booleans = {true, false})
+  public void testRequestTimeout(boolean separateHeartbeat) throws Exception {
     GrpcConfigKeys.Server.setHeartbeatChannel(getProperties(), separateHeartbeat);
     runWithNewCluster(NUM_SERVERS, cluster -> testRequestTimeout(false, cluster, LOG));
   }
 
   @ParameterizedTest
-  @MethodSource("data")
-  public void testUpdateViaHeartbeat(Boolean separateHeartbeat) throws Exception {
+  @ValueSource(booleans = {true, false})
+  public void testUpdateViaHeartbeat(boolean separateHeartbeat) throws Exception {
     GrpcConfigKeys.Server.setHeartbeatChannel(getProperties(), separateHeartbeat);
     runWithNewCluster(NUM_SERVERS, this::runTestUpdateViaHeartbeat);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestRaftWithGrpc#testWithLoad` is run 3 times, twice with the same value for `raft.grpc.server.heartbeat.channel`.  This happens because `testWithLoad(boolean)` no longer overrides `testWithLoad` from parent class after RATIS-1976.

```
$ mvn -am -pl :ratis-test clean test -Dtest='TestRaftWithGrpc' -Dsurefire.reportFormat=plain
...
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 174.463 s - in org.apache.ratis.grpc.TestRaftWithGrpc
org.apache.ratis.grpc.TestRaftWithGrpc.testStateMachineMetrics  Time elapsed: 3.415 s
org.apache.ratis.grpc.TestRaftWithGrpc.testBasicAppendEntries  Time elapsed: 12.339 s
org.apache.ratis.grpc.TestRaftWithGrpc.testBasicAppendEntriesKillLeader  Time elapsed: 11.075 s
org.apache.ratis.grpc.TestRaftWithGrpc.testOldLeaderCommit  Time elapsed: 5.489 s
org.apache.ratis.grpc.TestRaftWithGrpc.testWithLoad  Time elapsed: 39.118 s
org.apache.ratis.grpc.TestRaftWithGrpc.testOldLeaderNotCommit  Time elapsed: 5.974 s
org.apache.ratis.grpc.TestRaftWithGrpc.testWithLoad(Boolean)[1]  Time elapsed: 35.295 s
org.apache.ratis.grpc.TestRaftWithGrpc.testWithLoad(Boolean)[2]  Time elapsed: 31.996 s
org.apache.ratis.grpc.TestRaftWithGrpc.testRequestTimeout(Boolean)[1]  Time elapsed: 8.094 s
org.apache.ratis.grpc.TestRaftWithGrpc.testRequestTimeout(Boolean)[2]  Time elapsed: 8.178 s
org.apache.ratis.grpc.TestRaftWithGrpc.testUpdateViaHeartbeat(Boolean)[1]  Time elapsed: 6.718 s
org.apache.ratis.grpc.TestRaftWithGrpc.testUpdateViaHeartbeat(Boolean)[2]  Time elapsed: 6.675 s
```

Also, simplify parameterized test cases (use `boolean` instead of `Boolean`).

https://issues.apache.org/jira/browse/RATIS-2219

## How was this patch tested?

```
$ mvn -am -pl :ratis-test clean test -Dtest='TestRaftWithGrpc' -Dsurefire.reportFormat=plain
...
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 136.215 s - in org.apache.ratis.grpc.TestRaftWithGrpc
[INFO] org.apache.ratis.grpc.TestRaftWithGrpc.testStateMachineMetrics  Time elapsed: 2.96 s
[INFO] org.apache.ratis.grpc.TestRaftWithGrpc.testBasicAppendEntries  Time elapsed: 11.725 s
[INFO] org.apache.ratis.grpc.TestRaftWithGrpc.testBasicAppendEntriesKillLeader  Time elapsed: 11.64 s
[INFO] org.apache.ratis.grpc.TestRaftWithGrpc.testOldLeaderCommit  Time elapsed: 5.784 s
[INFO] org.apache.ratis.grpc.TestRaftWithGrpc.testOldLeaderNotCommit  Time elapsed: 5.727 s
[INFO] org.apache.ratis.grpc.TestRaftWithGrpc.testWithLoad(boolean)[1]  Time elapsed: 35.745 s
[INFO] org.apache.ratis.grpc.TestRaftWithGrpc.testWithLoad(boolean)[2]  Time elapsed: 32.84 s
[INFO] org.apache.ratis.grpc.TestRaftWithGrpc.testRequestTimeout(boolean)[1]  Time elapsed: 8.183 s
[INFO] org.apache.ratis.grpc.TestRaftWithGrpc.testRequestTimeout(boolean)[2]  Time elapsed: 8.181 s
[INFO] org.apache.ratis.grpc.TestRaftWithGrpc.testUpdateViaHeartbeat(boolean)[1]  Time elapsed: 6.683 s
[INFO] org.apache.ratis.grpc.TestRaftWithGrpc.testUpdateViaHeartbeat(boolean)[2]  Time elapsed: 6.658 s
```