### PR TITLE
RATIS-2267. The requestSemaphore should be released when InterruptedException occurs.

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedStreamAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedStreamAsync.java
@@ -117,6 +117,7 @@ public class OrderedStreamAsync {
       requestSemaphore.acquire();
     } catch (InterruptedException e){
       Thread.currentThread().interrupt();
+      requestSemaphore.release();
       return JavaUtils.completeExceptionally(IOUtils.toInterruptedIOException(
           "Interrupted when sending " + JavaUtils.getClassSimpleName(data.getClass()) + ", header= " + header, e));
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
invoke requestSemaphore.release() when InterruptedException occurs.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2267