### PR TITLE
RATIS-2244. Reduce the number of log messages during bootstrap

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -534,7 +534,7 @@ public class GrpcLogAppender extends LogAppenderBase {
           break;
         case INCONSISTENCY:
           grpcServerMetrics.onRequestInconsistency(getFollowerId().toString());
-          LOG.warn("{}: received {} reply with nextIndex {}, errorCount={}, request={}",
+          LOG.debug("{}: received {} reply with nextIndex {}, errorCount={}, request={}",
               this, reply.getResult(), reply.getNextIndex(), errorCount, request);
           final long requestFirstIndex = request != null? request.getFirstIndex(): RaftLog.INVALID_LOG_INDEX;
           updateNextIndex(getNextIndexForInconsistency(requestFirstIndex, reply.getNextIndex()));

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -197,9 +197,9 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
     @Override
     public void onCompleted() {
       if (isClosed.compareAndSet(false, true)) {
-        LOG.info("{}: Completed {}, lastRequest: {}", getId(), op, getPreviousRequestString());
+        LOG.debug("{}: Completed {}, lastRequest: {}", getId(), op, getPreviousRequestString());
         requestFuture.get().thenAccept(reply -> {
-          LOG.info("{}: Completed {}, lastReply: {}", getId(), op, reply);
+          LOG.debug("{}: Completed {}, lastReply: {}", getId(), op, reply);
           responseObserver.onCompleted();
         });
         releaseLast();

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -93,8 +93,8 @@ class SnapshotInstallationHandler {
   }
 
   InstallSnapshotReplyProto installSnapshot(InstallSnapshotRequestProto request) throws IOException {
-    if (LOG.isInfoEnabled()) {
-      LOG.info("{}: receive installSnapshot: {}", getMemberId(),
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("{}: receive installSnapshot: {}", getMemberId(),
           ServerStringUtils.toInstallSnapshotRequestString(request));
     }
     final InstallSnapshotReplyProto reply;
@@ -104,8 +104,8 @@ class SnapshotInstallationHandler {
       LOG.error("{}: installSnapshot failed", getMemberId(), e);
       throw e;
     }
-    if (LOG.isInfoEnabled()) {
-      LOG.info("{}: reply installSnapshot: {}", getMemberId(),
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("{}: reply installSnapshot: {}", getMemberId(),
           ServerStringUtils.toInstallSnapshotReplyString(reply));
     }
     return reply;


### PR DESCRIPTION
When one of the Ozone OM falls back and bootstraps, the logs are printed very frequently and it rolls off 30 log files (of 200MB each) in 15 mins. Since logs are rolled off too quick, troubleshooting cause of bootstrap is becoming difficult.

## What changes were proposed in this pull request?
Changed logging level on installsnapshot notification from WARN to DEBUG. This is to avoid frequent logging on bootstapping OM.
Changed logging level on inconsistency message to DEBUG too.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2244

## How was this patch tested?
Logging change. Didnt create unit test for this change.