### PR TITLE
RATIS-2332. Start new servers with empty peer list in tests.

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotFromLeaderTests.java
@@ -116,8 +116,7 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
     Assertions.assertEquals(3, snapshot.getFiles().size());
 
     // add two more peers
-    final PeerChanges change = cluster.addNewPeers(2, true,
-        true);
+    final PeerChanges change = cluster.addNewPeers(2, true);
     // trigger setConfiguration
     cluster.setConfiguration(change.getPeersInNewConf());
 
@@ -161,8 +160,7 @@ public abstract class InstallSnapshotFromLeaderTests<CLUSTER extends MiniRaftClu
     }
 
     // add two more peers and install snapshot from leaders
-    final PeerChanges change = cluster.addNewPeers(2, true,
-        true);
+    final PeerChanges change = cluster.addNewPeers(2, true);
     try (final RaftClient client = cluster.createClient(leaderId, RetryPolicies.noRetry())) {
       final RaftException e = Assertions.assertThrows(RaftException.class,
                () -> client.admin().setConfiguration(change.getPeersInNewConf()));

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -241,7 +241,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
       Assertions.assertTrue(set);
 
       // Add new peer(s)
-      final PeerChanges change = cluster.addNewPeers(1, true, true);
+      final PeerChanges change = cluster.addNewPeers(1, true);
       // trigger setConfiguration
       RaftServerTestUtil.runWithMinorityPeers(cluster, change.getPeersInNewConf(), cluster::setConfiguration);
 
@@ -389,7 +389,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
 
       // Add new peer(s) who will need snapshots from the leader.
       final int numNewPeers = 1;
-      final PeerChanges change = cluster.addNewPeers(numNewPeers, true, true);
+      final PeerChanges change = cluster.addNewPeers(numNewPeers, true);
       // trigger setConfiguration
       RaftServerTestUtil.runWithMinorityPeers(cluster, change.getPeersInNewConf(), cluster::setConfiguration);
       RaftServerTestUtil.waitAndCheckNewConf(cluster, change.getPeersInNewConf(), 0, null);
@@ -475,7 +475,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
       Assertions.assertTrue(set);
 
       // add one new peer
-      final PeerChanges change = cluster.addNewPeers(1, true, true);
+      final PeerChanges change = cluster.addNewPeers(1, true);
       // trigger setConfiguration
       RaftServerTestUtil.runWithMinorityPeers(cluster, change.getPeersInNewConf(), cluster::setConfiguration);
       RaftServerTestUtil.waitAndCheckNewConf(cluster, change.getPeersInNewConf(), 0, null);
@@ -551,7 +551,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
 
       // Add new peer(s)
       final int numNewPeers = 1;
-      final PeerChanges change = cluster.addNewPeers(numNewPeers, true, true);
+      final PeerChanges change = cluster.addNewPeers(numNewPeers, true);
       // trigger setConfiguration
       RaftServerTestUtil.runWithMinorityPeers(cluster, change.getPeersInNewConf(), cluster::setConfiguration);
 

--- a/ratis-server/src/test/java/org/apache/ratis/RaftExceptionBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftExceptionBaseTest.java
@@ -110,8 +110,7 @@ public abstract class RaftExceptionBaseTest<CLUSTER extends MiniRaftCluster>
       final RaftPeerId newLeader = RaftTestUtil.changeLeader(cluster, oldLeader);
 
       // add two more peers
-      PeerChanges change = cluster.addNewPeers(new String[]{
-          "ss1", "ss2"}, true, false);
+      PeerChanges change = cluster.addNewPeers(2, true);
       // trigger setConfiguration
       LOG.info("Start changing the configuration: {}", change.getPeersInNewConf());
       try (final RaftClient c2 = cluster.createClient(newLeader)) {

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -156,7 +156,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
       }
       // add 3 new servers and wait longer time
       CodeInjectionForTesting.put(RaftServerImpl.START_COMPLETE, new SleepCode(2000));
-      final PeerChanges peerChanges = cluster.addNewPeers(2, true, false);
+      final PeerChanges peerChanges = cluster.addNewPeers(2, true);
       LOG.info("add new 3 servers");
       LOG.info(cluster.printServers());
       RaftClientReply reply = client.admin().setConfiguration(SetConfigurationRequest.Arguments.newBuilder()
@@ -461,7 +461,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         client.io().send(new RaftTestUtil.SimpleMessage("message"));
         List<RaftPeer> servers = cluster.getPeers();
         assertEquals(servers.size(), 3);
-        final PeerChanges changes = cluster.addNewPeers(1, true, false, LISTENER);
+        final PeerChanges changes = cluster.addNewPeers(1, true);
         final List<RaftPeer> added = changes.getAddedPeers();
         final RaftClientReply reply = client.admin().setConfiguration(servers, added);
         assertTrue(reply.isSuccess());
@@ -486,7 +486,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         List<RaftPeer> listener = new ArrayList<>(
             leader.getRaftConf().getAllPeers(RaftProtos.RaftPeerRole.LISTENER));
         assertEquals(1, listener.size());
-        final PeerChanges changes = cluster.addNewPeers(1, true, false);
+        final PeerChanges changes = cluster.addNewPeers(1, true);
         final List<RaftPeer> newPeers = new ArrayList<>(changes.getAddedPeers());
         newPeers.addAll(leader.getRaftConf().getAllPeers(RaftProtos.RaftPeerRole.FOLLOWER));
         RaftClientReply reply = client.admin().setConfiguration(newPeers, listener);

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -159,7 +159,7 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
 
       RaftGroupId groupId = cluster.getGroup().getGroupId();
       RaftPeer curPeer = cluster.getGroup().getPeers().iterator().next();
-      RaftPeer newPeer = cluster.addNewPeers(1, true, true).getAddedPeers().get(0);
+      RaftPeer newPeer = cluster.addNewPeers(1, true).getAddedPeers().get(0);
 
       RaftServerProxy leaderServer = cluster.getServer(curPeer.getId());
 
@@ -336,7 +336,7 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
         CountDownLatch latch = new CountDownLatch(1);
         Thread clientThread = new Thread(() -> {
           try {
-            PeerChanges c1 = cluster.addNewPeers(2, true, true);
+            PeerChanges c1 = cluster.addNewPeers(2, true);
             LOG.info("Start changing the configuration: {}", c1.getPeersInNewConf());
 
             RaftClientReply reply = client.admin().setConfiguration(c1.getPeersInNewConf());

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/RaftSnapshotBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/RaftSnapshotBaseTest.java
@@ -227,7 +227,7 @@ public abstract class RaftSnapshotBaseTest<CLUSTER extends MiniRaftCluster>
       }
 
       // add a new peer
-      final PeerChanges change = cluster.addNewPeers(1, true, true);
+      final PeerChanges change = cluster.addNewPeers(1, true);
       // trigger setConfiguration
       RaftServerTestUtil.runWithMinorityPeers(cluster, change.getPeersInNewConf(), cluster::setConfiguration);
 
@@ -292,7 +292,7 @@ public abstract class RaftSnapshotBaseTest<CLUSTER extends MiniRaftCluster>
       assertLeaderContent(cluster);
 
       // add a new peer
-      final PeerChanges change = cluster.addNewPeers(1, true, true);
+      final PeerChanges change = cluster.addNewPeers(1, true);
       // trigger setConfiguration
       RaftServerTestUtil.runWithMinorityPeers(cluster, change.getPeersInNewConf(), cluster::setConfiguration);
 

--- a/ratis-test/src/test/java/org/apache/ratis/shell/cli/sh/PeerCommandIntegrationTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/shell/cli/sh/PeerCommandIntegrationTest.java
@@ -82,7 +82,7 @@ public abstract class PeerCommandIntegrationTest <CLUSTER extends MiniRaftCluste
 
     RaftTestUtil.waitForLeader(cluster);
     final List<RaftPeer> peers = cluster.getPeers();
-    final List<RaftPeer> newPeers = cluster.addNewPeers(1, true, true).getAddedPeers();
+    final List<RaftPeer> newPeers = cluster.addNewPeers(1, true).getAddedPeers();
 
     RaftServerTestUtil.waitAndCheckNewConf(cluster, peers, 0, null);
     StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
See RATIS-2332.

Note that this is a test only change.