### PR TITLE
RATIS-2180. Use Objects.requireNonNull instead of Preconditions.assertNotNull

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientMessage.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientMessage.java
@@ -18,7 +18,8 @@
 package org.apache.ratis.protocol;
 
 import org.apache.ratis.util.JavaUtils;
-import org.apache.ratis.util.Preconditions;
+
+import java.util.Objects;
 
 public abstract class RaftClientMessage implements RaftRpcMessage {
   private final ClientId clientId;
@@ -27,9 +28,9 @@ public abstract class RaftClientMessage implements RaftRpcMessage {
   private final long callId;
 
   RaftClientMessage(ClientId clientId, RaftPeerId serverId, RaftGroupId groupId, long callId) {
-    this.clientId = Preconditions.assertNotNull(clientId, "clientId");
-    this.serverId = Preconditions.assertNotNull(serverId, "serverId");
-    this.groupId = Preconditions.assertNotNull(groupId, "groupId");
+    this.clientId = Objects.requireNonNull(clientId, "clientId == null");
+    this.serverId = Objects.requireNonNull(serverId, "serverId == null");
+    this.groupId = Objects.requireNonNull(groupId, "groupId == null");
     this.callId = callId;
   }
 

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftId.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftId.java
@@ -85,7 +85,7 @@ public abstract class RaftId {
   private final Supplier<String> uuidString;
 
   RaftId(UUID uuid) {
-    this.uuid = Preconditions.assertNotNull(uuid, "uuid");
+    this.uuid = Objects.requireNonNull(uuid, "uuid == null");
     this.uuidBytes = JavaUtils.memoize(() -> toByteString(uuid));
     this.uuidString = JavaUtils.memoize(() -> createUuidString(uuid));
     Preconditions.assertTrue(ZERO_UUID == uuid || !uuid.equals(ZERO_UUID),

--- a/ratis-common/src/main/java/org/apache/ratis/retry/ExponentialBackoffRetry.java
+++ b/ratis-common/src/main/java/org/apache/ratis/retry/ExponentialBackoffRetry.java
@@ -17,9 +17,9 @@
  */
 package org.apache.ratis.retry;
 
-import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.TimeDuration;
 
+import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -56,7 +56,7 @@ public final class ExponentialBackoffRetry implements RetryPolicy {
     }
 
     public ExponentialBackoffRetry build() {
-      Preconditions.assertNotNull(baseSleepTime, "baseSleepTime");
+      Objects.requireNonNull(baseSleepTime, "baseSleepTime == null");
       return new ExponentialBackoffRetry(baseSleepTime, maxSleepTime,
           maxAttempts);
     }

--- a/ratis-common/src/main/java/org/apache/ratis/util/JavaUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/JavaUtils.java
@@ -148,7 +148,7 @@ public interface JavaUtils {
    *         otherwise, return system property value.
    */
   static String getSystemProperty(final String key) {
-    Preconditions.assertNotNull(key, "key");
+    Objects.requireNonNull(key, "key == null");
     Preconditions.assertTrue(!key.isEmpty(), "key is empty.");
     return doPrivileged(() -> System.getProperty(key), () -> "get system property " + key);
   }
@@ -166,9 +166,9 @@ public interface JavaUtils {
    * When there is a {@link SecurityException}, this becomes a NOOP.
    */
   static void setSystemProperty(String key, String value) {
-    Preconditions.assertNotNull(key, "key");
+    Objects.requireNonNull(key, "key == null");
     Preconditions.assertTrue(!key.isEmpty(), "key is empty.");
-    Preconditions.assertNotNull(value, "value");
+    Objects.requireNonNull(value, "value == null");
     doPrivileged(() -> System.setProperty(key, value), () -> "set system property " + key + " to " + value);
   }
 

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -202,7 +203,7 @@ public final class ReferenceCountedLeakDetector {
       }
 
       if (released) {
-        Preconditions.assertNotNull(removeMethod, () -> "Not yet retained (removeMethod == null): " + valueClass);
+        Objects.requireNonNull(removeMethod, "Not yet retained (removeMethod == null): " + valueClass);
         removeMethod.run();
       }
       return released;

--- a/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ReferenceCountedLeakDetector.java
@@ -203,7 +203,7 @@ public final class ReferenceCountedLeakDetector {
       }
 
       if (released) {
-        Objects.requireNonNull(removeMethod, "Not yet retained (removeMethod == null): " + valueClass);
+        Objects.requireNonNull(removeMethod, () -> "Not yet retained (removeMethod == null): " + valueClass);
         removeMethod.run();
       }
       return released;

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -177,7 +177,7 @@ public class GrpcLogAppender extends LogAppenderBase {
   public GrpcLogAppender(RaftServer.Division server, LeaderState leaderState, FollowerInfo f) {
     super(server, leaderState, f);
 
-    Preconditions.assertNotNull(getServerRpc(), "getServerRpc()");
+    Objects.requireNonNull(getServerRpc(), "getServerRpc() == null");
 
     final RaftProperties properties = server.getRaftServer().getProperties();
     this.maxPendingRequestsNum = GrpcConfigKeys.Server.leaderOutstandingAppendsMax(properties);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1295,7 +1295,7 @@ class RaftServerImpl implements RaftServer.Division,
     LOG.info("{}: takeSnapshotAsync {}", getMemberId(), request);
     assertLifeCycleState(LifeCycle.States.RUNNING);
     assertGroup(getMemberId(), request);
-    Preconditions.assertNotNull(request.getCreate(), "create");
+    Objects.requireNonNull(request.getCreate(), "create == null");
 
     final long creationGap = request.getCreate().getCreationGap();
     long minGapValue = creationGap > 0? creationGap : RaftServerConfigKeys.Snapshot.creationGap(proxy.getProperties());
@@ -1914,6 +1914,7 @@ class RaftServerImpl implements RaftServer.Division,
       break;
     case STATEMACHINELOGENTRY:
       TransactionContext trx = getTransactionContext(next, true);
+      Objects.requireNonNull(trx, "trx == null");
       final ClientInvocationId invocationId = ClientInvocationId.valueOf(next.getStateMachineLogEntry());
       writeIndexCache.add(invocationId.getClientId(), ((TransactionContextImpl) trx).getLogIndexFuture());
       ((TransactionContextImpl) trx).setDelegatedRef(nextRef);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerImplUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerImplUtils.java
@@ -171,8 +171,8 @@ public final class ServerImplUtils {
       ThreadGroup threadGroup, RaftProperties properties, Parameters parameters) throws IOException {
     RaftServer.LOG.debug("newRaftServer: {}, {}", id, group);
     if (group != null && !group.getPeers().isEmpty()) {
-      Objects.requireNonNull(id, "RaftPeerId " + id + " is not in RaftGroup " + group);
-      Objects.requireNonNull(group.getPeer(id), "RaftPeerId " + id + " is not in RaftGroup " + group);
+      Objects.requireNonNull(id, () -> "RaftPeerId " + id + " is not in RaftGroup " + group);
+      Objects.requireNonNull(group.getPeer(id), () -> "RaftPeerId " + id + " is not in RaftGroup " + group);
     }
     final RaftServerProxy proxy = newRaftServer(id, stateMachineRegistry, threadGroup, properties, parameters);
     proxy.initGroups(group, option);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerImplUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerImplUtils.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /** Server utilities for internal use. */
@@ -170,8 +171,8 @@ public final class ServerImplUtils {
       ThreadGroup threadGroup, RaftProperties properties, Parameters parameters) throws IOException {
     RaftServer.LOG.debug("newRaftServer: {}, {}", id, group);
     if (group != null && !group.getPeers().isEmpty()) {
-      Preconditions.assertNotNull(id, "RaftPeerId %s is not in RaftGroup %s", id, group);
-      Preconditions.assertNotNull(group.getPeer(id), "RaftPeerId %s is not in RaftGroup %s", id, group);
+      Objects.requireNonNull(id, "RaftPeerId " + id + " is not in RaftGroup " + group);
+      Objects.requireNonNull(group.getPeer(id), "RaftPeerId " + id + " is not in RaftGroup " + group);
     }
     final RaftServerProxy proxy = newRaftServer(id, stateMachineRegistry, threadGroup, properties, parameters);
     proxy.initGroups(group, option);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -628,7 +628,7 @@ public class SegmentedRaftLogCache {
   void appendEntry(LogSegment.Op op, ReferenceCountedObject<LogEntryProto> entry) {
     // SegmentedRaftLog does the segment creation/rolling work. Here we just
     // simply append the entry into the open segment.
-    Preconditions.assertNotNull(openSegment, "openSegment");
+    Objects.requireNonNull(openSegment, "openSegment == null");
     openSegment.appendToOpenSegment(op, entry);
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
@@ -152,7 +152,7 @@ public interface RaftTestUtil {
 
   static void waitFor(Supplier<Boolean> check, int checkEveryMillis,
       int waitForMillis) throws TimeoutException, InterruptedException {
-    Preconditions.assertNotNull(check, "check");
+    Objects.requireNonNull(check, "check == null");
     Preconditions.assertTrue(waitForMillis >= checkEveryMillis,
         () -> "waitFor: " + waitForMillis + " < checkEvery: " + checkEveryMillis);
 

--- a/ratis-test/src/test/java/org/apache/ratis/server/ServerBuilderTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/ServerBuilderTest.java
@@ -60,7 +60,7 @@ public class ServerBuilderTest extends BaseTest {
                 .build();
             Assertions.fail("did not get expected exception");
         } catch (IOException e) {
-            Preconditions.assertInstanceOf(e.getCause(), IllegalStateException.class);
+            Preconditions.assertInstanceOf(e.getCause(), NullPointerException.class);
         }
     }
 
@@ -76,7 +76,7 @@ public class ServerBuilderTest extends BaseTest {
                 .build();
             Assertions.fail("did not get expected exception");
         } catch (IOException e) {
-            Preconditions.assertInstanceOf(e.getCause(), IllegalStateException.class);
+            Preconditions.assertInstanceOf(e.getCause(), NullPointerException.class);
         }
     }
 

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLogCache.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLogCache.java
@@ -159,7 +159,7 @@ public class TestSegmentedRaftLogCache {
       cache.appendEntry(Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE, ReferenceCountedObject.wrap(entry)
       );
       Assertions.fail("the open segment is null");
-    } catch (IllegalStateException ignored) {
+    } catch (IllegalStateException | NullPointerException ignored) {
     }
 
     LogSegment openSegment = prepareLogSegment(100, 100, true);


### PR DESCRIPTION
## What changes were proposed in this pull request?
We use Objects.requireNonNull() to uniformly replace Preconditions.assertNotNull().

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2180

## How was this patch tested?
ci: 
https://github.com/jianghuazhu/ratis/actions/runs/14921172685