### PR TITLE
RATIS-2398. Add opentelemetry-javaagent to ratis-examples and assembly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,7 @@
     <!-- OpenTelemetry versions -->
     <opentelemetry.version>1.60.1</opentelemetry.version>
     <opentelemetry-semconv.version>1.40.0</opentelemetry-semconv.version>
+    <opentelemetry-javaagent.version>2.26.1</opentelemetry-javaagent.version>
     <!-- Test properties -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <test.exclude.pattern>_</test.exclude.pattern>
@@ -413,6 +414,11 @@
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-context</artifactId>
         <version>${opentelemetry.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentelemetry.javaagent</groupId>
+        <artifactId>opentelemetry-javaagent</artifactId>
+        <version>${opentelemetry-javaagent.version}</version>
       </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,7 @@
 
     <!-- OpenTelemetry versions -->
     <opentelemetry.version>1.63.0</opentelemetry.version>
+    <opentelemetry-javaagent.version>2.28.1</opentelemetry-javaagent.version>
     <!-- Test properties -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <test.exclude.pattern>_</test.exclude.pattern>

--- a/ratis-assembly/pom.xml
+++ b/ratis-assembly/pom.xml
@@ -289,6 +289,11 @@
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-shell</artifactId>
     </dependency>
+    <!-- Include OpenTelemetry agent -->
+    <dependency>
+      <groupId>io.opentelemetry.javaagent</groupId>
+      <artifactId>opentelemetry-javaagent</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/ratis-assembly/src/main/assembly/bin.xml
+++ b/ratis-assembly/src/main/assembly/bin.xml
@@ -33,6 +33,12 @@
       </includes>
       <outputDirectory>examples/lib</outputDirectory>
     </dependencySet>
+    <dependencySet>
+      <outputDirectory>lib/trace</outputDirectory>
+      <includes>
+        <include>io.opentelemetry.javaagent:*</include>
+      </includes>
+    </dependencySet>
   </dependencySets>
   <moduleSets>
     <moduleSet>

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java
@@ -26,6 +26,7 @@ import org.apache.ratis.client.api.SnapshotManagementApi;
 import org.apache.ratis.client.retry.ClientRetryEvent;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
+import io.opentelemetry.context.Context;
 import org.apache.ratis.proto.RaftProtos.SlidingWindowEntry;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
@@ -290,6 +291,9 @@ public final class RaftClientImpl implements RaftClient {
     } else {
       b.setLeaderId(getLeaderId())
        .setRepliedCallIds(repliedCallIds.get(callId));
+    }
+    if (TraceUtils.getGlobalTracer() != null) {
+      b.setSpanContext(TraceUtils.injectContextToProto(Context.current()));
     }
     return b.setClientId(clientId)
         .setGroupId(groupId)

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java
@@ -292,6 +292,9 @@ public final class RaftClientImpl implements RaftClient {
       b.setLeaderId(getLeaderId())
        .setRepliedCallIds(repliedCallIds.get(callId));
     }
+    if (TraceUtils.isEnabled()) {
+      b.setSpanContext(TraceUtils.injectContextToProto());
+    }
     return b.setClientId(clientId)
         .setGroupId(groupId)
         .setCallId(callId)

--- a/ratis-common/src/main/java/org/apache/ratis/trace/NoOpTraceProvider.java
+++ b/ratis-common/src/main/java/org/apache/ratis/trace/NoOpTraceProvider.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.trace;
 
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
+import org.apache.ratis.proto.RaftProtos.SpanContextProto;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.util.function.CheckedSupplier;
@@ -27,6 +28,11 @@ import java.util.concurrent.CompletableFuture;
 
 enum NoOpTraceProvider implements TraceProvider {
   INSTANCE;
+
+  @Override
+  public SpanContextProto injectContextToProto() {
+    return null;
+  }
 
   @Override
   public <T, THROWABLE extends Throwable> CompletableFuture<T> traceClientSend(

--- a/ratis-common/src/main/java/org/apache/ratis/trace/TraceConfigKeys.java
+++ b/ratis-common/src/main/java/org/apache/ratis/trace/TraceConfigKeys.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.trace;
 
 import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.util.StringUtils;
 
 import java.util.function.Consumer;
 
@@ -30,8 +31,20 @@ public interface TraceConfigKeys {
   String ENABLED_KEY = PREFIX + ".enabled";
   boolean ENABLED_DEFAULT = false;
 
+  /**
+   * Whether Ratis should emit OpenTelemetry spans. When the key is absent from
+   * {@link RaftProperties}, the JVM system property {@value #ENABLED_KEY} is consulted so
+   * {@code -Draft.otel.tracing.enabled=true} works with empty example configs.
+   */
   static boolean enabled(RaftProperties properties, Consumer<String> logger) {
-    return getBoolean(properties::getBoolean, ENABLED_KEY, ENABLED_DEFAULT, logger);
+    if (properties.getRaw(ENABLED_KEY) != null) {
+      return getBoolean(properties::getBoolean, ENABLED_KEY, ENABLED_DEFAULT, logger);
+    }
+    final String fromSystem = System.getProperty(ENABLED_KEY);
+    if (fromSystem != null) {
+      return StringUtils.string2boolean(fromSystem.trim(), ENABLED_DEFAULT);
+    }
+    return ENABLED_DEFAULT;
   }
 
   static boolean enabled(RaftProperties properties) {

--- a/ratis-common/src/main/java/org/apache/ratis/trace/TraceProvider.java
+++ b/ratis-common/src/main/java/org/apache/ratis/trace/TraceProvider.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.trace;
 
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
+import org.apache.ratis.proto.RaftProtos.SpanContextProto;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.util.function.CheckedSupplier;
@@ -26,6 +27,7 @@ import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
 public interface TraceProvider {
+
   <T, THROWABLE extends Throwable> CompletableFuture<T> traceClientSend(
       CheckedSupplier<CompletableFuture<T>, THROWABLE> action,
       RaftClientRequest.Type type, RaftPeerId server) throws THROWABLE;
@@ -37,4 +39,6 @@ public interface TraceProvider {
   <T> CompletableFuture<T> traceAppendEntries(
       CheckedSupplier<CompletableFuture<T>, IOException> action,
       AppendEntriesRequestProto request, String memberId) throws IOException;
+
+  SpanContextProto injectContextToProto();
 }

--- a/ratis-common/src/main/java/org/apache/ratis/trace/TraceUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/trace/TraceUtils.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.trace;
 
 import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.proto.RaftProtos.SpanContextProto;
 import org.apache.ratis.util.ServiceUtils;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -53,6 +54,10 @@ public final class TraceUtils {
 
   public static boolean isEnabled() {
     return !(getProvider() instanceof NoOpTraceProvider);
+  }
+
+  public static SpanContextProto injectContextToProto() {
+    return getProvider().injectContextToProto();
   }
 
   static TraceProvider getProvider() {

--- a/ratis-examples/README.md
+++ b/ratis-examples/README.md
@@ -146,3 +146,47 @@ by using the `run_all_tests.sh` script found in [dev-support/vagrant/](../dev-su
 See the [dev-support/vagrant/README.md](../dev-support/vagrant/README.md) for more on dependencies and what is setup.
 This will allow one to try a fully setup three server Ratis cluster on a single VM image,
 preventing resource contention with your development host and allowing failure injection too.
+
+
+## Enable Tracing when testing examples
+Ratis uses OpenTracing to provide distributed tracing of requests across the cluster. 
+To enable tracing, you need to set the `-Draft.otel.tracing.enabled=true` as part of 
+the JVM options when running the server and client.
+For example, to enable tracing for the FileStore server, you can run the following command:
+
+```bash
+# build the assembly jar first
+mvn clean package -DskipTests
+
+# extract the assembly jar, mainly we need the dependencies for tracing
+pushd ratis-assembly/target
+file=$(ls -1t ratis-assembly-*.tar.gz | head -n1)
+tar -zxvf "$file"
+popd
+
+# run the server, the tracing will be enabled because it found the 
+# opentelemetry agent jar
+BIN=ratis-examples/src/main/bin
+PEERS=n0:127.0.0.1:6000,n1:127.0.0.1:6001,n2:127.0.0.1:6002
+
+ID=n0; ${BIN}/server.sh filestore server --id ${ID} --storage /tmp/ratis/${ID} --peers ${PEERS}
+ID=n1; ${BIN}/server.sh filestore server --id ${ID} --storage /tmp/ratis/${ID} --peers ${PEERS}
+ID=n2; ${BIN}/server.sh filestore server --id ${ID} --storage /tmp/ratis/${ID} --peers ${PEERS}
+
+# some message should be shown
+[otel.javaagent 2026-04-15 15:55:11:320 -0700] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 2.26.1
+```
+
+If you want to configure the tracing further, you can set the following system properties
+
+```bash
+# below is an example to configure the OTLP exporter to send the traces to a local collector, 
+# you can change the endpoint and protocol as needed, and please make sure 
+# raft.otel.tracing.enabled is set to true to enable tracing in Ratis
+export OTEL_EXPORTER_OPTS="-Dotel.traces.exporter=otlp \
+-Dotel.exporter.otlp.protocol=grpc \
+-Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+-Dotel.metrics.exporter=none \
+-Dotel.logs.exporter=none \
+-Draft.otel.tracing.enabled=true"
+```

--- a/ratis-examples/README.md
+++ b/ratis-examples/README.md
@@ -146,3 +146,53 @@ by using the `run_all_tests.sh` script found in [dev-support/vagrant/](../dev-su
 See the [dev-support/vagrant/README.md](../dev-support/vagrant/README.md) for more on dependencies and what is setup.
 This will allow one to try a fully setup three server Ratis cluster on a single VM image,
 preventing resource contention with your development host and allowing failure injection too.
+
+
+## Enable Tracing when testing examples
+Ratis uses OpenTelemetry to provide distributed tracing of requests across the cluster.
+Tracing is configured through `RaftProperties`; Ratis itself does not read JVM system
+properties for configuration.
+
+The example shell scripts pass `-Draft.otel.tracing.enabled=true` as a JVM option when the
+OpenTelemetry agent is found. `Runner` reads that property through `ExampleLauncher` and
+applies it to `RaftProperties` before starting an example (e.g. "filestore" or
+"arithmetic").
+
+For example, to enable tracing for the FileStore server, you can run the following command:
+
+```bash
+# build the assembly jar first
+mvn clean package -DskipTests
+
+# extract the assembly jar, mainly we need the dependencies for tracing
+pushd ratis-assembly/target
+file=$(ls -1t ratis-assembly-*.tar.gz | head -n1)
+tar -zxvf "$file"
+popd
+
+# run the server, the tracing will be enabled because it found the 
+# opentelemetry agent jar
+BIN=ratis-examples/src/main/bin
+PEERS=n0:127.0.0.1:6000,n1:127.0.0.1:6001,n2:127.0.0.1:6002
+
+ID=n0; ${BIN}/server.sh filestore server --id ${ID} --storage /tmp/ratis/${ID} --peers ${PEERS}
+ID=n1; ${BIN}/server.sh filestore server --id ${ID} --storage /tmp/ratis/${ID} --peers ${PEERS}
+ID=n2; ${BIN}/server.sh filestore server --id ${ID} --storage /tmp/ratis/${ID} --peers ${PEERS}
+
+# some message should be shown
+[otel.javaagent 2026-04-15 15:55:11:320 -0700] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 2.26.1
+```
+
+If you want to configure the tracing further, you can set the following system properties
+
+```bash
+# below is an example to configure the OTLP exporter to send the traces to a local collector,
+# you can change the endpoint and protocol as needed. ExampleLauncher reads
+# -Draft.otel.tracing.enabled=true and applies it to RaftProperties.
+export OTEL_EXPORTER_OPTS="-Dotel.traces.exporter=otlp \
+-Dotel.exporter.otlp.protocol=grpc \
+-Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+-Dotel.metrics.exporter=none \
+-Dotel.logs.exporter=none \
+-Draft.otel.tracing.enabled=true"
+```

--- a/ratis-examples/pom.xml
+++ b/ratis-examples/pom.xml
@@ -116,7 +116,10 @@
       <artifactId>slf4j-reload4j</artifactId>
       <scope>runtime</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-trace-otel</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>

--- a/ratis-examples/src/main/bin/client.sh
+++ b/ratis-examples/src/main/bin/client.sh
@@ -23,7 +23,8 @@ if [ "$#" -lt 2 ]; then
   exit 1
 fi
 
-source $DIR/common.sh
+OTEL_SERVICE_NAME=ratis.client
+source "${DIR}/common.sh"
 
 # One of the examples, e.g. "filestore" or "arithmetic"
 example="$1"
@@ -32,4 +33,4 @@ shift
 subcommand="$1"
 shift
 
-java ${LOGGER_OPTS} -jar $ARTIFACT "$example" "$subcommand" "$@"
+java ${OTEL_OPTS} ${LOGGER_OPTS} -jar $ARTIFACT "$example" "$subcommand" "$@"

--- a/ratis-examples/src/main/bin/common.sh
+++ b/ratis-examples/src/main/bin/common.sh
@@ -46,3 +46,43 @@ if [[ -d "${CONF_DIR}" ]]; then
 else
   LOGGER_OPTS="-Dlog4j.configuration=file:${DIR}/../resources/log4j.properties"
 fi
+
+
+# for opentelemetry: release tarball uses lib/trace next to examples/;
+# dev tree uses ratis-assembly/target/apache-ratis-*-bin/lib/trace after package.
+if [[ -n "${OTEL_JAR:-}" && -f "${OTEL_JAR}" ]]; then
+  : # use OTEL_JAR from environment
+else
+  otel_jar_candidates=()
+  for _jar in "${SCRIPT_DIR}"/../../lib/trace/opentelemetry-javaagent*.jar; do
+    [[ -f "${_jar}" ]] && otel_jar_candidates+=("${_jar}")
+  done
+  for _otel_trace_dir in "${SCRIPT_DIR}"/../../../../ratis-assembly/target/apache-ratis-*-bin/lib/trace; do
+    [[ -d "${_otel_trace_dir}" ]] || continue
+    for _jar in "${_otel_trace_dir}"/opentelemetry-javaagent*.jar; do
+      [[ -f "${_jar}" ]] && otel_jar_candidates+=("${_jar}")
+    done
+  done
+  if ((${#otel_jar_candidates[@]} > 0)); then
+    OTEL_JAR="$(printf '%s\n' "${otel_jar_candidates[@]}" | sort -V | tail -n 1)"
+  else
+    echo "Warning: OpenTelemetry agent jar not found; OTEL disabled"
+    OTEL_JAR=""
+  fi
+fi
+
+OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-ratis.server}"
+OTEL_DEFAULT_EXPORTER_OPTS="-Dotel.traces.exporter=logging \
+-Dotel.metrics.exporter=none \
+-Dotel.logs.exporter=logging"
+# Unset or empty → default exporter flags (empty is not a supported override).
+OTEL_EXPORTER_OPTS="${OTEL_EXPORTER_OPTS:-${OTEL_DEFAULT_EXPORTER_OPTS}}"
+
+# Enable javaagent when OTEL_JAR resolves to a file (env or discovery above).
+if [[ -n "${OTEL_JAR}" && -f "${OTEL_JAR}" ]]; then
+  OTEL_OPTS="-javaagent:${OTEL_JAR} -Dotel.resource.attributes=service.name=${OTEL_SERVICE_NAME} ${OTEL_EXPORTER_OPTS} -Draft.otel.tracing.enabled=true"
+else
+  OTEL_OPTS=""
+fi
+
+echo "Using OTEL_OPTS: ${OTEL_OPTS}"

--- a/ratis-examples/src/main/bin/server.sh
+++ b/ratis-examples/src/main/bin/server.sh
@@ -16,5 +16,4 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 source $DIR/common.sh
-
-java ${LOGGER_OPTS} -jar $ARTIFACT "$@"
+java ${OTEL_OPTS} ${LOGGER_OPTS} -jar $ARTIFACT "$@"

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/cli/Client.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/cli/Client.java
@@ -37,7 +37,7 @@ public abstract class Client extends SubCommandBase {
 
   @Override
   public void run() throws Exception {
-    RaftProperties raftProperties = new RaftProperties();
+    RaftProperties raftProperties = newRaftProperties();
 
     final RaftGroup raftGroup = RaftGroup.valueOf(RaftGroupId.valueOf(ByteString.copyFromUtf8(getRaftGroupId())),
             getPeers());

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/cli/Server.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/cli/Server.java
@@ -56,7 +56,7 @@ public class Server extends SubCommandBase {
   @Override
   public void run() throws Exception {
     RaftPeerId peerId = RaftPeerId.valueOf(id);
-    RaftProperties properties = new RaftProperties();
+    RaftProperties properties = newRaftProperties();
 
     final int port = NetUtils.createSocketAddr(getPeer(peerId).getAddress()).getPort();
     GrpcConfigKeys.Server.setPort(properties, port);

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/common/ExampleLauncher.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/common/ExampleLauncher.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.examples.common;
+
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.trace.TraceConfigKeys;
+import org.apache.ratis.util.StringUtils;
+
+/**
+ * Applies example-only JVM system properties to {@link RaftProperties}.
+ * {@link Runner} calls {@link #init()} at startup; example subcommands obtain
+ * configured properties via {@link #newRaftProperties()}.
+ */
+public final class ExampleLauncher {
+
+  private static volatile boolean initialized;
+  private static Boolean tracingEnabled;
+
+  private ExampleLauncher() {
+  }
+
+  /** Reads example JVM system properties. Called once from {@link Runner#main}. */
+  public static void init() {
+    initFromSystemProperties();
+  }
+
+  /**
+   * Creates {@link RaftProperties} for examples, applying any tracing configuration
+   * read from the JVM system property {@value TraceConfigKeys#ENABLED_KEY}.
+   */
+  public static RaftProperties newRaftProperties() {
+    initFromSystemProperties();
+    final RaftProperties properties = new RaftProperties();
+    if (tracingEnabled != null) {
+      TraceConfigKeys.setEnabled(properties, tracingEnabled);
+    }
+    return properties;
+  }
+
+  private static void initFromSystemProperties() {
+    if (initialized) {
+      return;
+    }
+    synchronized (ExampleLauncher.class) {
+      if (initialized) {
+        return;
+      }
+      final String value = System.getProperty(TraceConfigKeys.ENABLED_KEY);
+      if (value != null) {
+        tracingEnabled = StringUtils.string2boolean(value.trim(), TraceConfigKeys.ENABLED_DEFAULT);
+      }
+      initialized = true;
+    }
+  }
+}

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/common/Runner.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/common/Runner.java
@@ -40,6 +40,7 @@ public final class Runner {
       System.err.println("No command type specified: ");
       return;
     }
+    ExampleLauncher.init();
     List<SubCommandBase> commands = initializeCommands(args[0]);
     Runner runner = new Runner();
 

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.examples.common;
 
 import com.beust.jcommander.Parameter;
+import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.RoutingTable;
@@ -113,6 +114,10 @@ public abstract class SubCommandBase {
   }
 
   public abstract void run() throws Exception;
+
+  protected RaftProperties newRaftProperties() {
+    return ExampleLauncher.newRaftProperties();
+  }
 
   public String getRaftGroupId() {
     return raftGroupId;

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
@@ -94,7 +94,7 @@ public abstract class Client extends SubCommandBase {
   @Override
   public void run() throws Exception {
     int raftSegmentPreallocatedSize = 1024 * 1024 * 1024;
-    RaftProperties raftProperties = new RaftProperties();
+    RaftProperties raftProperties = newRaftProperties();
     RaftConfigKeys.Rpc.setType(raftProperties, SupportedRpcType.GRPC);
     GrpcConfigKeys.setMessageSizeMax(raftProperties,
         SizeInBytes.valueOf(raftSegmentPreallocatedSize));

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Read.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Read.java
@@ -24,6 +24,7 @@ import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.client.RaftClientConfigKeys;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.datastream.SupportedDataStreamType;
+import org.apache.ratis.examples.common.ExampleLauncher;
 import org.apache.ratis.examples.common.SubCommandBase;
 import org.apache.ratis.examples.filestore.FileStoreClient;
 import org.apache.ratis.grpc.GrpcConfigKeys;
@@ -124,9 +125,10 @@ public class Read extends SubCommandBase {
     }
   }
 
-  private static RaftProperties newRaftProperties() {
+  @Override
+  protected RaftProperties newRaftProperties() {
     final int raftSegmentPreallocatedSize = 1024 * 1024 * 1024;
-    final RaftProperties raftProperties = new RaftProperties();
+    final RaftProperties raftProperties = ExampleLauncher.newRaftProperties();
     RaftConfigKeys.Rpc.setType(raftProperties, SupportedRpcType.GRPC);
     GrpcConfigKeys.setMessageSizeMax(raftProperties, SizeInBytes.valueOf(raftSegmentPreallocatedSize));
     RaftServerConfigKeys.Log.Appender.setBufferByteLimit(raftProperties,

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
@@ -77,7 +77,7 @@ public class Server extends SubCommandBase {
     JvmMetrics.initJvmMetrics(TimeDuration.valueOf(10, TimeUnit.SECONDS));
 
     RaftPeerId peerId = RaftPeerId.valueOf(id);
-    RaftProperties properties = new RaftProperties();
+    RaftProperties properties = newRaftProperties();
 
     // Avoid leader change affect the performance
     RaftServerConfigKeys.Rpc.setTimeoutMin(properties, TimeDuration.valueOf(2, TimeUnit.SECONDS));

--- a/ratis-trace-otel/pom.xml
+++ b/ratis-trace-otel/pom.xml
@@ -51,7 +51,11 @@
       <version>${opentelemetry.version}</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>io.opentelemetry.javaagent</groupId>
+      <artifactId>opentelemetry-javaagent</artifactId>
+      <version>${opentelemetry-javaagent.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>

--- a/ratis-trace-otel/src/main/java/org/apache/ratis/trace/otel/OTelTraceProvider.java
+++ b/ratis-trace-otel/src/main/java/org/apache/ratis/trace/otel/OTelTraceProvider.java
@@ -61,6 +61,11 @@ public final class OTelTraceProvider implements TraceProvider {
       "tracer == null");
 
   @Override
+  public SpanContextProto injectContextToProto() {
+    return OTelTraceUtils.injectContextToProto();
+  }
+
+  @Override
   public <T, THROWABLE extends Throwable> CompletableFuture<T> traceClientSend(
       CheckedSupplier<CompletableFuture<T>, THROWABLE> action,
       RaftClientRequest.Type type, RaftPeerId server) throws THROWABLE {

--- a/ratis-trace-otel/src/main/java/org/apache/ratis/trace/otel/OTelTraceUtils.java
+++ b/ratis-trace-otel/src/main/java/org/apache/ratis/trace/otel/OTelTraceUtils.java
@@ -32,6 +32,10 @@ public final class OTelTraceUtils {
   private OTelTraceUtils() {
   }
 
+  public static SpanContextProto injectContextToProto() {
+    return injectContextToProto(Context.current());
+  }
+
   public static SpanContextProto injectContextToProto(Context context) {
     final Map<String, String> carrier = new TreeMap<>();
     getTextMapPropagator().inject(context, carrier, (map, key, value) -> map.put(key, value));


### PR DESCRIPTION
also fixed a bug that client need to issue the parent span in the client request

## What changes were proposed in this pull request?

- make an example of how to use tracing in ratis-examples
- make sure the script could be automatically running and span shows in the logs and Jaegar UI
- fix the parent span issued from the client.

## What is the link to the Apache JIRA

[RATIS-2389](https://issues.apache.org/jira/browse/RATIS-2389)

## How was this patch tested?
manual tests for running the https://github.com/apache/ratis/tree/master/ratis-examples locally, tested with below

1. logger mode that emits span in logs

```
# on the server 
[otel.javaagent 2026-04-15 15:40:24:419 -0700] [pool-3-thread-1] INFO io.opentelemetry.exporter.logging.LoggingSpanExporter - 'raft.server.submitClientRequestAsync' : 2a9bfd5258de404d4c8dcd291408538f 98677058d4b31a8e SERVER [tracer: org.apache.ratis:3.3.0-SNAPSHOT] AttributesMap{data={thread.id=69, thread.name=n0-client-thread1, raft.member.id=n0@group-6F7570313233, raft.call.id=51198, raft.client.id=client-5813AB26C91D}, capacity=128, totalAddedValues=5}
[otel.javaagent 2026-04-15 15:40:24:419 -0700] [pool-3-thread-2] INFO io.opentelemetry.exporter.logging.LoggingSpanExporter - 'raft.server.submitClientRequestAsync' : f56c5fe25544695b023cfcdcd4f32447 57fd34b224ee3d6a SERVER [tracer: org.apache.ratis:3.3.0-SNAPSHOT] AttributesMap{data={thread.id=69, thread.name=n0-client-thread1, raft.member.id=n0@group-6F7570313233, raft.call.id=51196, raft.client.id=client-5813AB26C91D}, capacity=128, totalAddedValues=5}

# from the client 
[otel.javaagent 2026-04-15 15:40:24:420 -0700] [grpc-default-executor-7] INFO io.opentelemetry.exporter.logging.LoggingSpanExporter - 'Async::send' : 3326eebb2357274628d3dea57e586435 2715719eb0c38ec3 CLIENT [tracer: org.apache.ratis:3.3.0-SNAPSHOT] AttributesMap{data={thread.id=37, raft.peer.id=LEADER, thread.name=pool-1-thread-20, raft.operation.type=RW, raft.operation.name=Async::send}, capacity=128, totalAddedValues=5}
```

2. export traces to the third party otlp e.g. Jaegar 

<img width="1869" height="780" alt="Screenshot 2026-04-15 at 3 39 32 PM" src="https://github.com/user-attachments/assets/d746ff76-1153-4122-b588-8802c4f4ea79" />

