### PR TITLE
RATIS-2285. Bump ratis-thirdparty to 1.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,11 +208,11 @@
     <maven.min.version>3.3.9</maven.min.version>
 
     <!-- Contains all shaded thirdparty dependencies -->
-    <ratis.thirdparty.version>1.0.8</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.9</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
     <shaded.protobuf.version>3.25.5</shaded.protobuf.version>
-    <shaded.grpc.version>1.69.0</shaded.grpc.version>
+    <shaded.grpc.version>1.71.0</shaded.grpc.version>
 
     <!-- Test properties -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Ratis Thirdparty to 1.0.9, gRPC to 1.71.0.

https://issues.apache.org/jira/browse/RATIS-2285

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis/actions/runs/14789184306