### PR TITLE
RATIS-2244. Reduce the number of log messages during bootstrap

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
@@ -213,7 +213,7 @@ public final class OrderedAsync {
       final Throwable exception = e;
       final String key = client.getId() + "-" + request.getCallId() + "-" + exception;
       final Consumer<String> op = suffix -> LOG.error("{} {}: Failed* {}", suffix, client.getId(), request, exception);
-      BatchLogger.warn(BatchLogKey.SEND_REQUEST_EXCEPTION, key, op);
+      BatchLogger.print(BatchLogKey.SEND_REQUEST_EXCEPTION, key, op);
       handleException(pending, request, e);
       return null;
     });

--- a/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
@@ -47,7 +47,7 @@ public final class BatchLogger {
     private final Key key;
     private final Object name;
 
-    private UniqueId(Key key, String name) {
+    private UniqueId(Key key, Object name) {
       this.key = Objects.requireNonNull(key, "key == null");
       this.name = name;
     }

--- a/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/BatchLogger.java
@@ -45,7 +45,7 @@ public final class BatchLogger {
 
   private static final class UniqueId {
     private final Key key;
-    private final String name;
+    private final Object name;
 
     private UniqueId(Key key, String name) {
       this.key = Objects.requireNonNull(key, "key == null");
@@ -99,15 +99,15 @@ public final class BatchLogger {
   private static final TimeoutExecutor SCHEDULER = TimeoutExecutor.getInstance();
   private static final ConcurrentMap<UniqueId, BatchedLogEntry> LOG_CACHE = new ConcurrentHashMap<>();
 
-  public static void warn(Key key, String name, Consumer<String> op) {
-    warn(key, name, op, key.getBatchDuration(), true);
+  public static void print(Key key, Object name, Consumer<String> op) {
+    print(key, name, op, key.getBatchDuration(), true);
   }
 
-  public static void warn(Key key, String name, Consumer<String> op, TimeDuration batchDuration) {
-    warn(key, name, op, batchDuration, true);
+  public static void print(Key key, Object name, Consumer<String> op, TimeDuration batchDuration) {
+    print(key, name, op, batchDuration, true);
   }
 
-  public static void warn(Key key, String name, Consumer<String> op, TimeDuration batchDuration, boolean shouldBatch) {
+  public static void print(Key key, Object name, Consumer<String> op, TimeDuration batchDuration, boolean shouldBatch) {
     if (!shouldBatch || batchDuration.isNonPositive()) {
       op.accept("");
       return;

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -66,6 +66,7 @@ public class GrpcLogAppender extends LogAppenderBase {
 
   private enum BatchLogKey implements BatchLogger.Key {
     RESET_CLIENT,
+    INCONSISTENCY_REPLY,
     APPEND_LOG_RESPONSE_HANDLER_ON_ERROR
   }
 
@@ -217,7 +218,7 @@ public class GrpcLogAppender extends LogAppenderBase {
           .orElseGet(f::getMatchIndex);
       if (event.isError() && request == null) {
         final long followerNextIndex = f.getNextIndex();
-        BatchLogger.warn(BatchLogKey.RESET_CLIENT, f.getId() + "-" + followerNextIndex, suffix ->
+        BatchLogger.print(BatchLogKey.RESET_CLIENT, f.getId() + "-" + followerNextIndex, suffix ->
             LOG.warn("{}: Follower failed (request=null, errorCount={}); keep nextIndex ({}) unchanged and retry.{}",
                 this, errorCount, followerNextIndex, suffix), logMessageBatchDuration);
         return;
@@ -534,8 +535,9 @@ public class GrpcLogAppender extends LogAppenderBase {
           break;
         case INCONSISTENCY:
           grpcServerMetrics.onRequestInconsistency(getFollowerId().toString());
-          LOG.warn("{}: received {} reply with nextIndex {}, errorCount={}, request={}",
-              this, reply.getResult(), reply.getNextIndex(), errorCount, request);
+          BatchLogger.print(BatchLogKey.INCONSISTENCY_REPLY, getFollower().getName() + "_" + reply.getNextIndex(),
+              suffix -> LOG.warn("{}: received {} reply with nextIndex {}, errorCount={}, request={} {}",
+              this, reply.getResult(), reply.getNextIndex(), errorCount, request, suffix));
           final long requestFirstIndex = request != null? request.getFirstIndex(): RaftLog.INVALID_LOG_INDEX;
           updateNextIndex(getNextIndexForInconsistency(requestFirstIndex, reply.getNextIndex()));
           break;
@@ -555,7 +557,7 @@ public class GrpcLogAppender extends LogAppenderBase {
         LOG.info("{} is already stopped", GrpcLogAppender.this);
         return;
       }
-      BatchLogger.warn(BatchLogKey.APPEND_LOG_RESPONSE_HANDLER_ON_ERROR, AppendLogResponseHandler.this.name,
+      BatchLogger.print(BatchLogKey.APPEND_LOG_RESPONSE_HANDLER_ON_ERROR, AppendLogResponseHandler.this.name,
           suffix -> GrpcUtil.warn(LOG, () -> this + ": Failed appendEntries" + suffix, t),
           logMessageBatchDuration, t instanceof StatusRuntimeException);
       grpcServerMetrics.onRequestRetry(); // Update try counter


### PR DESCRIPTION
When one of the Ozone OM falls back and bootstraps, the logs are printed very frequently and it rolls off 30 log files (of 200MB each) in 15 mins. Since logs are rolled off too quick, troubleshooting cause of bootstrap is becoming difficult.

## What changes were proposed in this pull request?
Updated the logging to BatchLogger using the review patch from @szetszwo https://github.com/apache/ratis/pull/1216 - I closed that pull request by mistake.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2244

## How was this patch tested?
Logging change. Didnt create unit test for this change.
