### PR TITLE
RATIS-2385. Don't keep failed requests in the RetryCache.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -772,9 +772,8 @@ class RaftServerImpl implements RaftServer.Division,
    */
   private CompletableFuture<RaftClientReply> checkLeaderState(RaftClientRequest request, CacheEntry entry) {
     if (!getInfo().isLeader()) {
-      NotLeaderException exception = generateNotLeaderException();
-      final RaftClientReply reply = newExceptionReply(request, exception);
-      return RetryCacheImpl.failWithReply(reply, entry);
+      return retryCache.failWithReplyAndInvalidate(
+          newExceptionReply(request, generateNotLeaderException()), entry);
     }
     if (!getInfo().isLeaderReady()) {
       final CacheEntry cacheEntry = retryCache.getIfPresent(ClientInvocationId.valueOf(request));
@@ -832,8 +831,8 @@ class RaftServerImpl implements RaftServer.Division,
 
     final LeaderStateImpl unsyncedLeaderState = role.getLeaderState().orElse(null);
     if (unsyncedLeaderState == null) {
-      final RaftClientReply reply = newExceptionReply(request, generateNotLeaderException());
-      return RetryCacheImpl.failWithReply(reply, cacheEntry);
+      return retryCache.failWithReplyAndInvalidate(
+          newExceptionReply(request, generateNotLeaderException()), cacheEntry);
     }
     final PendingRequests.Permit unsyncedPermit = unsyncedLeaderState.tryAcquirePendingRequest(request.getMessage());
     if (unsyncedPermit == null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
If the leader has changed after we placed the request in the RetryCache but before we wrote it to the log file, we should remove it from the cache.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2385
## How was this patch tested?
Manual tests with Ozone. Under load with a continuously changing leader, NPEs occur during retry operations. No exception occurs; the patch and retry operations complete successfully. 