### PR TITLE
RATIS-2283. GrpcLogAppender Thread Restart Leaves catchup=false, Blocking Reconfiguration Progress

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/FollowerInfo.java
@@ -112,4 +112,10 @@ public interface FollowerInfo {
 
   /** Update lastRpcResponseTime and LastRespondedAppendEntriesSendTime */
   void updateLastRespondedAppendEntriesSendTime(Timestamp sendTime);
+
+  /** Set the caughtUp flag to true. */
+  void catchUp();
+
+  /** @return true if this follower is caught up. */
+  boolean isCaughtUp();
 }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -147,10 +147,10 @@ public interface LogAppender {
     // 2. or the follower's next index is smaller than the log start index
     // 3. or the follower is bootstrapping and has not installed any snapshot yet
     final FollowerInfo follower = getFollower();
-    final boolean isFollowerBootstrapping = getLeaderState().isFollowerBootstrapping(follower);
+    final boolean isFollowerCaughtUp = follower.isCaughtUp();
     final SnapshotInfo snapshot = getServer().getStateMachine().getLatestSnapshot();
 
-    if (isFollowerBootstrapping && !follower.hasAttemptedToInstallSnapshot()) {
+    if (!isFollowerCaughtUp && !follower.hasAttemptedToInstallSnapshot()) {
       if (snapshot == null) {
         // Leader cannot send null snapshot to follower. Hence, acknowledge InstallSnapshot attempt (even though it
         // was not attempted) so that follower can come out of staging state after appending log entries.

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfoImpl.java
@@ -173,11 +173,13 @@ class FollowerInfoImpl implements FollowerInfo {
         ", lastRpcResponseTime=" + lastRpcResponseTime.get().elapsedTimeMs() + ")";
   }
 
-  void catchUp() {
+  @Override
+  public void catchUp() {
     caughtUp = true;
   }
 
-  boolean isCaughtUp() {
+  @Override
+  public boolean isCaughtUp() {
     return caughtUp;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adjust shouldInstallSnapshot() Logic: Allow snapshot installation for both new followers in stagingState and restarted old followers.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2283

## How was this patch tested?

unit tests
