### PR TITLE
RATIS-2274. Newly added peer may retain outdated configuration after membership change, causing election failure.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -799,6 +799,7 @@ class LeaderStateImpl implements LeaderState {
           follower.getLastRpcResponseTime().elapsedTimeMs());
       return BootStrapProgress.NOPROGRESS;
     } else if (follower.getMatchIndex() + stagingCatchupGap > committed
+        && follower.getMatchIndex() >= server.getRaftConf().getLogEntryIndex()
         && follower.getLastRpcResponseTime().compareTo(progressTime) > 0
         && follower.hasAttemptedToInstallSnapshot()) {
       return BootStrapProgress.CAUGHTUP;


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the leader has no snapshot (forcing log-based catch-up), the new peer might lack timely configuration change logs due to stagingCatchupGap. This leaves the new peer with outdated configurations, violating Raft's membership change safety guarantees.
To solve this problem, the Leader is essentially required to ensure that the configuration of the Follower is the latest when the Follower completes the catch-up.
We add one more condition to the CAUGHTUP judgment logic. That is, CAUGHTUP is complete only after a follower receives the latest conf logs from the leader.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2274

## How was this patch tested?

unit tests
