### PR TITLE
RATIS-2271 Leadership Loss Causes ClosedByInterruptException and NullPointerException in LogAppender Thread

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -292,7 +292,7 @@ public final class LogSegment {
         }
       });
       loadingTimes.incrementAndGet();
-      return Objects.requireNonNull(toReturn.get(), () -> "toReturn == null for " + key);
+      return toReturn.get();
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -292,7 +292,11 @@ public final class LogSegment {
         }
       });
       loadingTimes.incrementAndGet();
-      return toReturn.get();
+      final ReferenceCountedObject<LogEntryProto> proto = toReturn.get();
+      if (proto == null) {
+        throw new RaftLogIOException("Failed to load log entry " + key);
+      }
+      return proto;
     }
   }
 
@@ -502,8 +506,10 @@ public final class LogSegment {
     }
     try {
       return cacheLoader.load(ti);
+    } catch (RaftLogIOException e) {
+      throw e;
     } catch (Exception e) {
-      throw new RaftLogIOException(e);
+      throw new RaftLogIOException("Failed to loadCache for log entry " + ti, e);
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogInputStream.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogInputStream.java
@@ -104,11 +104,11 @@ public class SegmentedRaftLogInputStream implements Closeable {
     if (state.isUnopened()) {
         try {
           init();
-        } catch (IOException e) {
+        } catch (Exception e) {
           if (e.getCause() instanceof ClosedByInterruptException) {
             LOG.warn("Initialization is interrupted: {}", this, e);
           } else {
-            LOG.error("caught exception initializing " + this, e);
+            LOG.error("Failed to initialize {}", this, e);
           }
           throw IOUtils.asIOException(e);
         }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogInputStream.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogInputStream.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.channels.ClosedByInterruptException;
 import java.util.Optional;
 
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
@@ -103,8 +104,12 @@ public class SegmentedRaftLogInputStream implements Closeable {
     if (state.isUnopened()) {
         try {
           init();
-        } catch (Exception e) {
-          LOG.error("caught exception initializing " + this, e);
+        } catch (IOException e) {
+          if (e.getCause() instanceof ClosedByInterruptException) {
+            LOG.warn("Initialization is interrupted: {}", this, e);
+          } else {
+            LOG.error("caught exception initializing " + this, e);
+          }
           throw IOUtils.asIOException(e);
         }
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogReader.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogReader.java
@@ -34,7 +34,14 @@ import org.apache.ratis.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.channels.ClosedByInterruptException;
 import java.util.Optional;
 import java.util.zip.Checksum;
@@ -163,28 +170,30 @@ class SegmentedRaftLogReader implements Closeable {
    */
   boolean verifyHeader() throws IOException {
     final int headerLength = SegmentedRaftLogFormat.getHeaderLength();
+    final int readLength;
     try{
-      final int readLength = in.read(temp, 0, headerLength);
-      Preconditions.assertTrue(readLength <= headerLength);
-      final int matchLength = SegmentedRaftLogFormat.matchHeader(temp, 0, readLength);
-      Preconditions.assertTrue(matchLength <= readLength);
-
-      if (readLength == headerLength && matchLength == readLength) {
-        // The header is matched successfully
-        return true;
-      } else if (SegmentedRaftLogFormat.isTerminator(temp, matchLength, readLength - matchLength)) {
-        // The header is partially written
-        return false;
-      }
-      // The header is corrupted
-      throw new CorruptedFileException(file, "Log header mismatched: expected header length="
-          + SegmentedRaftLogFormat.getHeaderLength() + ", read length=" + readLength + ", match length=" + matchLength
-          + ", header in file=" + StringUtils.bytes2HexString(temp, 0, readLength)
-          + ", expected header=" + StringUtils.bytes2HexString(SegmentedRaftLogFormat.getHeaderBytebuffer()));
+      readLength = in.read(temp, 0, headerLength);
     } catch (ClosedByInterruptException e) {
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted while reading the header of " + file, e);
     }
+
+    Preconditions.assertTrue(readLength <= headerLength);
+    final int matchLength = SegmentedRaftLogFormat.matchHeader(temp, 0, readLength);
+    Preconditions.assertTrue(matchLength <= readLength);
+
+    if (readLength == headerLength && matchLength == readLength) {
+      // The header is matched successfully
+      return true;
+    } else if (SegmentedRaftLogFormat.isTerminator(temp, matchLength, readLength - matchLength)) {
+      // The header is partially written
+      return false;
+    }
+    // The header is corrupted
+    throw new CorruptedFileException(file, "Log header mismatched: expected header length="
+        + SegmentedRaftLogFormat.getHeaderLength() + ", read length=" + readLength + ", match length=" + matchLength
+        + ", header in file=" + StringUtils.bytes2HexString(temp, 0, readLength)
+        + ", expected header=" + StringUtils.bytes2HexString(SegmentedRaftLogFormat.getHeaderBytebuffer()));
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

After a leader loses leadership due to heartbeat timeout with a majority of followers, it forcibly interrupts the GrpcLogAppender thread.
This abrupt termination leads to two critical exceptions during log file reads:
1. ClosedByInterruptException when initializing SegmentedRaftLogInputStream.
2. A cascading NullPointerException in LogSegment.loadCache() due to incomplete log loading.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2271?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel

## How was this patch tested?

unit tests