### PR TITLE
RATIS-2289. Coverage is 0% due to no execution data files provided

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -79,7 +79,7 @@ on:
 env:
   MAVEN_ARGS: --batch-mode --show-version
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
-  WITH_COVERAGE: true
+  WITH_COVERAGE: ${{ github.event_name == 'push' }}
 
 jobs:
   check:
@@ -157,7 +157,6 @@ jobs:
           dev-support/checks/${{ inputs.script }}.sh ${{ inputs.script-args }}
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-          WITH_COVERAGE: ${{ inputs.with-coverage }}
 
       - name: Summary of failures
         if: ${{ failure() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
       - unit
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    if: (github.repository == 'apache/ratis' || github.repository == 'apache/incubator-ratis') && github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     steps:
         - name: Checkout project
           uses: actions/checkout@v4
@@ -137,6 +137,7 @@ jobs:
         - name: Calculate combined coverage
           run: ./dev-support/checks/coverage.sh
         - name: Upload coverage to Sonar
+          if: github.repository == 'apache/ratis'
           run: ./dev-support/checks/sonar.sh
           env:
             SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Calculated coverage is 0% because input files are missing.

```
[WARN] No execution data files provided.
[INFO] Writing execution data to /home/runner/work/ratis/ratis/dev-support/checks/../../target/coverage/jacoco-all.exec.
[INFO] Loading execution data file /home/runner/work/ratis/ratis/dev-support/checks/../../target/coverage/jacoco-all.exec.
[INFO] Analyzing 694 classes.
```

https://github.com/apache/ratis/actions/runs/14887012940/job/41810202866#step:7:1977

The problem is re-definition of `WITH_COVERAGE` variable in `unit` job.  Originally `with-coverage` was supposed to be a workflow input, but it was removed.

This change:

- removes the leftover definition
- defines global `WITH_COVERAGE` depending on whether the workflow is triggered by `push` or `pull_reqest`
- enables `coverage` in forks (to exercise `coverage.sh` and allow checking coverage results before merging to `apache/ratis`)
- but still skips `sonar.sh` in forks (since token required for uploading to Sonar Qube is only available in `apache/ratis`)

https://issues.apache.org/jira/browse/RATIS-2289

## How was this patch tested?

```
[INFO] Loading execution data file /home/runner/work/ratis/ratis/target/artifacts/unit-flaky/jacoco-combined.exec.
[INFO] Loading execution data file /home/runner/work/ratis/ratis/target/artifacts/unit-misc/jacoco-combined.exec.
[INFO] Loading execution data file /home/runner/work/ratis/ratis/target/artifacts/unit-server/jacoco-combined.exec.
[INFO] Loading execution data file /home/runner/work/ratis/ratis/target/artifacts/unit-grpc/jacoco-combined.exec.
[INFO] Writing execution data to /home/runner/work/ratis/ratis/dev-support/checks/../../target/coverage/jacoco-all.exec.
[INFO] Loading execution data file /home/runner/work/ratis/ratis/dev-support/checks/../../target/coverage/jacoco-all.exec.
[INFO] Analyzing 694 classes.
```

https://github.com/adoroszlai/ratis/actions/runs/14913776473/job/41895151947#step:7:1967

Downloaded `coverage.zip` and verified coverage is > 0% in `all/index.html`.
