### PR TITLE
RATIS-2263. Bump sonar-maven-plugin to 5.0.0.4389

### DIFF
--- a/dev-support/checks/sonar.sh
+++ b/dev-support/checks/sonar.sh
@@ -24,6 +24,6 @@ if [ ! "$SONAR_TOKEN" ]; then
 fi
 
 ${MVN} -B verify -DskipShade -DskipTests \
-  org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar \
+  sonar:sonar \
   -Dsonar.coverage.jacoco.xmlReportPaths="$(pwd)/target/coverage/all.xml" \
   -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache-ratis

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,7 @@
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <wagon-ssh.version>3.5.3</wagon-ssh.version>
     <hadoop-maven-plugins.version>3.4.0</hadoop-maven-plugins.version>
+    <sonar-maven-plugin.version>5.0.0.4389</sonar-maven-plugin.version>
 
 
     <!-- org.codehaus.mojo -->
@@ -731,6 +732,11 @@
           <groupId>org.cyclonedx</groupId>
           <artifactId>cyclonedx-maven-plugin</artifactId>
           <version>${cyclonedx.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.sonarsource.scanner.maven</groupId>
+          <artifactId>sonar-maven-plugin</artifactId>
+          <version>${sonar-maven-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Sonar Maven plugin to 5.0.0.4389 in attempt to fix [error](https://github.com/apache/ratis/actions/runs/13903203958/job/38900869515#step:8:2745) in coverage check:

```
Error:  Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar (default-cli) on project ratis: Project not found. Please check the 'sonar.projectKey' and 'sonar.organization' properties, the 'SONAR_TOKEN' environment variable, or contact the project administrator to check the permissions of the user the token belongs to
```

This started happening without related code change.

https://issues.apache.org/jira/browse/RATIS-2263

## How was this patch tested?

Verified that version is being picked up and is valid:

```
$ SONAR_TOKEN=invalid ./dev-support/checks/sonar.sh
...
[INFO] --- sonar:5.0.0.4389:sonar (default-cli) @ ratis ---
[INFO] ...
[INFO] JRE provisioning: os[linux], arch[x86_64]
```

but cannot confirm if it fixes the `Project not found` issue, since I don't have access to the real token, so it fails with 403.
