### PR TITLE
RATIS-2215. Bump maven-remote-resources-plugin to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
     <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
     <maven-clover2-plugin.version>4.0.6</maven-clover2-plugin.version>
     <maven-pdf-plugin.version>1.6.1</maven-pdf-plugin.version>
+    <maven-remote-resources-plugin.version>3.3.0</maven-remote-resources-plugin.version>
     <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <wagon-ssh.version>3.5.3</wagon-ssh.version>
@@ -698,6 +699,11 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-remote-resources-plugin</artifactId>
+          <version>${maven-remote-resources-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/ratis-resource-bundle/src/main/resources/META-INF/LICENSE.vm
+++ b/ratis-resource-bundle/src/main/resources/META-INF/LICENSE.vm
@@ -221,10 +221,10 @@ under the License.
    limitations under the License.
 
 ## Special cases, for e.g. ASL2.0 licensed works that bundle additional third party works
-#set($bundled-jquery = ${bundled-jquery.equalsIgnoreCase("true")})
-#set($bundled-logo = ${bundled-logo.equalsIgnoreCase("true")})
-#set($bundled-dependencies = ${bundled-dependencies.equalsIgnoreCase("true")})
-#if($bundled-jquery || $bundled-logo || $bundled-dependencies)
+#set($bundled_jquery = ${bundled_jquery.equalsIgnoreCase("true")})
+#set($bundled_logo = ${bundled_logo.equalsIgnoreCase("true")})
+#set($bundled_dependencies = ${bundled_dependencies.equalsIgnoreCase("true")})
+#if($bundled_jquery || $bundled_logo || $bundled_dependencies)
 ====
 ${project.name} contained works
 
@@ -884,12 +884,12 @@ facade for Java, which can be obtained at:
   * HOMEPAGE:
     * http://www.slf4j.org/
 #end
-## Supplemental from commons-math
+## Supplemental from commons_math
 #macro(commons_math_license)
 ----
 APACHE COMMONS MATH DERIVATIVE WORKS:
 
-The Apache commons-math library includes a number of subcomponents
+The Apache commons_math library includes a number of subcomponents
 whose implementation is derived from original sources written
 in C or Fortran.  License terms of the original sources
 are reproduced below.
@@ -1178,7 +1178,7 @@ For the org.apache.hadoop.util.bloom.* classes:
 ## skip jquery
 ## skip backbone
 ## relocated jackson 2.4.0 is ASLv2 with no notice
-## relocated commons-logging 1.1.1 is in NOTICE.vm
+## relocated commons_logging 1.1.1 is in NOTICE.vm
 #end
 #macro (thrift_license)
 ## Thrift supplemental for libthrift is a no-op.
@@ -1295,15 +1295,15 @@ You can redistribute it and/or modify it under either the terms of the
      PURPOSE.
 #end
 ## modules with bundled works in source
-#if(${bundled-jquery})
+#if(${bundled_jquery})
 #jquery_license()
 #end
-#if(${bundled-logo})
+#if(${bundled_logo})
 #orca_logo_license()
 #end
 ## when true, we're in a module that makes a binary dist with
 ## bundled works.
-#if(${bundled-dependencies})
+#if(${bundled_dependencies})
 ====
 ## gather up CDDL licensed works
 #set($cddl_1_0 = [])
@@ -1316,8 +1316,8 @@ You can redistribute it and/or modify it under either the terms of the
 #set($cpl = [])
 ## gather up EPL 1.0 works
 #set($epl = [])
-## track commons-math
-#set($commons-math = false)
+## track commons_math
+#set($commons_math = false)
 ## track if we need jruby additionals.
 #set($jruby = false)
 ## track hadoops
@@ -1342,7 +1342,7 @@ g:${dep.groupId} AND a:${dep.artifactId} AND v:${dep.version}
 Until ratis-resource-bundle/src/main/resources/supplemental-models.xml
 is updated, the build should fail.
 #end
-#if(${debug-print-included-work-info.equalsIgnoreCase("true")})
+#if(${debug_print_included_work_info.equalsIgnoreCase("true")})
 =====
 Check license for included work
 
@@ -1364,8 +1364,8 @@ ${dep.scm.url}
 #end
 #set($aggregated=false)
 ## Check for our set of known dependencies that require manual LICENSE additions.
-#if($dep.artifactId.equals("commons-math3"))
-#set($commons-math=true)
+#if($dep.artifactId.equals("commons_math3"))
+#set($commons_math=true)
 #end
 #if($dep.artifactId.equals("jruby-complete"))
 #set($jruby=true)
@@ -1465,7 +1465,7 @@ ${dep.scm.url}
 #if($hadoop)
 #hadoop_license()
 #end
-#if($commons-math)
+#if($commons_math)
 #commons_math_license()
 #end
 #if(!(${mit.isEmpty()}))

--- a/ratis-resource-bundle/src/main/resources/META-INF/NOTICE.vm
+++ b/ratis-resource-bundle/src/main/resources/META-INF/NOTICE.vm
@@ -23,10 +23,10 @@ Copyright 2017-2019 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 ## Specially handled included deps. e.g. ASL2.0 works that have additional bundled works but
-#set($bundled-boostrap = ${bundled-boostrap.equalsIgnoreCase("true")})
-#set($bundled-logo = ${bundled-logo.equalsIgnoreCase("true")})
-#set($bundled-dependencies = ${bundled-dependencies.equalsIgnoreCase("true")})
-#if($bundled-bootstrap || $bundled-logo || $bundled-dependencies)
+#set($bundled_boostrap = ${bundled_boostrap.equalsIgnoreCase("true")})
+#set($bundled_logo = ${bundled_logo.equalsIgnoreCase("true")})
+#set($bundled_dependencies = ${bundled_dependencies.equalsIgnoreCase("true")})
+#if($bundled_bootstrap || $bundled_logo || $bundled_dependencies)
 ====
 ${project.name} contained works
 
@@ -102,13 +102,13 @@ noted in the LICENSE file.
 
 #end
 
-#macro(jetty_notice $jetty-include-unixcrypt)
+#macro(jetty_notice $jetty_include_unixcrypt)
 --
 This product includes portions of 'The Jetty Web Container'
 
 Copyright 1995-2016 Mort Bay Consulting Pty Ltd.
 
-#if(${jetty-include-unixcrypt})
+#if(${jetty_include_unixcrypt})
 ## UnixCrypt.java paragraph only in server
 The UnixCrypt.java code ~Implements the one way cryptography used by
 Unix systems for simple password protection.  Copyright 1996 Aki Yoshida,
@@ -207,13 +207,13 @@ under the Apache License 2.0 (see: StringUtils.containsWhitespace())
 
 #end
 ## first bundled source
-#if(${bundled-logo})
+#if(${bundled_logo})
 #orca_logo_notice()
 #end
-#if(${bundled-bootstrap})
+#if(${bundled_bootstrap})
 #bootstrap_notice()
 #end
-#if(${bundled-dependencies})
+#if(${bundled_dependencies})
 #**
  Note that this will fail the build if we don't have a license. update supplemental-models via
  setting '-Dlicense.debug.print.included' and looking in the generated LICENSE file
@@ -229,7 +229,7 @@ under the Apache License 2.0 (see: StringUtils.containsWhitespace())
 #set($mpl_1_1=[])
 ## track jettys
 #set($jetty=false)
-#set($jetty-with-crypt=false)
+#set($jetty_with_crypt=false)
 ## track jruby
 #set($jruby=false)
 #foreach( ${dep} in ${projects} )
@@ -244,7 +244,7 @@ under the Apache License 2.0 (see: StringUtils.containsWhitespace())
 #if(${dep.artifactId.startsWith("jetty")})
 #set($jetty=true)
 #if(${dep.artifactId.equals("jetty")})
-#set($jetty-with-crypt=true)
+#set($jetty_with_crypt=true)
 #end
 #end
 #if(${dep.artifactId.equals("log4j")})
@@ -317,7 +317,7 @@ For source see '${dep.url}'.
 #end
 ## Print out jetty
 #if(${jetty})
-#jetty_notice(${jetty-with-crypt})
+#jetty_notice(${jetty_with_crypt})
 #end
 ## Now go through all the lists of Category-B licensed works and make sure we
 ## name them and give a URL for the project's home page.


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Bump `maven-remote-resources-plugin` to 3.3.0, which fixes an intermittent reproducibility problem (MRRESOURCES-150).
- Replace `-` with `_` in variable names in the templates, because `-` is causes error with newer versions of the plugin.  (BTW, are these templates inherited from Hadoop?  Most of the dependencies mentioned seem to be unused in Ratis.)

https://issues.apache.org/jira/browse/RATIS-2215

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis/actions/runs/12657963122