### PR TITLE
RATIS-2239. Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -156,6 +156,7 @@ jobs:
         run: |
           dev-support/checks/${{ inputs.script }}.sh ${{ inputs.script-args }}
         env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           WITH_COVERAGE: ${{ inputs.with-coverage }}
 
       - name: Summary of failures

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -22,16 +22,25 @@
 <develocity
         xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <projectId>ratis</projectId>
+  <server>
+    <url>https://develocity.apache.org</url>
+    <allowUntrusted>false</allowUntrusted>
+  </server>
   <buildScan>
     <capture>
-      <fileFingerprints>false</fileFingerprints>
-      <buildLogging>false</buildLogging>
-      <testLogging>false</testLogging>
+      <fileFingerprints>true</fileFingerprints>
+      <buildLogging>true</buildLogging>
+      <testLogging>true</testLogging>
       <resourceUsage>false</resourceUsage>
     </capture>
+    <backgroundBuildScanUpload>#{isFalse(env['GITHUB_ACTIONS'])}</backgroundBuildScanUpload>
     <publishing>
-      <onlyIf>false</onlyIf>
+      <onlyIf><![CDATA[authenticated]]></onlyIf>
     </publishing>
+    <obfuscation>
+      <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
+    </obfuscation>
   </buildScan>
   <buildCache>
     <local>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -24,7 +24,7 @@
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>develocity-maven-extension</artifactId>
-    <version>1.23</version>
+    <version>1.22.2</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Publish data about CI builds to `develocity.apache.org`.

Downgrade `develocity-maven-extension`, because the server at `develocity.apache.org` [does not yet support 1.23](https://github.com/apache/ozone/pull/7701#discussion_r1916538894).

https://issues.apache.org/jira/browse/RATIS-2239

## How was this patch tested?

Similar config file is already used for Ozone.

CI:
https://github.com/adoroszlai/ratis/actions/runs/12805619564
