### PR TITLE
RATIS-2497. Implement dummy request as a noop request instead of watch request

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
@@ -144,6 +144,8 @@ public interface ClientProtoUtils {
         return RaftClientRequest.Type.valueOf(p.getDataStream());
       case FORWARD:
         return RaftClientRequest.Type.valueOf(p.getForward());
+      case NOOP:
+        return RaftClientRequest.Type.valueOf(p.getNoop());
       case MESSAGESTREAM:
         return RaftClientRequest.Type.valueOf(p.getMessageStream());
       case READ:
@@ -228,6 +230,9 @@ public interface ClientProtoUtils {
         break;
       case FORWARD:
         b.setForward(type.getForward());
+        break;
+      case NOOP:
+        b.setNoop(type.getNoop());
         break;
       case MESSAGESTREAM:
         b.setMessageStream(type.getMessageStream());

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
@@ -62,39 +62,6 @@ public final class OrderedAsync {
     SEND_REQUEST_EXCEPTION
   }
 
-  static final class DummyBootstrap {
-    private boolean noopSent = false;
-    private boolean watchFallbackPending = false;
-    private boolean watchFallbackSent = false;
-
-    RaftClientRequest.Type nextRequestType() {
-      if (!noopSent) {
-        noopSent = true;
-        return RaftClientRequest.noopRequestType();
-      }
-      if (watchFallbackPending && !watchFallbackSent) {
-        watchFallbackPending = false;
-        watchFallbackSent = true;
-        return RaftClientRequest.watchRequestType();
-      }
-      return null;
-    }
-
-    boolean handleFailure(Throwable throwable) {
-      if (!noopSent || watchFallbackSent) {
-        return false;
-      }
-      final Throwable e = JavaUtils.unwrapCompletionException(throwable);
-      if (e instanceof IllegalArgumentException
-          && e.getMessage() != null
-          && e.getMessage().contains("Unexpected request type")) {
-        watchFallbackPending = true;
-        return true;
-      }
-      return false;
-    }
-  }
-
   static class PendingOrderedRequest extends PendingClientRequest
       implements SlidingWindow.ClientSideRequest<RaftClientReply> {
     private final long callId;
@@ -146,6 +113,44 @@ public final class OrderedAsync {
     @Override
     public String toString() {
       return "[cid=" + callId + ", seq=" + getSeqNum() + "]";
+    }
+  }
+
+  static final class DummyBootstrap {
+    private boolean noopSent = false;
+    private boolean watchFallbackPending = false;
+    private boolean watchFallbackSent = false;
+
+    RaftClientRequest.Type nextRequestType() {
+      if (!noopSent) {
+        noopSent = true;
+        return RaftClientRequest.noopRequestType();
+      }
+      // If the server-side does not support the noop request
+      // fallback to the previous dummy request implementation (send WATCH(0))
+      // to preserve the original behavior and performance.
+      // However, this might causes client to immediately failover to the leader
+      // which causes follower read to not work. 
+      if (watchFallbackPending && !watchFallbackSent) {
+        watchFallbackPending = false;
+        watchFallbackSent = true;
+        return RaftClientRequest.watchRequestType();
+      }
+      return null;
+    }
+
+    boolean handleFailure(Throwable throwable) {
+      if (!noopSent || watchFallbackSent) {
+        return false;
+      }
+      final Throwable e = JavaUtils.unwrapCompletionException(throwable);
+      if (e instanceof IllegalArgumentException
+          && e.getMessage() != null
+          && e.getMessage().contains("Unexpected request type")) {
+        watchFallbackPending = true;
+        return true;
+      }
+      return false;
     }
   }
 

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
@@ -130,7 +130,7 @@ public final class OrderedAsync {
       // fallback to the previous dummy request implementation (send WATCH(0))
       // to preserve the original behavior and performance.
       // However, this might causes client to immediately failover to the leader
-      // which causes follower read to not work. 
+      // which causes follower read to not work.
       if (watchFallbackPending && !watchFallbackSent) {
         watchFallbackPending = false;
         watchFallbackSent = true;

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
@@ -62,6 +62,39 @@ public final class OrderedAsync {
     SEND_REQUEST_EXCEPTION
   }
 
+  static final class DummyBootstrap {
+    private boolean noopSent = false;
+    private boolean watchFallbackPending = false;
+    private boolean watchFallbackSent = false;
+
+    RaftClientRequest.Type nextRequestType() {
+      if (!noopSent) {
+        noopSent = true;
+        return RaftClientRequest.noopRequestType();
+      }
+      if (watchFallbackPending && !watchFallbackSent) {
+        watchFallbackPending = false;
+        watchFallbackSent = true;
+        return RaftClientRequest.watchRequestType();
+      }
+      return null;
+    }
+
+    boolean handleFailure(Throwable throwable) {
+      if (!noopSent || watchFallbackSent) {
+        return false;
+      }
+      final Throwable e = JavaUtils.unwrapCompletionException(throwable);
+      if (e instanceof IllegalArgumentException
+          && e.getMessage() != null
+          && e.getMessage().contains("Unexpected request type")) {
+        watchFallbackPending = true;
+        return true;
+      }
+      return false;
+    }
+  }
+
   static class PendingOrderedRequest extends PendingClientRequest
       implements SlidingWindow.ClientSideRequest<RaftClientReply> {
     private final long callId;
@@ -118,10 +151,10 @@ public final class OrderedAsync {
 
   static OrderedAsync newInstance(RaftClientImpl client, RaftProperties properties) {
     final OrderedAsync ordered = new OrderedAsync(client, properties);
-    // send a dummy watch request to establish the connection
+    // send a dummy request to establish the connection
     // TODO: this is a work around, it is better to fix the underlying RPC implementation
     if (RaftClientConfigKeys.Async.Experimental.sendDummyRequest(properties)) {
-      ordered.send(RaftClientRequest.watchRequestType(), null, null);
+      ordered.sendDummyRequest(new DummyBootstrap());
     }
     return ordered;
   }
@@ -154,8 +187,25 @@ public final class OrderedAsync {
     getSlidingWindow(request).fail(request.getSlidingWindowEntry().getSeqNum(), t);
   }
 
+  private void sendDummyRequest(DummyBootstrap bootstrap) {
+    final RaftClientRequest.Type type = bootstrap.nextRequestType();
+    if (type == null) {
+      return;
+    }
+
+    send(type, null, null).whenComplete((reply, throwable) -> {
+      if (throwable == null || !bootstrap.handleFailure(throwable)) {
+        return;
+      }
+
+      final Throwable unwrapped = JavaUtils.unwrapCompletionException(throwable);
+      client.getClientRpc().handleException(client.getLeaderId(), unwrapped, true);
+      sendDummyRequest(bootstrap);
+    });
+  }
+
   CompletableFuture<RaftClientReply> send(RaftClientRequest.Type type, Message message, RaftPeerId server) {
-    if (!type.is(TypeCase.WATCH) && !type.is(TypeCase.MESSAGESTREAM)) {
+    if (!type.is(TypeCase.WATCH) && !type.is(TypeCase.MESSAGESTREAM) && !type.is(TypeCase.NOOP)) {
       Objects.requireNonNull(message, "message == null");
     }
     try {

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientRequest.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientRequest.java
@@ -20,6 +20,7 @@ package org.apache.ratis.protocol;
 import org.apache.ratis.proto.RaftProtos.DataStreamRequestTypeProto;
 import org.apache.ratis.proto.RaftProtos.ForwardRequestTypeProto;
 import org.apache.ratis.proto.RaftProtos.MessageStreamRequestTypeProto;
+import org.apache.ratis.proto.RaftProtos.NoopRequestTypeProto;
 import org.apache.ratis.proto.RaftProtos.RaftClientRequestProto.TypeCase;
 import org.apache.ratis.proto.RaftProtos.ReadRequestTypeProto;
 import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
@@ -43,6 +44,7 @@ import java.util.Optional;
 public class RaftClientRequest extends RaftClientMessage {
   private static final Type DATA_STREAM_DEFAULT = new Type(DataStreamRequestTypeProto.getDefaultInstance());
   private static final Type FORWARD_DEFAULT = new Type(ForwardRequestTypeProto.getDefaultInstance());
+  private static final Type NOOP_DEFAULT = new Type(NoopRequestTypeProto.getDefaultInstance());
   private static final Type WATCH_DEFAULT = new Type(
       WatchRequestTypeProto.newBuilder().setIndex(0L).setReplication(ReplicationLevel.MAJORITY).build());
 
@@ -81,6 +83,10 @@ public class RaftClientRequest extends RaftClientMessage {
 
   public static Type forwardRequestType() {
     return FORWARD_DEFAULT;
+  }
+
+  public static Type noopRequestType() {
+    return NOOP_DEFAULT;
   }
 
   public static Type messageStreamRequestType(long streamId, long messageId, boolean endOfRequest) {
@@ -129,6 +135,10 @@ public class RaftClientRequest extends RaftClientMessage {
       return FORWARD_DEFAULT;
     }
 
+    public static Type valueOf(NoopRequestTypeProto noop) {
+      return NOOP_DEFAULT;
+    }
+
     public static Type valueOf(ReadRequestTypeProto read) {
       return read.getPreferNonLinearizable()? READ_NONLINEARIZABLE_DEFAULT
           : read.getReadAfterWriteConsistent()? READ_AFTER_WRITE_CONSISTENT_DEFAULT
@@ -173,6 +183,10 @@ public class RaftClientRequest extends RaftClientMessage {
       this(TypeCase.FORWARD, forward);
     }
 
+    private Type(NoopRequestTypeProto noop) {
+      this(TypeCase.NOOP, noop);
+    }
+
     private Type(MessageStreamRequestTypeProto messageStream) {
       this(TypeCase.MESSAGESTREAM, messageStream);
     }
@@ -198,6 +212,7 @@ public class RaftClientRequest extends RaftClientMessage {
         case READ:
         case STALEREAD:
         case WATCH:
+        case NOOP:
           return true;
         case WRITE:
         case MESSAGESTREAM:
@@ -237,6 +252,11 @@ public class RaftClientRequest extends RaftClientMessage {
       return (MessageStreamRequestTypeProto)proto;
     }
 
+    public NoopRequestTypeProto getNoop() {
+      assertType(TypeCase.NOOP);
+      return (NoopRequestTypeProto) proto;
+    }
+
     public ReadRequestTypeProto getRead() {
       assertType(TypeCase.READ);
       return (ReadRequestTypeProto)proto;
@@ -273,6 +293,8 @@ public class RaftClientRequest extends RaftClientMessage {
           return "DataStream";
         case FORWARD:
           return "Forward";
+        case NOOP:
+          return "Noop";
         case MESSAGESTREAM:
           return toString(getMessageStream());
         case READ:

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -299,6 +299,9 @@ message DataStreamRequestTypeProto {
 message ForwardRequestTypeProto {
 }
 
+message NoopRequestTypeProto {
+}
+
 message ReadRequestTypeProto {
   bool preferNonLinearizable = 1;
   bool readAfterWriteConsistent = 2;
@@ -335,6 +338,7 @@ message RaftClientRequestProto {
     MessageStreamRequestTypeProto messageStream = 7;
     DataStreamRequestTypeProto dataStream = 8;
     ForwardRequestTypeProto forward = 9;
+    NoopRequestTypeProto noop = 10;
   }
 }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1005,6 +1005,8 @@ class RaftServerImpl implements RaftServer.Division,
     switch (type) {
       case STALEREAD:
         return staleReadAsync(request);
+      case NOOP:
+        return CompletableFuture.completedFuture(newSuccessReply(request));
       case READ:
         return readAsync(request);
       case WATCH:

--- a/ratis-server/src/test/java/org/apache/ratis/LinearizableReadTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/LinearizableReadTests.java
@@ -88,10 +88,8 @@ public abstract class LinearizableReadTests<CLUSTER extends MiniRaftCluster>
     RaftServerConfigKeys.Read.setOption(p, LINEARIZABLE);
     RaftServerConfigKeys.Read.setLeaderLeaseEnabled(p, isLeaderLeaseEnabled());
     RaftServerConfigKeys.Read.ReadIndex.setType(p, readIndexType());
-    // Disable dummy request since currently the request is implemented as a watch request
-    // which can cause follower client to trigger failover to leader which will cause the
-    // all reads to be sent to the leader, making the follower read moot.
-    RaftClientConfigKeys.Async.Experimental.setSendDummyRequest(p, false);
+    // Enable dummy request so linearizable-read tests exercise the default ordered-async bootstrap path.
+    RaftClientConfigKeys.Async.Experimental.setSendDummyRequest(p, true);
   }
 
   @Test

--- a/ratis-test/src/test/java/org/apache/ratis/client/TestClientProtoUtils.java
+++ b/ratis-test/src/test/java/org/apache/ratis/client/TestClientProtoUtils.java
@@ -22,6 +22,7 @@ import org.apache.ratis.BaseTest;
 import org.apache.ratis.client.impl.ClientProtoUtils;
 import org.apache.ratis.proto.RaftProtos.RaftClientRequestProto;
 import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -98,5 +99,24 @@ public class TestClientProtoUtils extends BaseTest {
       }
       return out.toByteString();
     }
+  }
+
+  @Test
+  public void testNoopTypeRoundTripAndStringForm() {
+    final RaftClientRequest request = RaftClientRequest.newBuilder()
+        .setClientId(ClientId.randomId())
+        .setServerId(RaftPeerId.valueOf("s0"))
+        .setGroupId(RaftGroupId.randomId())
+        .setCallId(1L)
+        .setMessage(Message.EMPTY)
+        .setType(RaftClientRequest.noopRequestType())
+        .build();
+
+    final RaftClientRequestProto proto = ClientProtoUtils.toRaftClientRequestProto(request);
+    Assertions.assertEquals(RaftClientRequestProto.TypeCase.NOOP, proto.getTypeCase());
+    Assertions.assertEquals("Noop", request.getType().toString());
+    Assertions.assertTrue(request.getType().isReadOnly());
+    Assertions.assertEquals(RaftClientRequest.noopRequestType(),
+        ClientProtoUtils.toRaftClientRequestType(proto));
   }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/client/impl/TestOrderedAsyncDummyBootstrap.java
+++ b/ratis-test/src/test/java/org/apache/ratis/client/impl/TestOrderedAsyncDummyBootstrap.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.client.impl;
+
+import org.apache.ratis.BaseTest;
+import org.apache.ratis.protocol.RaftClientRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+class TestOrderedAsyncDummyBootstrap extends BaseTest {
+  @Test
+  void testBootstrapStartsWithNoopAndFallsBackToWatchOnce() {
+    final OrderedAsync.DummyBootstrap bootstrap = new OrderedAsync.DummyBootstrap();
+    Assertions.assertEquals(RaftClientRequest.noopRequestType(), bootstrap.nextRequestType());
+    Assertions.assertTrue(bootstrap.handleFailure(new IllegalArgumentException("Unexpected request type: TYPE_NOT_SET")));
+    Assertions.assertEquals(RaftClientRequest.watchRequestType(), bootstrap.nextRequestType());
+    Assertions.assertNull(bootstrap.nextRequestType());
+  }
+
+  @Test
+  void testNonCompatibilityFailuresDoNotTriggerLegacyWatchFallback() {
+    final OrderedAsync.DummyBootstrap bootstrap = new OrderedAsync.DummyBootstrap();
+    Assertions.assertEquals(RaftClientRequest.noopRequestType(), bootstrap.nextRequestType());
+    Assertions.assertFalse(bootstrap.handleFailure(new IOException("connection reset")));
+    Assertions.assertNull(bootstrap.nextRequestType());
+  }
+}

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLinearizableReadWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLinearizableReadWithGrpc.java
@@ -18,7 +18,25 @@
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.LinearizableReadTests;
+import org.apache.ratis.RaftTestUtil;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.metrics.impl.DefaultTimekeeperImpl;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys.Read.ReadIndex.Type;
+import org.apache.ratis.util.JavaUtils;
+import org.apache.ratis.util.TimeDuration;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.apache.ratis.ReadOnlyRequestTests.INCREMENT;
+import static org.apache.ratis.ReadOnlyRequestTests.QUERY;
+import static org.apache.ratis.ReadOnlyRequestTests.assertReplyExact;
+import static org.apache.ratis.server.metrics.RaftServerMetricsImpl.RAFT_CLIENT_READ_REQUEST;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestLinearizableReadWithGrpc
   extends LinearizableReadTests<MiniRaftClusterWithGrpc>
@@ -32,5 +50,46 @@ public class TestLinearizableReadWithGrpc
   @Override
   public Type readIndexType() {
     return Type.COMMIT_INDEX;
+  }
+
+  @Test
+  public void testFollowerLinearizableReadStaysOnFollower() throws Exception {
+    runWithNewCluster(TestLinearizableReadWithGrpc::runTestFollowerLinearizableReadStaysOnFollower);
+  }
+
+  static void runTestFollowerLinearizableReadStaysOnFollower(MiniRaftClusterWithGrpc cluster) throws Exception {
+    final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster);
+    final List<RaftServer.Division> followers = cluster.getFollowers();
+    assertEquals(2, followers.size());
+    final RaftServer.Division follower = followers.get(0);
+    final RaftPeerId followerId = follower.getId();
+
+    final RatisMetricRegistry leaderRegistry = TestRaftServerWithGrpc.getRaftServerMetrics(leader).getRegistry();
+    final RatisMetricRegistry followerRegistry = TestRaftServerWithGrpc.getRaftServerMetrics(follower).getRegistry();
+    final DefaultTimekeeperImpl leaderReadTimer =
+        (DefaultTimekeeperImpl) leaderRegistry.timer(RAFT_CLIENT_READ_REQUEST);
+    final DefaultTimekeeperImpl followerReadTimer =
+        (DefaultTimekeeperImpl) followerRegistry.timer(RAFT_CLIENT_READ_REQUEST);
+
+    final long leaderReadCountBefore = leaderReadTimer.getTimer().getCount();
+    final long followerReadCountBefore = followerReadTimer.getTimer().getCount();
+    final int numReads = 5;
+
+    try (RaftClient client = cluster.createClient(leader.getId())) {
+      assertReplyExact(1, client.io().send(INCREMENT));
+
+      for (int i = 0; i < numReads; i++) {
+        assertReplyExact(1, client.async().sendReadOnly(QUERY, followerId).get());
+      }
+    }
+
+    JavaUtils.attempt(() -> {
+      final long leaderReadCountAfter = leaderReadTimer.getTimer().getCount();
+      final long followerReadCountAfter = followerReadTimer.getTimer().getCount();
+      assertEquals(leaderReadCountBefore, leaderReadCountAfter,
+          () -> "leader unexpectedly handled follower-directed reads");
+      assertTrue(followerReadCountAfter >= followerReadCountBefore + numReads,
+          () -> "follower did not record the follower-directed reads");
+    }, 3, TimeDuration.ONE_SECOND, "follower read metrics", null);
   }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/retry/TestRetryPolicy.java
+++ b/ratis-test/src/test/java/org/apache/ratis/retry/TestRetryPolicy.java
@@ -80,12 +80,14 @@ public class TestRetryPolicy extends BaseTest {
     final RetryPolicies.RetryLimited writePolicy = RetryPolicies.retryUpToMaximumCountWithFixedSleep(n, writeSleep);
     b.setRetryPolicy(RaftClientRequestProto.TypeCase.WRITE, writePolicy);
     b.setRetryPolicy(RaftClientRequestProto.TypeCase.WATCH, RetryPolicies.noRetry());
+    b.setRetryPolicy(RaftClientRequestProto.TypeCase.NOOP, RetryPolicies.noRetry());
     final RetryPolicy policy = b.build();
     LOG.info("policy = {}", policy);
 
     final RaftClientRequest staleReadRequest = newRaftClientRequest(RaftClientRequest.staleReadRequestType(1));
     final RaftClientRequest readRequest = newRaftClientRequest(RaftClientRequest.readRequestType());
     final RaftClientRequest writeRequest = newRaftClientRequest(RaftClientRequest.writeRequestType());
+    final RaftClientRequest noopRequest = newRaftClientRequest(RaftClientRequest.noopRequestType());
     final RaftClientRequest watchRequest = newRaftClientRequest(
         RaftClientRequest.watchRequestType(1, ReplicationLevel.MAJORITY));
     for(int i = 1; i < 2*n; i++) {
@@ -118,6 +120,13 @@ public class TestRetryPolicy extends BaseTest {
 
       { //watch has no retry
         final ClientRetryEvent event = newClientRetryEvent(i, watchRequest, null);
+        final RetryPolicy.Action action = policy.handleAttemptFailure(event);
+        Assertions.assertFalse(action.shouldRetry());
+        Assertions.assertEquals(0L, action.getSleepTime().getDuration());
+      }
+
+      { //noop has no retry
+        final ClientRetryEvent event = newClientRetryEvent(i, noopRequest, null);
         final RetryPolicy.Action action = policy.handleAttemptFailure(event);
         Assertions.assertFalse(action.shouldRetry());
         Assertions.assertEquals(0L, action.getSleepTime().getDuration());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the dummy request is a WATCH(0) which will trigger client leader failover. In a follower read client scenario, this might cause client to always failover to the leader which reduces the follower read effectiveness.

We can try implement a new noop request (some kind of ping request) which simply returns a successful response regardless of the Raft peer role.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2497

## How was this patch tested?

UT.