### PR TITLE
RATIS-2240. updatePurgeIndex doesn't need to hold RaftLogBase.writeLock

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogBase.java
@@ -144,10 +144,8 @@ public abstract class RaftLogBase implements RaftLog {
   }
 
   protected void updatePurgeIndex(Long purged) {
-    try (AutoCloseableLock writeLock = writeLock()) {
-      if (purged != null) {
-        purgeIndex.updateToMax(purged, infoIndexChange);
-      }
+    if (purged != null) {
+      purgeIndex.updateToMax(purged, infoIndexChange);
     }
   }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-2240