### PR TITLE
RATIS-2234. Remove lock race between heartbeat and append log channels

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/AutoCloseableLock.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/AutoCloseableLock.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.util;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 
@@ -43,6 +44,13 @@ public final class AutoCloseableLock implements AutoCloseable {
   public static AutoCloseableLock acquire(final Lock lock, Runnable preUnlock) {
     lock.lock();
     return new AutoCloseableLock(lock, preUnlock);
+  }
+
+  public static AutoCloseableLock tryAcquire(final Lock lock, Runnable preUnlock, TimeDuration timeout)
+      throws InterruptedException {
+    Objects.requireNonNull(timeout, "timeout == null");
+    final boolean locked = lock.tryLock(timeout.getDuration(), timeout.getUnit());
+    return locked? new AutoCloseableLock(lock, preUnlock): null;
   }
 
   private final Lock underlying;

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -122,7 +122,7 @@ public abstract class RaftLogBase implements RaftLog {
 
   @Override
   public boolean updateCommitIndex(long majorityIndex, long currentTerm, boolean isLeader) {
-    try(AutoCloseableLock writeLock = writeLock()) {
+    try(AutoCloseableLock writeLock = tryWriteLock(TimeDuration.ONE_SECOND)) {
       final long oldCommittedIndex = getLastCommittedIndex();
       final long newCommitIndex = Math.min(majorityIndex, getFlushIndex());
       if (oldCommittedIndex < newCommitIndex) {
@@ -136,6 +136,9 @@ public abstract class RaftLogBase implements RaftLog {
           return commitIndex.updateIncreasingly(newCommitIndex, traceIndexChange);
         }
       }
+    } catch (InterruptedException e) {
+      LOG.warn("{}: Interrupted to updateCommitIndex: majorityIndex={}, currentTerm={}, isLeader={}",
+          getName(), majorityIndex, currentTerm, isLeader, e);
     }
     return false;
   }
@@ -387,6 +390,10 @@ public abstract class RaftLogBase implements RaftLog {
 
   public AutoCloseableLock writeLock() {
     return AutoCloseableLock.acquire(lock.writeLock());
+  }
+
+  public AutoCloseableLock tryWriteLock(TimeDuration timeout) throws InterruptedException {
+    return AutoCloseableLock.tryAcquire(lock.writeLock(), null, timeout);
   }
 
   public boolean hasWriteLock() {


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-2234.
See discussion at https://issues.apache.org/jira/browse/RATIS-2208

Thanks @szetszwo for the patch provided!