### PR TITLE
RATIS-2340. Add ReadIndexAsync executor for readIndex stateMachine query

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1054,6 +1054,9 @@ class RaftServerImpl implements RaftServer.Division,
     return writeIndexCache.getWriteIndexFuture(request).thenCompose(leader::getReadIndex);
   }
 
+  private final ExecutorService readAsyncExecutor = ConcurrentUtils.newThreadPoolWithMax(false,
+      Math.max(2, Runtime.getRuntime().availableProcessors()), "ReadAsync");
+
   private CompletableFuture<RaftClientReply> readAsync(RaftClientRequest request) {
     if (request.getType().getRead().getPreferNonLinearizable()
         || readOption == RaftServerConfigKeys.Read.Option.DEFAULT) {
@@ -1087,7 +1090,8 @@ class RaftServerImpl implements RaftServer.Division,
 
       return replyFuture
           .thenCompose(readIndex -> getReadRequests().waitToAdvance(readIndex))
-          .thenCompose(readIndex -> queryStateMachine(request))
+          .thenComposeAsync(ignored -> stateMachine.query(request.getMessage()), readAsyncExecutor)
+          .thenCompose(reply -> processQueryFuture(CompletableFuture.completedFuture(reply), request))
           .exceptionally(e -> readException2Reply(request, e));
     } else {
       throw new IllegalStateException("Unexpected read option: " + readOption);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the query work is done by the ELG worker threads, need to separate the works so that workers can focus on their job.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2340

## How was this patch tested?

Stack dump shows not using ELG worker threads.
