### PR TITLE
RATIS-2226. Enable Develocity local build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .hugo_build.lock
 .idea
 .classpath
+.mvn/.develocity/
 .project
 .settings
 target

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<develocity
+        xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <buildScan>
+    <capture>
+      <fileFingerprints>false</fileFingerprints>
+      <buildLogging>false</buildLogging>
+      <testLogging>false</testLogging>
+      <resourceUsage>false</resourceUsage>
+    </capture>
+    <publishing>
+      <onlyIf>false</onlyIf>
+    </publishing>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>#{isFalse(env['GITHUB_ACTIONS'])}</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>develocity-maven-extension</artifactId>
+    <version>1.23</version>
+  </extension>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>common-custom-user-data-maven-extension</artifactId>
+    <version>2.0.1</version>
+  </extension>
+</extensions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

> The [Develocity] Build Cache speeds up your builds by reusing outputs from any previous build
> [The] local Build Cache [...] allows other subsequent builds on the same machine to reuse the outputs whenever they execute a goal with the same inputs.
> ([source](https://docs.gradle.com/develocity/maven-extension/current/#using_the_build_cache))

This PR enables cache for local builds, but not for CI builds.

Develocity can also publish build scans (information about build/test runs), which could be enabled in a follow-up task.

https://issues.apache.org/jira/browse/RATIS-2226

## How was this patch tested?

First build with cache (can be reproduced later by adding `-Ddevelocity.cache.local.enabled=false`):

```
$ ./mvnw -Prelease -DskipTests clean verify
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  41.167 s
...
[INFO] 417 goals, 417 executed
```

Re-build uses output from build cache for several steps:

```
$ ./mvnw -Prelease -DskipTests clean verify
...
[INFO] --- javadoc:3.3.2:jar (module-javadocs) @ ratis ---
[INFO] Loaded from the build cache
...
[INFO] --- compiler:3.10.0:compile (default-compile) @ ratis-proto ---
[INFO] Loaded from the build cache, saving 1.854s
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14.471 s
...
[INFO] 417 goals, 366 executed, 51 from cache, saving at least 23s
```

As a follow-up, we may check if other builds steps (e.g. jar, shade, etc.) can be tweaked to allow caching.

CI build:

```
[INFO] 436 goals, 436 executed
```

https://github.com/adoroszlai/ratis/actions/runs/12453457990/job/34763583099#step:5:3079