### PR TITLE
RATIS-2294. Fix NettyClientRpc exception and timeout handling

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientRpc.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.netty.client;
 
+import org.apache.ratis.client.RaftClientConfigKeys;
 import org.apache.ratis.client.impl.ClientProtoUtils;
 import org.apache.ratis.client.impl.RaftClientRpcWithProxy;
 import org.apache.ratis.conf.RaftProperties;
@@ -28,23 +29,45 @@ import org.apache.ratis.proto.RaftProtos.RaftRpcRequestProto;
 import org.apache.ratis.proto.RaftProtos.GroupManagementRequestProto;
 import org.apache.ratis.proto.RaftProtos.SetConfigurationRequestProto;
 import org.apache.ratis.proto.netty.NettyProtos.RaftNettyServerRequestProto;
+import org.apache.ratis.protocol.exceptions.LeaderNotReadyException;
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
+import org.apache.ratis.protocol.exceptions.TimeoutIOException;
 import org.apache.ratis.util.JavaUtils;
+import org.apache.ratis.util.TimeDuration;
+import org.apache.ratis.util.TimeoutExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 public class NettyClientRpc extends RaftClientRpcWithProxy<NettyRpcProxy> {
+
+  public static final Logger LOG = LoggerFactory.getLogger(NettyClientRpc.class);
+
+  private Supplier<String> name;
+  private ClientId cId;
+  private final TimeDuration requestTimeoutDuration;
+  private final TimeoutExecutor scheduler = TimeoutExecutor.getInstance();
+
   public NettyClientRpc(ClientId clientId, RaftProperties properties) {
     super(new NettyRpcProxy.PeerMap(clientId.toString(), properties));
+    this.cId = clientId;
+    this.requestTimeoutDuration = RaftClientConfigKeys.Rpc.requestTimeout(properties);
   }
 
   @Override
   public CompletableFuture<RaftClientReply> sendRequestAsync(RaftClientRequest request) {
     final RaftPeerId serverId = request.getServerId();
+    long callId = request.getCallId();
     try {
+      name = JavaUtils.memoize(() -> cId + "->" + serverId);
       final NettyRpcProxy proxy = getProxies().getProxy(serverId);
       final RaftNettyServerRequestProto serverRequestProto = buildRequestProto(request);
-      return proxy.sendAsync(serverRequestProto).thenApply(replyProto -> {
+      final CompletableFuture<RaftClientReply> replyFuture = new CompletableFuture<>();
+
+      proxy.sendAsync(serverRequestProto).thenApply(replyProto -> {
         if (request instanceof GroupListRequest) {
           return ClientProtoUtils.toGroupListReply(replyProto.getGroupListReply());
         } else if (request instanceof GroupInfoRequest) {
@@ -52,10 +75,49 @@ public class NettyClientRpc extends RaftClientRpcWithProxy<NettyRpcProxy> {
         } else {
           return ClientProtoUtils.toRaftClientReply(replyProto.getRaftClientReply());
         }
+      }).thenCompose(raftReply -> {
+        final NotLeaderException nle = raftReply.getNotLeaderException();
+        if (nle != null) {
+          return failedFuture(nle);
+        }
+        final LeaderNotReadyException lnre = raftReply.getLeaderNotReadyException();
+        if (lnre != null) {
+          return failedFuture(lnre);
+        }
+        return CompletableFuture.completedFuture(raftReply);
+      }).whenComplete((raftReply, ex) -> {
+        if (ex != null) {
+          replyFuture.completeExceptionally(ex);
+        } else {
+          replyFuture.complete(raftReply);
+        }
       });
+
+      scheduler.onTimeout(requestTimeoutDuration,
+        () -> {
+          if (!replyFuture.isDone()) {
+            TimeoutIOException timeout = new TimeoutIOException(
+                getName()+ " request #" + callId + " timeout " +
+                requestTimeoutDuration.getDuration());
+            replyFuture.completeExceptionally(timeout);
+          }
+        }, LOG, () -> "Timeout check for client request #" + callId
+      );
+
+      return replyFuture;
     } catch (Throwable e) {
       return JavaUtils.completeExceptionally(e);
     }
+  }
+
+  private String getName() {
+    return name.get();
+  }
+
+  private <T> CompletableFuture<T> failedFuture(Throwable ex) {
+    CompletableFuture<T> future = new CompletableFuture<>();
+    future.completeExceptionally(ex);
+    return future;
   }
 
   @Override

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientRpc.java
@@ -29,8 +29,6 @@ import org.apache.ratis.proto.RaftProtos.RaftRpcRequestProto;
 import org.apache.ratis.proto.RaftProtos.GroupManagementRequestProto;
 import org.apache.ratis.proto.RaftProtos.SetConfigurationRequestProto;
 import org.apache.ratis.proto.netty.NettyProtos.RaftNettyServerRequestProto;
-import org.apache.ratis.protocol.exceptions.LeaderNotReadyException;
-import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.exceptions.TimeoutIOException;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.TimeDuration;
@@ -40,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 
 public class NettyClientRpc extends RaftClientRpcWithProxy<NettyRpcProxy> {
 

--- a/ratis-server/src/test/java/org/apache/ratis/RaftAsyncTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftAsyncTests.java
@@ -309,6 +309,7 @@ public abstract class RaftAsyncTests<CLUSTER extends MiniRaftCluster> extends Ba
       // Use a follower with the max commit index
       final RaftClientReply lastWriteReply = replies.get(replies.size() - 1);
       final RaftPeerId leader = lastWriteReply.getServerId();
+      Assert.assertEquals(leader, lastWriteReply.getServerId());
       LOG.info("leader = " + leader);
       final Collection<CommitInfoProto> commitInfos = lastWriteReply.getCommitInfos();
       LOG.info("commitInfos = " + commitInfos);
@@ -371,8 +372,8 @@ public abstract class RaftAsyncTests<CLUSTER extends MiniRaftCluster> extends Ba
 
   void runTestWriteAsyncCustomReplicationLevel(CLUSTER cluster) throws Exception {
     final int numMessages = 20;
-    try (RaftClient client = cluster.createClient()) {
-      RaftTestUtil.waitForLeader(cluster);
+    final RaftPeerId leader = waitForLeader(cluster).getId();
+    try (RaftClient client = cluster.createClient(leader)) {
 
       // submit some messages
       for (int i = 0; i < numMessages; i++) {
@@ -422,13 +423,13 @@ public abstract class RaftAsyncTests<CLUSTER extends MiniRaftCluster> extends Ba
     LOG.info("Running testAppendEntriesTimeout");
     final TimeDuration oldExpiryTime = RaftServerConfigKeys.RetryCache.expiryTime(getProperties());
     RaftServerConfigKeys.RetryCache.setExpiryTime(getProperties(), TimeDuration.valueOf(20, TimeUnit.SECONDS));
-    RaftPeerId id = waitForLeader(cluster).getId();
+    final RaftPeerId leader = waitForLeader(cluster).getId();
     long time = System.currentTimeMillis();
     long waitTime = 5000;
     try (final RaftClient client = cluster.createClient()) {
       // block append requests
       cluster.getServerAliveStream()
-          .filter(impl -> !impl.getInfo().isLeader() && impl.getPeer().getId() != id)
+          .filter(impl -> !impl.getInfo().isLeader() && !impl.getPeer().getId().equals(leader))
           .map(SimpleStateMachine4Testing::get)
           .forEach(SimpleStateMachine4Testing::blockWriteStateMachineData);
 
@@ -438,7 +439,7 @@ public abstract class RaftAsyncTests<CLUSTER extends MiniRaftCluster> extends Ba
       Assert.assertFalse(replyFuture.isDone());
       // unblock append request.
       cluster.getServerAliveStream()
-          .filter(impl -> !impl.getInfo().isLeader() && impl.getPeer().getId() != id)
+          .filter(impl -> !impl.getInfo().isLeader() && !impl.getPeer().getId().equals(leader))
           .map(SimpleStateMachine4Testing::get)
           .forEach(SimpleStateMachine4Testing::unblockWriteStateMachineData);
 

--- a/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java
@@ -457,7 +457,7 @@ public abstract class RaftBasicTests<CLUSTER extends MiniRaftCluster>
 
   static void runTestStateMachineMetrics(boolean async, MiniRaftCluster cluster) throws Exception {
     RaftServer.Division leader = waitForLeader(cluster);
-    try (final RaftClient client = cluster.createClient()) {
+    try (final RaftClient client = cluster.createClient(leader.getId())) {
       Gauge appliedIndexGauge = getStatemachineGaugeWithName(leader,
           STATEMACHINE_APPLIED_INDEX_GAUGE);
       Gauge smAppliedIndexGauge = getStatemachineGaugeWithName(leader,


### PR DESCRIPTION
## What changes were proposed in this pull request?

I'm currently follow up on [RATIS-2251](https://issues.apache.org/jira/browse/RATIS-2251), and test results indicate that we have some flaky tests. I'm working on identifying and resolving the root causes.

Specifically, I found that testStaleReadAsync and testStateMachineMetrics are failing because the client doesn't know the correct leaderId, which leads to request failures.

In async mode, if the leaderId is not explicitly specified, the default used in tests is s0. However, during actual test execution with three peers (s0, s1, and s2), any of them can become the leader. Therefore, we need to explicitly set the correct leaderId for the client to ensure reliable communication.

The output of the unit test is as follows:

```
java.util.concurrent.ExecutionException: org.apache.ratis.protocol.exceptions.NotLeaderException: Server s0@group-B8CEF3994187 is not the leader, suggested leader is: s2|localhost:15020

	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
	at org.apache.ratis.RaftBasicTests.runTestStateMachineMetrics(RaftBasicTests.java:472)
	at org.apache.ratis.RaftAsyncTests.lambda$testStateMachineMetrics$14(RaftAsyncTests.java:408)
	at org.apache.ratis.server.impl.MiniRaftCluster$Factory$Get.runWithNewCluster(MiniRaftCluster.java:144)
	at org.apache.ratis.server.impl.MiniRaftCluster$Factory$Get.runWithNewCluster(MiniRaftCluster.java:121)
	at org.apache.ratis.RaftAsyncTests.testStateMachineMetrics(RaftAsyncTests.java:407)
	........
Caused by: org.apache.ratis.protocol.exceptions.NotLeaderException: Server s0@group-B8CEF3994187 is not the leader, suggested leader is: s2|localhost:15020
```

The issue is caused by the client not finding the actual leader.

## What is the link to the Apache JIRA

JIRA: RATIS-2294. Fix TestRaftAsyncWithNetty Flaky test.

## How was this patch tested?

mvn clean test.
