### PR TITLE
RATIS-2323. Extend ratis-shell add command

### DIFF
--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/peer/AddCommand.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/peer/AddCommand.java
@@ -81,9 +81,10 @@ public class AddCommand extends AbstractRatisCommand {
       }
 
       if (cl.hasOption(CLIENT_ADDRESS_OPTION_NAME)) {
-        final List<InetSocketAddress> clientAddresses = Arrays.stream(cl.getOptionValue(CLIENT_ADDRESS_OPTION_NAME).split(","))
-            .map(CliUtils::parseInetSocketAddress)
-            .collect(Collectors.toList());
+        final List<InetSocketAddress> clientAddresses =
+            Arrays.stream(cl.getOptionValue(CLIENT_ADDRESS_OPTION_NAME).split(","))
+              .map(CliUtils::parseInetSocketAddress)
+              .collect(Collectors.toList());
         Preconditions.assertSame(ids.size(), clientAddresses.size(), "clientAddress size");
         for (int i = 0; i < ids.size(); i++) {
           clientAddressInfo.put(ids.get(i), clientAddresses.get(i));
@@ -91,9 +92,10 @@ public class AddCommand extends AbstractRatisCommand {
       }
 
       if (cl.hasOption(ADMIN_ADDRESS_OPTION_NAME)) {
-        final List<InetSocketAddress> adminAddresses = Arrays.stream(cl.getOptionValue(ADMIN_ADDRESS_OPTION_NAME).split(","))
-            .map(CliUtils::parseInetSocketAddress)
-            .collect(Collectors.toList());
+        final List<InetSocketAddress> adminAddresses =
+            Arrays.stream(cl.getOptionValue(ADMIN_ADDRESS_OPTION_NAME).split(","))
+              .map(CliUtils::parseInetSocketAddress)
+              .collect(Collectors.toList());
         Preconditions.assertSame(ids.size(), adminAddresses.size(), "adminAddress size");
         for (int i = 0; i < ids.size(); i++) {
           adminAddressInfo.put(ids.get(i), adminAddresses.get(i));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extend ratis-shell add command to support clientAddress and adminAddress parameters

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2323

## How was this patch tested?

manual tests within 3 ratis based celeborn masters

```
➜  apache-ratis-3.1.3-bin bin/ratis sh group info -Draft.rpc.type=NETTY -peers zw06-data-k8s-sparktest-cm0003.sankuai.com:9872
group id: c5196f6d-2c34-3ed3-8b8a-47bede733167
leader info: 2(zw06-data-k8s-sparktest-cm0003.sankuai.com:9872)

[server {
  id: "2"
  address: "zw06-data-k8s-sparktest-cm0003.sankuai.com:9872"
  clientAddress: "zw06-data-k8s-sparktest-cm0003.sankuai.com:9097"
  adminAddress: "zw06-data-k8s-sparktest-cm0003.sankuai.com:9097"
  startupRole: FOLLOWER
}
commitIndex: 1495821
, server {
  id: "1"
  address: "zw06-data-k8s-sparktest-cm0002.sankuai.com:9872"
  clientAddress: "zw06-data-k8s-sparktest-cm0002.sankuai.com:9097"
  adminAddress: "zw06-data-k8s-sparktest-cm0002.sankuai.com:9097"
  startupRole: FOLLOWER
}
commitIndex: 1495821
]

➜  apache-ratis-3.1.3-bin bin/ratis sh peer add -Draft.rpc.type=NETTY -peers zw06-data-k8s-sparktest-cm0003.sankuai.com:9872 -peerId 0 -clientAddress zw06-data-k8s-sparktest-cm0001.sankuai.com:9097 -adminAddress zw06-data-k8s-sparktest-cm0001.sankuai.com:9097  -address zw06-data-k8s-sparktest-cm0001.sankuai.com:9872
[main] INFO org.apache.ratis.netty.NettyUtils - Create EpollEventLoopGroup for client-EAD690983326; Thread size is 0.
[main] INFO org.apache.ratis.netty.NettyUtils - Create EpollEventLoopGroup for client-0F180D5DDFEE; Thread size is 0.
New peer list: [1|zw06-data-k8s-sparktest-cm0002.sankuai.com:9872, 2|zw06-data-k8s-sparktest-cm0003.sankuai.com:9872, 0|zw06-data-k8s-sparktest-cm0001.sankuai.com:9872]
New listener list:  []

➜  apache-ratis-3.1.3-bin bin/ratis sh group info -Draft.rpc.type=NETTY -peers zw06-data-k8s-sparktest-cm0003.sankuai.com:9872
[main] INFO org.apache.ratis.netty.NettyUtils - Create EpollEventLoopGroup for client-B66AD33FDE96; Thread size is 0.
group id: c5196f6d-2c34-3ed3-8b8a-47bede733167
leader info: 2(zw06-data-k8s-sparktest-cm0003.sankuai.com:9872)

[server {
  id: "2"
  address: "zw06-data-k8s-sparktest-cm0003.sankuai.com:9872"
  clientAddress: "zw06-data-k8s-sparktest-cm0003.sankuai.com:9097"
  adminAddress: "zw06-data-k8s-sparktest-cm0003.sankuai.com:9097"
  startupRole: FOLLOWER
}
commitIndex: 1495889
, server {
  id: "1"
  address: "zw06-data-k8s-sparktest-cm0002.sankuai.com:9872"
  clientAddress: "zw06-data-k8s-sparktest-cm0002.sankuai.com:9097"
  adminAddress: "zw06-data-k8s-sparktest-cm0002.sankuai.com:9097"
  startupRole: FOLLOWER
}
commitIndex: 1495889
, server {
  id: "0"
  address: "zw06-data-k8s-sparktest-cm0001.sankuai.com:9872"
  clientAddress: "zw06-data-k8s-sparktest-cm0001.sankuai.com:9097"
  adminAddress: "zw06-data-k8s-sparktest-cm0001.sankuai.com:9097"
  startupRole: FOLLOWER
}
commitIndex: 1495889
]


```

