### PR TITLE
RATIS-2341. Introduce LocalLease for roughly up-to-date check

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
@@ -122,6 +122,8 @@ public interface RaftServer extends Closeable, RpcType.Get,
 
     @Override
     void close();
+
+    public boolean okForLocalReadBounded(int maxLag, long leaseMs);
   }
 
   /** @return the server ID. */

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LocalLease.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LocalLease.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server.impl;
+
+import org.apache.ratis.protocol.RaftPeerId;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/** LocalLease can be used for followers to check if it's updated to Leader.
+ */
+public class LocalLease {
+  final AtomicLong leaderCommit = new AtomicLong(-1);
+  volatile long lastHbNanos = 0L;
+  volatile long leaseTerm   = -1L;
+  volatile RaftPeerId leaseLeader = null;
+
+  public LocalLease() {
+
+  }
+  void onAppend(long term, RaftPeerId leader, long commitIdx) {
+    if (leaseTerm != term || leaseLeader == null || !leaseLeader.equals(leader)) {
+      leaseTerm = term;
+      leaseLeader = leader;
+      leaderCommit.set(commitIdx);
+    } else {
+      long prev;
+      do { prev = leaderCommit.get(); }
+      while (commitIdx > prev && !leaderCommit.compareAndSet(prev, commitIdx));
+    }
+    lastHbNanos = System.nanoTime();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current logic of ReadIndex limits the performance of FollowerRead.

 
In production, the vast majority of requests are for old data, so running the readIndex logic for every request becomes somewhat wasteful.

This ticket is to introduce LocalLease for followers, so that followers can decide if it's catched up with Leader, and application can reasonably make use of this information.
 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2341

## How was this patch tested?

Local performance test.
