### PR TITLE
RATIS-2242 change consistency criteria of heartbeat during appendLog

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1717,7 +1717,7 @@ class RaftServerImpl implements RaftServer.Division,
     }
 
     // Check if "previous" is contained in current state.
-    if (previous != null && !state.containsTermIndex(previous)) {
+    if (previous != null && !state.containsTermIndex(previous) && appendLogFuture.get().isDone()) {
       final long replyNextIndex = Math.min(state.getNextIndex(), previous.getIndex());
       LOG.info("{}: Failed appendEntries as previous log entry ({}) is not found", getMemberId(), previous);
       return replyNextIndex;


### PR DESCRIPTION
## What changes were proposed in this pull request?

When enable both appendLog channel and heartbeat channel,

Leader:

appendLog will send an AppendEntries RPC with (previous = nextIndex0, entries = [e1,e2...]), then update the follower nextIndex to nextIndex1
Subsequent heartbeat channel will send AppendEntries RPCs with (previous = nextIndex1, entries = empty)
Follower:

Inconsistency reply will be triggered when handling the heartbeats by 
https://github.com/apache/ratis/blob/8353a017fe6545fbfb74960ecb3a0f4396c478d2/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java#L1720-1724 

 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/RATIS/issues/RATIS-2242?filter=allissues
## How was this patch tested?

Unit tests
