### PR TITLE
RATIS-2325. Create GrpcStubPool for Grpc Client

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
@@ -147,6 +147,15 @@ public interface GrpcConfigKeys {
       setInt(properties::setInt, PORT_KEY, port);
     }
 
+    String STUB_POOL_SIZE_KEY = PREFIX + ".stub.pool.size";
+    int STUB_POOL_SIZE_DEFAULT = 10;
+    static int stubPoolSize(RaftProperties properties) {
+      return get(properties::getInt, STUB_POOL_SIZE_KEY, STUB_POOL_SIZE_DEFAULT, getDefaultLog());
+    }
+    static void setStubPoolSize(RaftProperties properties, int size) {
+      setInt(properties::setInt, STUB_POOL_SIZE_KEY, size);
+    }
+
     String TLS_CONF_PARAMETER = PREFIX + ".tls.conf";
     Class<GrpcTlsConfig> TLS_CONF_CLASS = TLS.CONF_CLASS;
     static GrpcTlsConfig tlsConf(Parameters parameters) {

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -47,6 +47,7 @@ import java.io.Closeable;
 public class GrpcServerProtocolClient implements Closeable {
   // Common channel
   private final ManagedChannel channel;
+  private final GrpcStubPool<RaftServerProtocolServiceStub> pool;
   // Channel and stub for heartbeat
   private ManagedChannel hbChannel;
   private RaftServerProtocolServiceStub hbAsyncStub;
@@ -59,7 +60,7 @@ public class GrpcServerProtocolClient implements Closeable {
   //visible for using in log / error messages AND to use in instrumented tests
   private final RaftPeerId raftPeerId;
 
-  public GrpcServerProtocolClient(RaftPeer target, int flowControlWindow,
+  public GrpcServerProtocolClient(RaftPeer target, int connections, int flowControlWindow,
       TimeDuration requestTimeout, GrpcTlsConfig tlsConfig, boolean separateHBChannel) {
     raftPeerId = target.getId();
     LOG.info("Build channel for {}", target);
@@ -72,6 +73,8 @@ public class GrpcServerProtocolClient implements Closeable {
       hbAsyncStub = RaftServerProtocolServiceGrpc.newStub(hbChannel);
     }
     requestTimeoutDuration = requestTimeout;
+    this.pool = new GrpcStubPool<RaftServerProtocolServiceStub>(target, connections,
+            ch -> RaftServerProtocolServiceGrpc.newStub(ch));
   }
 
   private ManagedChannel buildChannel(RaftPeer target, int flowControlWindow,
@@ -125,8 +128,19 @@ public class GrpcServerProtocolClient implements Closeable {
   }
 
   void readIndex(ReadIndexRequestProto request, StreamObserver<ReadIndexReplyProto> s) {
-    asyncStub.withDeadlineAfter(requestTimeoutDuration.getDuration(), requestTimeoutDuration.getUnit())
-        .readIndex(request, s);
+    GrpcStubPool.PooledStub<RaftServerProtocolServiceStub> p;
+    try {
+      p = pool.acquire();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      s.onError(e); return;
+    }
+    p.stub.withDeadlineAfter(requestTimeoutDuration.getDuration(), requestTimeoutDuration.getUnit())
+            .readIndex(request, new StreamObserver<ReadIndexReplyProto>() {
+              @Override public void onNext(ReadIndexReplyProto v) { s.onNext(v); }
+              @Override public void onError(Throwable t) { try { s.onError(t); } finally { pool.release(p); } }
+              @Override public void onCompleted() { try { s.onCompleted(); } finally { pool.release(p); } }
+            });
   }
 
   CallStreamObserver<AppendEntriesRequestProto> appendEntries(

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServicesImpl.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServicesImpl.java
@@ -109,6 +109,7 @@ public final class GrpcServicesImpl
     private GrpcTlsConfig adminTlsConfig;
     private String clientHost;
     private int clientPort;
+    private int clientStubPoolSize;
     private GrpcTlsConfig clientTlsConfig;
     private String serverHost;
     private int serverPort;
@@ -129,6 +130,7 @@ public final class GrpcServicesImpl
       this.adminPort = GrpcConfigKeys.Admin.port(properties);
       this.clientHost = GrpcConfigKeys.Client.host(properties);
       this.clientPort = GrpcConfigKeys.Client.port(properties);
+      this.clientStubPoolSize = GrpcConfigKeys.Client.stubPoolSize(properties);
       this.serverHost = GrpcConfigKeys.Server.host(properties);
       this.serverPort = GrpcConfigKeys.Server.port(properties);
       this.messageSizeMax = GrpcConfigKeys.messageSizeMax(properties, LOG::info);
@@ -155,7 +157,7 @@ public final class GrpcServicesImpl
     }
 
     private GrpcServerProtocolClient newGrpcServerProtocolClient(RaftPeer target) {
-      return new GrpcServerProtocolClient(target, flowControlWindow.getSizeInt(),
+      return new GrpcServerProtocolClient(target, clientStubPoolSize, flowControlWindow.getSizeInt(),
           requestTimeoutDuration, serverTlsConfig, separateHeartbeatChannel);
     }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcStubPool.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcStubPool.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.grpc.server;
+
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.thirdparty.io.grpc.ManagedChannel;
+import org.apache.ratis.thirdparty.io.grpc.netty.NettyChannelBuilder;
+import org.apache.ratis.thirdparty.io.grpc.stub.AbstractStub;
+import org.apache.ratis.thirdparty.io.netty.channel.ChannelOption;
+import org.apache.ratis.thirdparty.io.netty.channel.WriteBufferWaterMark;
+import org.apache.ratis.thirdparty.io.netty.channel.nio.NioEventLoopGroup;
+import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioSocketChannel;
+
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class GrpcStubPool<S extends AbstractStub<S>> implements AutoCloseable {
+
+    static final class PooledStub<S extends AbstractStub<S>> {
+        final ManagedChannel ch;
+        final S stub;
+        final Semaphore permits;
+        PooledStub(ManagedChannel ch, S stub, int maxInflight) {
+            this.ch = ch;
+            this.stub = stub;
+            this.permits = new Semaphore(maxInflight);
+        }
+    }
+
+    private final List<PooledStub<S>> pool;
+    private final AtomicInteger rr = new AtomicInteger();
+    private final NioEventLoopGroup elg;
+    private final int size;
+
+    GrpcStubPool(RaftPeer target, int n, java.util.function.Function<ManagedChannel, S> stubFactory) {
+        this(target, n, stubFactory, Math.max(2, Runtime.getRuntime().availableProcessors()/2), 16);
+    }
+
+    GrpcStubPool(RaftPeer target, int n,
+                 java.util.function.Function<ManagedChannel, S> stubFactory,
+                 int elgThreads, int maxInflightPerConn) {
+        this.elg = new NioEventLoopGroup(elgThreads);
+        java.util.ArrayList<PooledStub<S>> tmp = new java.util.ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            ManagedChannel ch = NettyChannelBuilder.forTarget(target.getAddress())
+                    .eventLoopGroup(elg)
+                    .channelType(NioSocketChannel.class)
+                    .keepAliveTime(30, java.util.concurrent.TimeUnit.SECONDS)
+                    .keepAliveWithoutCalls(true)
+                    .idleTimeout(24, java.util.concurrent.TimeUnit.HOURS)
+                    .withOption(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(64<<10, 128<<10))
+                    .usePlaintext()
+                    .build();
+            tmp.add(new PooledStub<>(ch, stubFactory.apply(ch), maxInflightPerConn));
+            ch.getState(true);
+        }
+        this.pool = java.util.Collections.unmodifiableList(tmp);
+        this.size = n;
+    }
+
+    PooledStub<S> acquire() throws InterruptedException {
+        int start = rr.getAndIncrement();
+        for (int k = 0; k < size; k++) {
+            PooledStub<S> p = pool.get((start + k) % size);
+            if (p.permits.tryAcquire()) return p;
+        }
+        PooledStub<S> p = pool.get(Math.floorMod(start, size));
+        p.permits.acquire();
+        return p;
+    }
+
+    void release(PooledStub<S> p) { p.permits.release(); }
+
+    @Override public void close() {
+        for (PooledStub p: pool) p.ch.shutdown();
+        elg.shutdownGracefully();
+    }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The performance of ReadIndex is limited, a GrpcStubPool is added to improve the performence.

With this patch, QPS increase from 51326 to 81003 calls per second.

## What is the link to the Apache JIRA

The performance of ReadIndex is limited, a GrpcStubPool is added to improve the performence.

With this patch, QPS increase from 51326 to 81003 calls per second.

## How was this patch tested?

Ozone Follower Read performance.