### PR TITLE
RATIS-2247. Bump GitHub Actions runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,7 +55,7 @@ on:
       runner:
         type: string
         description: "GitHub Actions runner to use"
-        default: 'ubuntu-20.04'
+        default: 'ubuntu-24.04'
         required: false
 
       script-args:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
     needs:
       - build
       - unit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     if: (github.repository == 'apache/ratis' || github.repository == 'apache/incubator-ratis') && github.event_name != 'pull_request'
     steps:

--- a/.github/workflows/repeat-test.yml
+++ b/.github/workflows/repeat-test.yml
@@ -50,7 +50,7 @@ env:
 run-name: ${{ github.event_name == 'workflow_dispatch' && format('{0}#{1}[{2}]-{3}x{4}', inputs.test-class, inputs.test-method, inputs.ref, inputs.splits, inputs.iterations) || '' }}
 jobs:
   prepare:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
       test-spec: ${{ steps.test-spec.outputs.test-spec }}
@@ -79,7 +79,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - prepare
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       TEST_SPEC: ${{ needs.prepare.outputs.test-spec }}
     strategy:
@@ -121,7 +121,7 @@ jobs:
   count-failures:
     if: ${{ failure() }}
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download build results
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ubuntu 20.04 is being deprecated: https://github.com/actions/runner-images/issues/11101

Upgrade to 24.04.

https://issues.apache.org/jira/browse/RATIS-2247

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis/actions/runs/13249818209