### PR TITLE
RATIS-2022. Replace some Guava usage with builtins

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
@@ -18,7 +18,6 @@
 package org.apache.ratis.conf;
 
 import org.apache.ratis.security.TlsConf;
-import org.apache.ratis.thirdparty.com.google.common.base.Objects;
 import org.apache.ratis.util.NetUtils;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
@@ -33,6 +32,7 @@ import java.lang.reflect.Modifier;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
@@ -60,7 +60,7 @@ public interface ConfUtils {
   static <T> void logGet(String key, T value, T defaultValue, Consumer<String> logger) {
     if (logger != null && Utils.isNew(key, value)) {
       logger.accept(String.format("%s = %s (%s)", key, value,
-          Objects.equal(value, defaultValue)? "default": "custom"));
+          Objects.equals(value, defaultValue)? "default": "custom"));
     }
   }
 

--- a/ratis-common/src/test/java/org/apache/ratis/util/TestRefCountingMap.java
+++ b/ratis-common/src/test/java/org/apache/ratis/util/TestRefCountingMap.java
@@ -22,10 +22,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
-import org.apache.ratis.thirdparty.com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -128,7 +128,7 @@ public class TestRefCountingMap {
     Set<String> keys = map.keySet();
     assertEquals(3, keys.size());
 
-    Lists.newArrayList("foo", "bar", "baz").forEach(v -> assertTrue(keys.contains(v)));
+    Arrays.asList("foo", "bar", "baz").forEach(v -> assertTrue(keys.contains(v)));
   }
 
   @Test
@@ -141,7 +141,7 @@ public class TestRefCountingMap {
     Collection<String> values = map.values();
     assertEquals(3, values.size());
 
-    Lists.newArrayList("foovalue", "foovalue3", "foovalue4")
+    Arrays.asList("foovalue", "foovalue3", "foovalue4")
             .forEach(v -> assertTrue(values.contains(v)));
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
@@ -37,11 +37,11 @@ import org.apache.ratis.server.raftlog.LogEntryHeader;
 import org.apache.ratis.server.raftlog.LogProtoUtils;
 import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.server.raftlog.RaftLogBase;
-import org.apache.ratis.thirdparty.com.google.common.base.Preconditions;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.AutoCloseableLock;
 import org.apache.ratis.util.CollectionUtils;
 import org.apache.ratis.util.JavaUtils;
+import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.ProtoUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.Assert;
@@ -152,8 +152,9 @@ public interface RaftTestUtil {
 
   static void waitFor(Supplier<Boolean> check, int checkEveryMillis,
       int waitForMillis) throws TimeoutException, InterruptedException {
-    Preconditions.checkNotNull(check);
-    Preconditions.checkArgument(waitForMillis >= checkEveryMillis);
+    Preconditions.assertNotNull(check, "check");
+    Preconditions.assertTrue(waitForMillis >= checkEveryMillis,
+        () -> "waitFor: " + waitForMillis + " < checkEvery: " + checkEveryMillis);
 
     long st = System.currentTimeMillis();
     boolean result = check.get();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace few usages of Guava with equivalents from JDK or Ratis.

https://issues.apache.org/jira/browse/RATIS-2022

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis/actions/runs/13572312975