### PR TITLE
RATIS-2286. Generate the necessary unified names for the submodules under RaftServerImpl

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
@@ -19,8 +19,8 @@ package org.apache.ratis.server.impl;
 
 import org.apache.ratis.server.DivisionInfo;
 import org.apache.ratis.server.leader.LeaderState;
+import org.apache.ratis.server.util.ServerStringUtils;
 import org.apache.ratis.util.Daemon;
-import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.Timestamp;
 import org.slf4j.Logger;
@@ -68,7 +68,7 @@ class FollowerState extends Daemon {
 
   FollowerState(RaftServerImpl server, Object reason) {
     super(newBuilder()
-        .setName(server.getMemberId() + "-" + JavaUtils.getClassSimpleName(FollowerState.class))
+        .setName(ServerStringUtils.generateUnifiedName(server.getMemberId(), FollowerState.class))
         .setThreadGroup(server.getThreadGroup()));
     this.server = server;
     this.reason = reason;

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -29,7 +29,6 @@ import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.util.ServerStringUtils;
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.util.Daemon;
-import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.LogUtils;
 import org.apache.ratis.util.Preconditions;
@@ -191,7 +190,7 @@ class LeaderElection implements Runnable {
   private final ConfAndTerm round0;
 
   LeaderElection(RaftServerImpl server, boolean force) {
-    this.name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass()) + COUNT.incrementAndGet();
+    this.name = ServerStringUtils.generateUnifiedName(server.getMemberId(), getClass()) + COUNT.incrementAndGet();
     this.lifeCycle = new LifeCycle(this);
     this.daemon = Daemon.newBuilder().setName(name).setRunnable(this)
         .setThreadGroup(server.getThreadGroup()).build();

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -49,6 +49,7 @@ import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.LogEntryHeader;
 import org.apache.ratis.server.raftlog.LogProtoUtils;
 import org.apache.ratis.server.raftlog.RaftLog;
+import org.apache.ratis.server.util.ServerStringUtils;
 import org.apache.ratis.statemachine.TransactionContext;
 import org.apache.ratis.util.CodeInjectionForTesting;
 import org.apache.ratis.util.CollectionUtils;
@@ -147,7 +148,7 @@ class LeaderStateImpl implements LeaderState {
   }
 
   private class EventQueue {
-    private final String name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
+    private final String name = ServerStringUtils.generateUnifiedName(server.getMemberId(), getClass());
     private final BlockingQueue<StateUpdateEvent> queue = new ArrayBlockingQueue<>(4096);
 
     void submit(StateUpdateEvent event) {
@@ -361,7 +362,7 @@ class LeaderStateImpl implements LeaderState {
   private final LeaderLease lease;
 
   LeaderStateImpl(RaftServerImpl server) {
-    this.name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
+    this.name = ServerStringUtils.generateUnifiedName(server.getMemberId(), getClass());
     this.server = server;
 
     final RaftProperties properties = server.getRaftServer().getProperties();
@@ -1236,7 +1237,7 @@ class LeaderStateImpl implements LeaderState {
   }
 
   private class ConfigurationStagingState {
-    private final String name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
+    private final String name = ServerStringUtils.generateUnifiedName(server.getMemberId(), getClass());
     private final Map<RaftPeerId, RaftPeer> newPeers;
     private final Map<RaftPeerId, RaftPeer> newListeners;
     private final PeerConfiguration newConf;

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
@@ -29,6 +29,7 @@ import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.server.raftlog.RaftLogIOException;
 import org.apache.ratis.server.raftlog.RaftLogIndex;
+import org.apache.ratis.server.util.ServerStringUtils;
 import org.apache.ratis.statemachine.SnapshotInfo;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.statemachine.SnapshotRetentionPolicy;
@@ -95,7 +96,7 @@ class StateMachineUpdater implements Runnable {
 
   StateMachineUpdater(StateMachine stateMachine, RaftServerImpl server,
       ServerState serverState, long lastAppliedIndex, RaftProperties properties, Consumer<Long> appliedIndexConsumer) {
-    this.name = serverState.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
+    this.name = ServerStringUtils.generateUnifiedName(serverState.getMemberId(), getClass());
     this.appliedIndexConsumer = appliedIndexConsumer;
     this.infoIndexChange = s -> LOG.info("{}: {}", name, s);
     this.debugIndexChange = s -> LOG.debug("{}: {}", name, s);

--- a/ratis-server/src/main/java/org/apache/ratis/server/util/ServerStringUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/util/ServerStringUtils.java
@@ -24,8 +24,10 @@ import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.StateMachineLogEntryProto;
+import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.LogProtoUtils;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.ProtoUtils;
 
 import java.util.List;
@@ -117,5 +119,14 @@ public final class ServerStringUtils {
       return null;
     }
     return ProtoUtils.toString(proto.getServerReply()) + "-t" + proto.getTerm();
+  }
+
+  /**
+   * Used to generate the necessary unified name in the submodules under
+   * {@link org.apache.ratis.server.impl.RaftServerImpl}, which consists
+   * of {@link org.apache.ratis.server.impl.ServerState#memberId} and the specific class.
+   */
+  public static String generateUnifiedName(RaftGroupMemberId memberId, Class<?> clazz) {
+    return memberId + "-" + JavaUtils.getClassSimpleName(clazz);
   }
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?
We built a unified method for generating the necessary name attributes in the RaftServerImpl submodule.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2286

## How was this patch tested?
Ensure that the CI test passes smoothly.
ci: https://github.com/jianghuazhu/ratis/actions/runs/14794277631