### PR TITLE
RATIS-2287. Improve RaftServerImpl#toString() to make it more readable

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -727,7 +727,7 @@ class RaftServerImpl implements RaftServer.Division,
 
   @Override
   public String toString() {
-    return role + "-> " + state + "->" + lifeCycle.getCurrentState();
+    return role + " (" + lifeCycle.getCurrentState() + "): " + state;
   }
 
   RaftClientReply.Builder newReplyBuilder(RaftClientRequest request) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -727,7 +727,7 @@ class RaftServerImpl implements RaftServer.Division,
 
   @Override
   public String toString() {
-    return role + " " + state + " " + lifeCycle.getCurrentState();
+    return role + "-> " + state + "->" + lifeCycle.getCurrentState();
   }
 
   RaftClientReply.Builder newReplyBuilder(RaftClientRequest request) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -362,8 +362,8 @@ class ServerState {
 
   @Override
   public String toString() {
-    return getMemberId() + ":t" + currentTerm + ", leader=" + getLeaderId()
-        + ", voted=" + votedFor + ", raftlog=" + log + ", conf=" + getRaftConf();
+    return "serverState(" + getMemberId() + ":t" + currentTerm + ", leader=" + getLeaderId()
+        + ", voted=" + votedFor + ", raftlog=" + log + ", conf=" + getRaftConf() + ")";
   }
 
   boolean isConfCommitted() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -362,8 +362,8 @@ class ServerState {
 
   @Override
   public String toString() {
-    return "serverState(" + getMemberId() + ":t" + currentTerm + ", leader=" + getLeaderId()
-        + ", voted=" + votedFor + ", raftlog=" + log + ", conf=" + getRaftConf() + ")";
+    return getMemberId() + ":t" + currentTerm + ", leader=" + getLeaderId()
+        + ", voted=" + votedFor + ", raftlog=" + log + ", conf=" + getRaftConf();
   }
 
   boolean isConfCommitted() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
The purpose of this PR is to improve RaftServerImpl#toString() to make it more readable.
Old:
`
LEADER s0@group-19104963FACE:t1, leader=s0, voted=s0, raftlog=Memoized:s0@group-19104963FACE-SegmentedRaftLog:OPENED:c0:last(t:1, i:0), conf=conf: {index: 0, cur=peers:[s0|localhost:15000]|listeners:[], old=null} RUNNING
`

New:
`
LEADER-> serverState(s0@group-7219D3B559C9:t1, leader=s0, voted=s0, raftlog=Memoized:s0@group-7219D3B559C9-SegmentedRaftLog:OPENED:c0:last(t:1, i:0), conf=conf: {index: 0, cur=peers:[s0|localhost:15000]|listeners:[], old=null})->RUNNING
`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2287

## How was this patch tested?
ci: 
https://github.com/jianghuazhu/ratis/actions/runs/14853381971

