### PR TITLE
RATIS-2227. LogEntryProto leak in SegmentedRaftLog

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
@@ -271,7 +271,7 @@ public final class ReferenceCountedLeakDetector {
       }
 
       static <T> int findFirstUnequalFromTail(T[] current, T[] previous) {
-        int c = current.length - 1;
+        int c = current.length == 0 ? 0 : current.length - 1;
         for(int p = previous.length - 1; p >= 0; p--, c--) {
           if (!previous[p].equals(current[c])) {
             return c;


### PR DESCRIPTION
## What changes were proposed in this pull request?
When GrpcLogAppender sends logEntry to Follower, if an exception is encountered, some leaks will occur.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2227

## How was this patch tested?
ci: https://github.com/jianghuazhu/ratis/actions/runs/12492897006
