### PR TITLE
RATIS-2228. Refactor the offered map in LogAppenderBase.nextAppendEntriesRequest

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderBase.java
@@ -339,7 +339,11 @@ public abstract class LogAppenderBase implements LogAppender {
     assertProtos(protos, followerNext, previous, snapshotIndex);
     AppendEntriesRequestProto appendEntriesProto =
         leaderState.newAppendEntriesRequestProto(follower, protos, previous, callId);
-    return ReferenceCountedObject.wrap(appendEntriesProto, entryList::retain, entryList::release);
+    final ReferenceCountedObject<AppendEntriesRequestProto> ref = ReferenceCountedObject.wrap(
+        appendEntriesProto, entryList::retain, entryList::release);
+    ref.retain();
+    entryList.release();
+    return ref;
   }
 
   private void assertProtos(List<LogEntryProto> protos, long nextIndex, TermIndex previous, long snapshotIndex) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -490,7 +490,7 @@ public final class LogSegment {
    * Acquire LogSegment's monitor so that there is no concurrent loading.
    */
   synchronized ReferenceCountedObject<LogEntryProto> loadCache(TermIndex ti) throws RaftLogIOException {
-    ReferenceCountedObject<LogEntryProto> entry = entryCache.get(ti);
+    final ReferenceCountedObject<LogEntryProto> entry = entryCache.get(ti);
     if (entry != null) {
       try {
         entry.retain();

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -304,7 +304,8 @@ public final class SegmentedRaftLog extends RaftLogBase {
     if (record == null) {
       return null;
     }
-    final ReferenceCountedObject<LogEntryProto> entry = segment.getEntryFromCache(record.getTermIndex());
+    final TermIndex ti = record.getTermIndex();
+    final ReferenceCountedObject<LogEntryProto> entry = segment.getEntryFromCache(ti);
     if (entry != null) {
       try {
         entry.retain();
@@ -319,7 +320,7 @@ public final class SegmentedRaftLog extends RaftLogBase {
     // the entry is not in the segment's cache. Load the cache without holding the lock.
     getRaftLogMetrics().onRaftLogCacheMiss();
     cacheEviction.signal();
-    return segment.loadCache(record);
+    return segment.loadCache(ti);
   }
 
   @Override

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestLogSegment.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestLogSegment.java
@@ -139,6 +139,7 @@ public class TestLogSegment extends BaseTest {
     long offset = SegmentedRaftLogFormat.getHeaderLength();
     for (long i = start; i <= end; i++) {
       LogSegment.LogRecord record = segment.getLogRecord(i);
+      Assertions.assertNotNull(record);
       final TermIndex ti = record.getTermIndex();
       Assertions.assertEquals(i, ti.getIndex());
       Assertions.assertEquals(term, ti.getTerm());
@@ -146,7 +147,7 @@ public class TestLogSegment extends BaseTest {
 
       ReferenceCountedObject<LogEntryProto> entry = segment.getEntryFromCache(ti);
       if (entry == null) {
-        entry = segment.loadCache(record);
+        entry = segment.loadCache(ti);
       }
       offset += getEntrySize(entry.get(), Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
     }


### PR DESCRIPTION
RATIS-2228
- Add a new `EntryBuffer` class for the buffer queue and the ref map.
- Remove the `buffer` field from `LogAppenderBase`.
- Add a method for readLogEntries and a method for pollList.
- Change `LogEntryLoader` to not extending guava `CacheLoader`.
  - Fix a bug in `LogEntryLoader.load` -- it should re-throw an exception.
- Pass `TermIndex` instead of `LogRecord` in `LogEntryLoader`