### PR TITLE
RATIS-2268. A minor documatention fix for method getSuccessors.

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -202,7 +202,7 @@ public class DataStreamManagement {
       }
 
       if (isPrimary()) {
-        // Default start topology
+        // Default star topology
         // get the other peers from the current configuration
         return conf.getCurrentPeers().stream()
             .filter(p -> !p.getId().equals(division.getId()))


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix documatention for method `DataStreamManagement.StreamInfo#getSuccessors`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2268

## How was this patch tested?
Doc fix， no need tests.
