### PR TITLE
RATIS-2505. Improve RATIS-2387 with direct synchronous append when compose disabled

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1680,14 +1680,9 @@ class RaftServerImpl implements RaftServer.Division,
       state.updateConfiguration(entries);
     }
     future.join();
-    final CompletableFuture<Void> appendFuture;
-    if (entries.isEmpty()) {
-      appendFuture = CompletableFuture.completedFuture(null);
-    } else if (appendLogTermIndices != null) {
-      appendFuture = appendLogTermIndices.append(entries, this::appendLog);
-    } else {
-      appendFuture = JavaUtils.allOf(state.getLog().append(entries));
-    }
+    final CompletableFuture<Void> appendFuture = entries.isEmpty()? CompletableFuture.completedFuture(null)
+        : appendLogTermIndices != null ? appendLogTermIndices.append(entries, this::appendLog)
+        : JavaUtils.allOf(state.getLog().append(entries));
 
     proto.getCommitInfosList().forEach(commitInfoCache::update);
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1680,9 +1680,14 @@ class RaftServerImpl implements RaftServer.Division,
       state.updateConfiguration(entries);
     }
     future.join();
-    final CompletableFuture<Void> appendFuture = entries.isEmpty()? CompletableFuture.completedFuture(null)
-        : appendLogTermIndices != null ? appendLogTermIndices.append(entries, this::appendLog)
-        : appendLog(entries);
+    final CompletableFuture<Void> appendFuture;
+    if (entries.isEmpty()) {
+      appendFuture = CompletableFuture.completedFuture(null);
+    } else if (appendLogTermIndices != null) {
+      appendFuture = appendLogTermIndices.append(entries, this::appendLog);
+    } else {
+      appendFuture = JavaUtils.allOf(state.getLog().append(entries));
+    }
 
     proto.getCommitInfosList().forEach(commitInfoCache::update);
 
@@ -1714,6 +1719,7 @@ class RaftServerImpl implements RaftServer.Division,
       return reply;
     });
   }
+
   private CompletableFuture<Void> appendLog(List<LogEntryProto> entries) {
     return CompletableFuture.completedFuture(null)
         .thenComposeAsync(dummy -> JavaUtils.allOf(state.getLog().append(entries)), serverExecutor);


### PR DESCRIPTION
## What changes were proposed in this pull request?
When appendEntriesComposeEnabled is disabled (set to false), the code now bypasses the appendLog() method entirely and invokes the append operation directly on the current thread. This change eliminates the unnecessary async hop that remained in RATIS-2387. Instead of creating a completed future and then using thenComposeAsync() to schedule the append on the executor, the append now happens immediately on the calling thread.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2505

## How was this patch tested?

Ozone cluster deployment with high volume write load.