### PR TITLE
RATIS-2282. LogAppender Restart Due to Premature Log Entry Access During Concurrent Write Processing

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -117,10 +117,6 @@ public final class LogSegment {
       return map.size();
     }
 
-    boolean contains(long index) {
-      return map.containsKey(index);
-    }
-
     LogRecord getFirst() {
       final Map.Entry<Long, LogRecord> first = map.firstEntry();
       return first != null? first.getValue() : null;
@@ -519,10 +515,7 @@ public final class LogSegment {
   }
 
   LogRecord getLogRecord(long index) {
-    if (records.contains(index)) {
-      return records.get(index);
-    }
-    return null;
+    return records.get(index);
   }
 
   TermIndex getLastTermIndex() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Put entry to cache before adding the record.
modify the getLogRecord function with contains.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2282

## How was this patch tested?

unit tests
