### PR TITLE
RATIS-2250. Add RAT exclusions for bootstrap and jquery

### DIFF
--- a/rat-excludes.txt
+++ b/rat-excludes.txt
@@ -14,4 +14,7 @@
 .gitignore
 .hugo_build.lock
 build
+bootstrap.min.css
+bootstrap.min.js
+jquery.min.js
 ./*.patch


### PR DESCRIPTION
## What changes were proposed in this pull request?

Addendum for #1222.  Exclude bootstrap and jquery minimized scripts for RAT check.

## How was this patch tested?

```
./build.sh ../ratis-site
```