### PR TITLE
RATIS-2278. Follower Fails to Append Entries Due to Index Validation in NavigableIndices

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerImplUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerImplUtils.java
@@ -141,7 +141,9 @@ public final class ServerImplUtils {
         // validate startIndex
         final Map.Entry<Long, ConsecutiveIndices> lastEntry = map.lastEntry();
         if (lastEntry != null) {
-          Preconditions.assertSame(lastEntry.getValue().getNextIndex(), indices.startIndex, "startIndex");
+          final long nextIndex = lastEntry.getValue().getNextIndex();
+          Preconditions.assertTrue(indices.startIndex >= nextIndex,
+                  () -> "startIndex = " + indices.startIndex + " < nextIndex = " + nextIndex);
         }
         map.put(indices.startIndex, indices);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a follower receives multiple appendEntries requests from the leader, it may throw an IllegalStateException during log index validation. Specifically, the NavigableIndices class fails to handle concurrent log appends properly, causing the follower to incorrectly reject valid entries with an "index mismatch" error.

The reason is that removeExisting can be called out of order. So we changing the Preconditions to check startIndex.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2278

## How was this patch tested?

unit tests
