### PR TITLE
RATIS-2310. Implement hashCode and equals method for SizeInBytes class.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/SizeInBytes.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/SizeInBytes.java
@@ -83,4 +83,14 @@ public final class SizeInBytes {
   public String toString() {
     return description;
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof SizeInBytes && size == ((SizeInBytes)obj).size;
+  }
+
+  @Override
+  public int hashCode() {
+    return Long.hashCode(size);
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Implement hashCode and equals method for SizeInBytes class.

Since `SizeInBytes` doesn't have `equals` method implemented, two different objects of `SizeInBytes` with same value are considered different. This is causing flood in the logs as `ConfUtils#isNew` method considers the same value of `SizeInBytes` as different.
Ref: #1200 

```
2025-06-15 00:30:18 INFO  RaftServerConfigKeys:63 - raft.server.log.appender.buffer.byte-limit = 32m (=33554432) (custom)
2025-06-15 00:30:18 INFO  RaftServerConfigKeys:63 - raft.server.log.appender.buffer.byte-limit = 32m (=33554432) (custom)
2025-06-15 00:30:18 INFO  RaftServerConfigKeys:63 - raft.server.log.appender.buffer.byte-limit = 32m (=33554432) (custom)
2025-06-15 00:30:18 INFO  RaftServerConfigKeys:63 - raft.server.log.appender.buffer.byte-limit = 32m (=33554432) (custom)
2025-06-15 00:30:18 INFO  RaftServerConfigKeys:63 - raft.server.log.appender.buffer.byte-limit = 32m (=33554432) (custom)
2025-06-15 00:30:18 INFO  RaftServerConfigKeys:63 - raft.server.log.appender.buffer.byte-limit = 32m (=33554432) (custom)
```

## What is the link to the Apache JIRA
RATIS-2310

## How was this patch tested?
Unit tests

