### PR TITLE
RATIS-2291. Fix failing TestInstallSnapshotNotificationWithGrpc#testAddNewFollowersNoSnapshot.

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -220,7 +220,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
     // delete the log segments from the leader
     LOG.info("Delete logs {}", logs);
     for (LogSegmentPath path : logs) {
-      FileUtils.deleteFully(path.getPath()); // the log may be already puged
+      FileUtils.deleteFully(path.getPath()); // the log may be already purged
     }
 
     // restart the peer
@@ -252,7 +252,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
       // Check the installed snapshot index on each Follower matches with the
       // leader snapshot.
       for (RaftServer.Division follower : cluster.getFollowers()) {
-        final long expected = shouldInstallSnapshot ? leaderSnapshotInfo.getIndex() : RaftLog.INVALID_LOG_INDEX;
+        final long expected = leaderSnapshotInfo.getIndex();
         Assert.assertEquals(expected, RaftServerTestUtil.getLatestInstalledSnapshotIndex(follower));
         RaftSnapshotBaseTest.assertLogContent(follower, false);
       }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -134,7 +134,7 @@ public abstract class MiniRaftCluster implements Closeable {
       default void runWithNewCluster(int numServers, int numListeners, boolean startCluster,
           CheckedConsumer<CLUSTER, Exception> testCase) throws Exception {
         final StackTraceElement caller = JavaUtils.getCallerStackTraceElement();
-        LOG.info("Running " + caller.getMethodName());
+        LOG.info("Running {}", caller.getMethodName());
         final CLUSTER cluster = newCluster(numServers, numListeners);
         Throwable failed = null;
         try {
@@ -144,7 +144,7 @@ public abstract class MiniRaftCluster implements Closeable {
           testCase.accept(cluster);
         } catch(Throwable t) {
           LOG.info(cluster.printServers());
-          LOG.error("Failed " + caller, t);
+          LOG.error("Failed {}", caller, t);
           failed = t;
           throw t;
         } finally {
@@ -167,7 +167,7 @@ public abstract class MiniRaftCluster implements Closeable {
       default void runWithSameCluster(int numServers, int numListeners, CheckedConsumer<CLUSTER, Exception> testCase)
           throws Exception {
         final StackTraceElement caller = JavaUtils.getCallerStackTraceElement();
-        LOG.info("Running " + caller.getMethodName());
+        LOG.info("Running {}", caller.getMethodName());
         CLUSTER cluster = null;
         try {
           cluster = getFactory().reuseCluster(numServers, numListeners, getProperties());
@@ -176,7 +176,7 @@ public abstract class MiniRaftCluster implements Closeable {
           if (cluster != null) {
             LOG.info(cluster.printServers());
           }
-          LOG.error("Failed " + caller, t);
+          LOG.error("Failed {}", caller, t);
           throw t;
         }
       }
@@ -328,7 +328,7 @@ public abstract class MiniRaftCluster implements Closeable {
   }
 
   public MiniRaftCluster initServers() {
-    LOG.info("servers = " + servers);
+    LOG.info("servers = {}", servers);
     if (servers.isEmpty()) {
       putNewServers(CollectionUtils.as(group.getPeers(), RaftPeer::getId), true, group);
     }
@@ -359,7 +359,7 @@ public abstract class MiniRaftCluster implements Closeable {
     startServers(servers.values());
 
     this.timer.updateAndGet(t -> t != null? t
-        : JavaUtils.runRepeatedly(() -> LOG.info("TIMED-PRINT: " + printServers()), 10, 10, TimeUnit.SECONDS));
+        : JavaUtils.runRepeatedly(() -> LOG.info("TIMED-PRINT: {}.", printServers()), 10, 10, TimeUnit.SECONDS));
   }
 
   /**
@@ -546,7 +546,7 @@ public abstract class MiniRaftCluster implements Closeable {
   }
 
   public void killServer(RaftPeerId id) {
-    LOG.info("killServer " + id);
+    LOG.info("killServer {}", id);
     servers.get(id).close();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

During the investigation of [RATIS-2251](https://issues.apache.org/jira/browse/RATIS-2251), we encountered a persistent unit test failure in TestInstallSnapshotNotificationWithGrpc#testAddNewFollowersNoSnapshot. Initially, we suspected this was caused by the JUnit version upgrade, but further analysis confirms that the test also fails under JUnit 4. Detailed discussions and debugging steps can be found in the comments of PR #1227.

When addressing the issue with the unit test : TestInstallSnapshotNotificationWithGrpc#testAddNewFollowersNoSnapshot

I found that the error persists even after applying the fix from [RATIS-2045](https://issues.apache.org/jira/browse/RATIS-2045).

[RATIS-2045](https://issues.apache.org/jira/browse/RATIS-2045) fixed the issue where SnapshotInstallationHandler didn't notify followers to install snapshots when the snapshot index was -1 and the leader's firstAvailableLogIndex was 0 (PR [#1053](https://github.com/apache/ratis/pull/1053)).

This PR changes the behavior of whether followers pull snapshots from the leader.

From the logs, we can observe that the newly added followers `s1` and `s2` have both synchronized snapshots from the leader `s0`. As a result, the snapshot index for followers `s1` and `s2` becomes 16 (16 because we manually created messages twice), instead of -1. Therefore, the current check condition is problematic.

```
follower s1:
2025-05-10 17:23:10,134 [grpc-default-executor-2] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:notifyStateMachineToInstallSnapshot(262)) - s1@group-F83BA0BDB609: Received notification to install snapshot at index 0
2025-05-10 17:23:10,137 [grpc-default-executor-2] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:notifyStateMachineToInstallSnapshot(297)) - s1@group-F83BA0BDB609: notifyInstallSnapshot: nextIndex is 0 but the leader's first available index is 0.
......
2025-05-10 17:23:11,151 [grpc-default-executor-0] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:notifyStateMachineToInstallSnapshot(365)) - s1@group-F83BA0BDB609: InstallSnapshot notification result: SNAPSHOT_INSTALLED, at index: (t:1, i:16)

follower s2:
2025-05-10 17:23:11,214 [grpc-default-executor-2] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:notifyStateMachineToInstallSnapshot(262)) - s2@group-F83BA0BDB609: Received notification to install snapshot at index 0
2025-05-10 17:23:11,214 [grpc-default-executor-2] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:notifyStateMachineToInstallSnapshot(297)) - s2@group-F83BA0BDB609: notifyInstallSnapshot: nextIndex is 0 but the leader's first available index is 0.
......
2025-05-10 17:23:12,217 [grpc-default-executor-0] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:notifyStateMachineToInstallSnapshot(365)) - s2@group-F83BA0BDB609: InstallSnapshot notification result: SNAPSHOT_INSTALLED, at index: (t:1, i:16) 
```

Logs before applying [RATIS-2045](https://issues.apache.org/jira/browse/RATIS-2045):

```
2025-05-10 17:42:54,878 [grpc-default-executor-0] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:notifyStateMachineToInstallSnapshot(221)) - s1@group-46FD094EFC86: Received notification to install snapshot at index 0
2025-05-10 17:42:54,878 [grpc-default-executor-0] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:notifyStateMachineToInstallSnapshot(230)) - s1@group-46FD094EFC86: InstallSnapshot notification result: ALREADY_INSTALLED, current snapshot index: -1
.....
2025-05-10 17:42:54,880 [grpc-default-executor-2] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:notifyStateMachineToInstallSnapshot(221)) - s2@group-46FD094EFC86: Received notification to install snapshot at index 0
2025-05-10 17:42:54,880 [grpc-default-executor-2] INFO  impl.SnapshotInstallationHandler (SnapshotInstallationHandler.java:notifyStateMachineToInstallSnapshot(230)) - s2@group-46FD094EFC86: InstallSnapshot notification result: ALREADY_INSTALLED, current snapshot index: -1 
```

So, if we believe that #1053 is reasonable, we should modify the check condition by adjusting the expected value to match the leader's value.


## What is the link to the Apache JIRA

JIRA: RATIS-2291. Fix failing TestInstallSnapshotNotificationWithGrpc#testAddNewFollowersNoSnapshot.

## How was this patch tested?

CI: https://github.com/slfan1989/ratis/actions/runs/14949784656