### PR TITLE
RATIS-2222. Remove copy-rename-maven-plugin usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,6 @@
     <license-maven-plugin.version>2.2.0</license-maven-plugin.version>
 
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
-    <copy-rename-maven-plugin.version>1.0</copy-rename-maven-plugin.version>
     <cyclonedx.version>2.8.0</cyclonedx.version>
 
     <spotbugs.version>4.2.1</spotbugs.version>
@@ -472,11 +471,6 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>${license-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>com.coderplus.maven.plugins</groupId>
-          <artifactId>copy-rename-maven-plugin</artifactId>
-          <version>${copy-rename-maven-plugin.version}</version>
         </plugin>
 
         <plugin>

--- a/ratis-examples/pom.xml
+++ b/ratis-examples/pom.xml
@@ -151,7 +151,7 @@
             </goals>
             <configuration>
               <createDependencyReducedPom>false</createDependencyReducedPom>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.apache.ratis.examples.common.Runner</mainClass>
@@ -183,23 +183,6 @@
             <root>${project.basedir}</root>
           </roots>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.coderplus.maven.plugins</groupId>
-        <artifactId>copy-rename-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-file</id>
-            <phase>package</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-            <configuration>
-              <sourceFile>target/${project.artifactId}-${project.version}-shaded.jar</sourceFile>
-              <destinationFile>target/${project.artifactId}-${project.version}.jar</destinationFile>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/ratis-experiments/pom.xml
+++ b/ratis-experiments/pom.xml
@@ -121,7 +121,7 @@
             </goals>
             <configuration>
               <createDependencyReducedPom>false</createDependencyReducedPom>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>
@@ -136,23 +136,6 @@
                   </excludes>
                 </filter>
               </filters>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.coderplus.maven.plugins</groupId>
-        <artifactId>copy-rename-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-file</id>
-            <phase>package</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-            <configuration>
-              <sourceFile>target/${project.artifactId}-${project.version}-shaded.jar</sourceFile>
-              <destinationFile>target/${project.artifactId}-${project.version}.jar</destinationFile>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Build uses `copy-rename-maven-plugin` to overwrite original jar with shaded one in `ratis-examples` (and experiments).  `maven-shade-plugin` can do that, so we can remove usage of `copy-rename-maven-plugin`.

> `<shadedArtifactAttached>`
> Defines whether the shaded artifact should be attached as classifier to the original artifact. If false, the shaded jar will be the main artifact of the project
> ([source](https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html#shadedArtifactAttached))

https://issues.apache.org/jira/browse/RATIS-2222

## How was this patch tested?

Built locally:

```
$ ./mvnw -Prelease -DskipTests -Dmaven.javadoc.skip clean verify
...
[INFO] --- shade:3.6.0:shade (default) @ ratis-examples ---
...
[INFO] Replacing original artifact with shaded artifact.
[INFO] Replacing ratis-examples/target/ratis-examples-3.2.0-SNAPSHOT.jar with ratis-examples/target/ratis-examples-3.2.0-SNAPSHOT-shaded.jar
...
```

Checked examples jar size:

```
$ ls -1sh ratis-examples/target/*SNAPSHOT.jar 
148K ratis-examples/target/original-ratis-examples-3.2.0-SNAPSHOT.jar
 21M ratis-examples/target/ratis-examples-3.2.0-SNAPSHOT.jar

$ tar tzvf ratis-assembly/target/ratis-assembly-3.2.0-SNAPSHOT-bin.tar.gz | grep ratis-examples             
-rw-r--r-- root/root  21222451 2023-11-19 15:23 apache-ratis-3.2.0-SNAPSHOT-bin/examples/lib/ratis-examples-3.2.0-SNAPSHOT.jar
```

Tested arithmetic example:

```
$ tar zxf ratis-assembly/target/ratis-assembly-3.2.0-SNAPSHOT-bin.tar.gz apache-ratis-3.2.0-SNAPSHOT-bin
$ cd apache-ratis-3.2.0-SNAPSHOT-bin

$ export PEERS="n0:127.0.0.1:6000,n1:127.0.0.1:6001,n2:127.0.0.1:6002"
$ export BIN=examples/bin

$ "${BIN}"/start-all.sh arithmetic server
Found examples/lib/ratis-examples-3.2.0-SNAPSHOT.jar
...
INFO  RaftServer$Division:379 - n0@group-6F7570313233: changes role from CANDIDATE to LEADER at term 1 for changeToLeader
...

$ "${BIN}"/client.sh arithmetic assign --name a --value 3 --peers "${PEERS}"
$ "${BIN}"/client.sh arithmetic assign --name b --value 4 --peers "${PEERS}"
$ "${BIN}"/client.sh arithmetic assign --name c --value "a+b" --peers "${PEERS}"
$ "${BIN}"/client.sh arithmetic get --name c --peers "${PEERS}"
...
c=7
```