### PR TITLE
RATIS-2220. Skip further tests after leak detected

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/LeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/LeakDetector.java
@@ -156,6 +156,10 @@ public class LeakDetector {
     return trackers.add(leakable, queue, reportLeak)::remove;
   }
 
+  public int getLeakCount() {
+    return trackers.getNumLeaks(false);
+  }
+
   public void assertNoLeaks(int maxRetries, TimeDuration retrySleep) throws InterruptedException {
     synchronized (leakMessages) {
       // leakMessages are all the leaks discovered so far.

--- a/ratis-common/src/test/java/org/apache/ratis/BaseTest.java
+++ b/ratis-common/src/test/java/org/apache/ratis/BaseTest.java
@@ -22,6 +22,7 @@ import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.JavaUtils;
+import org.apache.ratis.util.ReferenceCountedLeakDetector;
 import org.apache.ratis.util.Slf4jUtils;
 import org.apache.ratis.util.StringUtils;
 import org.apache.ratis.util.TimeDuration;
@@ -30,6 +31,7 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -97,6 +99,9 @@ public abstract class BaseTest {
     testCaseName = testInfo.getTestMethod()
         .orElseThrow(() -> new RuntimeException("Exception while getting test name."))
         .getName();
+
+    final int leaks = ReferenceCountedLeakDetector.getLeakDetector().getLeakCount();
+    Assumptions.assumeFalse(0 < leaks, () -> "numLeaks " + leaks + " > 0");
   }
 
   // @After annotation is retained to support junit 4 tests.


### PR DESCRIPTION
## What changes were proposed in this pull request?

> After the first test case has failed, the leak detector will fail the following test cases (even if there are no new leaks) since it won't reset the leak trackers. ([comment](https://issues.apache.org/jira/browse/RATIS-2184?focusedCommentId=17894661&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17894661))

We should skip further tests to avoid wasting time.

(I'm guessing JUnit4 tests may not benefit from this, since it's added in a JUnit5 hook method.)

https://issues.apache.org/jira/browse/RATIS-2220

## How was this patch tested?

10x10 [run](https://github.com/adoroszlai/ratis/actions/runs/12443701223) of `TestRaftWithGrpc`, as expected has many failures.

In each case at most 1 test failed with error, various number of other tests were skipped:

```
[ERROR] Tests run: 11, Failures: 0, Errors: 1, Skipped: 8, Time elapsed: 60.854 s <<< FAILURE! - in org.apache.ratis.grpc.TestRaftWithGrpc
[ERROR] Tests run: 11, Failures: 0, Errors: 1, Skipped: 8, Time elapsed: 54.102 s <<< FAILURE! - in org.apache.ratis.grpc.TestRaftWithGrpc
[ERROR] Tests run: 11, Failures: 0, Errors: 1, Skipped: 4, Time elapsed: 154.546 s <<< FAILURE! - in org.apache.ratis.grpc.TestRaftWithGrpc
[ERROR] Tests run: 11, Failures: 0, Errors: 1, Skipped: 8, Time elapsed: 56.705 s <<< FAILURE! - in org.apache.ratis.grpc.TestRaftWithGrpc
[ERROR] Tests run: 11, Failures: 0, Errors: 1, Skipped: 9, Time elapsed: 45.134 s <<< FAILURE! - in org.apache.ratis.grpc.TestRaftWithGrpc
[ERROR] Tests run: 11, Failures: 0, Errors: 1, Skipped: 9, Time elapsed: 43.876 s <<< FAILURE! - in org.apache.ratis.grpc.TestRaftWithGrpc
[ERROR] Tests run: 11, Failures: 0, Errors: 1, Skipped: 8, Time elapsed: 57.373 s <<< FAILURE! - in org.apache.ratis.grpc.TestRaftWithGrpc
...
```

CI:
https://github.com/adoroszlai/ratis/actions/runs/12445569381