### PR TITLE
RATIS-2511. Follower should throw ReadException if it is installing snapshot

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1092,8 +1092,11 @@ class RaftServerImpl implements RaftServer.Division,
     }
     return processQueryFuture(stateMachine.queryStale(request.getMessage(), minIndex), request);
   }
-
   private CompletableFuture<ReadIndexReplyProto> sendReadIndexAsync(RaftClientRequest clientRequest) {
+    final Throwable snapshotInstallation = snapshotInstallationHandler.getInProgressInstallSnapshotReadException();
+    if (snapshotInstallation != null) {
+      return JavaUtils.completeExceptionally(snapshotInstallation);
+    }
     final RaftPeerId leaderId = getInfo().getLeaderId();
     if (leaderId == null) {
       return JavaUtils.completeExceptionally(new ReadIndexException(getMemberId() + ": Leader is unknown."));

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1093,10 +1093,6 @@ class RaftServerImpl implements RaftServer.Division,
     return processQueryFuture(stateMachine.queryStale(request.getMessage(), minIndex), request);
   }
 
-  ReadRequests getReadRequests() {
-    return getState().getReadRequests();
-  }
-
   private CompletableFuture<ReadIndexReplyProto> sendReadIndexAsync(RaftClientRequest clientRequest) {
     final RaftPeerId leaderId = getInfo().getLeaderId();
     if (leaderId == null) {
@@ -1146,7 +1142,8 @@ class RaftServerImpl implements RaftServer.Division,
       }
 
       return replyFuture
-          .thenCompose(readIndex -> getReadRequests().waitToAdvance(readIndex))
+          .thenCompose(readIndex -> getState().getReadRequests().waitToAdvance(readIndex,
+              snapshotInstallationHandler::getInProgressInstallSnapshotReadException))
           .thenCompose(readIndex -> queryStateMachine(request))
           .exceptionally(e -> readException2Reply(request, e));
     } else {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1092,10 +1092,14 @@ class RaftServerImpl implements RaftServer.Division,
     }
     return processQueryFuture(stateMachine.queryStale(request.getMessage(), minIndex), request);
   }
+  ReadException newReadException(String op, long installSnapshot, boolean started) {
+    return new ReadException(getMemberId() + ": Failed to " + op + " readIndex as snapshot (" + installSnapshot
+        + ") installation is " + (started ? "started" : "in progress"));
+  }
   private CompletableFuture<ReadIndexReplyProto> sendReadIndexAsync(RaftClientRequest clientRequest) {
-    final Throwable snapshotInstallation = snapshotInstallationHandler.getInProgressInstallSnapshotReadException();
-    if (snapshotInstallation != null) {
-      return JavaUtils.completeExceptionally(snapshotInstallation);
+    final long installSnapshot = snapshotInstallationHandler.getInProgressInstallSnapshotIndex();
+    if (installSnapshot != RaftLog.INVALID_LOG_INDEX) {
+      return JavaUtils.completeExceptionally(newReadException("get", installSnapshot, false));
     }
     final RaftPeerId leaderId = getInfo().getLeaderId();
     if (leaderId == null) {
@@ -1108,11 +1112,9 @@ class RaftServerImpl implements RaftServer.Division,
       return JavaUtils.completeExceptionally(e);
     }
   }
-
   private CompletableFuture<Long> getReadIndex(RaftClientRequest request, LeaderStateImpl leader) {
     return writeIndexCache.getWriteIndexFuture(request).thenCompose(leader::getReadIndex);
   }
-
   private CompletableFuture<RaftClientReply> readAsync(RaftClientRequest request) {
     if (request.getType().getRead().getPreferNonLinearizable()
         || readOption == RaftServerConfigKeys.Read.Option.DEFAULT) {
@@ -1122,12 +1124,6 @@ class RaftServerImpl implements RaftServer.Division,
        }
        return queryStateMachine(request);
     } else if (readOption == RaftServerConfigKeys.Read.Option.LINEARIZABLE){
-      /*
-        Linearizable read using ReadIndex. See Raft paper section 6.4.
-        1. First obtain readIndex from Leader.
-        2. Then waits for statemachine to advance at least as far as readIndex.
-        3. Finally, query the statemachine and return the result.
-       */
       final LeaderStateImpl leader = role.getLeaderState().orElse(null);
 
       final CompletableFuture<Long> replyFuture;
@@ -1145,15 +1141,19 @@ class RaftServerImpl implements RaftServer.Division,
       }
 
       return replyFuture
-          .thenCompose(readIndex -> getState().getReadRequests().waitToAdvance(readIndex,
-              snapshotInstallationHandler::getInProgressInstallSnapshotReadException))
+          .thenCompose(this::waitReadIndex)
           .thenCompose(readIndex -> queryStateMachine(request))
           .exceptionally(e -> readException2Reply(request, e));
     } else {
       throw new IllegalStateException("Unexpected read option: " + readOption);
     }
   }
-
+  private CompletableFuture<Long> waitReadIndex(long readIndex) {
+    final long installSnapshot = snapshotInstallationHandler.getInProgressInstallSnapshotIndex();
+    return installSnapshot != RaftLog.INVALID_LOG_INDEX
+        ? JavaUtils.completeExceptionally(newReadException("start waiting for", installSnapshot, false))
+        : getState().getReadRequests().waitToAdvance(readIndex);
+  }
   private RaftClientReply readException2Reply(RaftClientRequest request, Throwable e) {
     e = JavaUtils.unwrapCompletionException(e);
     if (e instanceof StateMachineException ) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1092,14 +1092,14 @@ class RaftServerImpl implements RaftServer.Division,
     }
     return processQueryFuture(stateMachine.queryStale(request.getMessage(), minIndex), request);
   }
-  ReadException newReadException(String op, long installSnapshot, boolean started) {
-    return new ReadException(getMemberId() + ": Failed to " + op + " readIndex as snapshot (" + installSnapshot
-        + ") installation is " + (started ? "started" : "in progress"));
+  ReadException getReadException(String op, long installSnapshot, boolean started) {
+    return installSnapshot == RaftLog.INVALID_LOG_INDEX ? null : new ReadException(getMemberId() + ": Failed to " + op
+        + " readIndex as snapshot (" + installSnapshot + ") installation is " + (started ? "started" : "in progress"));
   }
   private CompletableFuture<ReadIndexReplyProto> sendReadIndexAsync(RaftClientRequest clientRequest) {
     final long installSnapshot = snapshotInstallationHandler.getInProgressInstallSnapshotIndex();
     if (installSnapshot != RaftLog.INVALID_LOG_INDEX) {
-      return JavaUtils.completeExceptionally(newReadException("get", installSnapshot, false));
+      return JavaUtils.completeExceptionally(getReadException("get", installSnapshot, false));
     }
     final RaftPeerId leaderId = getInfo().getLeaderId();
     if (leaderId == null) {
@@ -1125,7 +1125,6 @@ class RaftServerImpl implements RaftServer.Division,
        return queryStateMachine(request);
     } else if (readOption == RaftServerConfigKeys.Read.Option.LINEARIZABLE){
       final LeaderStateImpl leader = role.getLeaderState().orElse(null);
-
       final CompletableFuture<Long> replyFuture;
       if (leader != null) {
         replyFuture = getReadIndex(request, leader);
@@ -1141,18 +1140,13 @@ class RaftServerImpl implements RaftServer.Division,
       }
 
       return replyFuture
-          .thenCompose(this::waitReadIndex)
+          .thenCompose(readIndex -> getState().getReadRequests().waitToAdvance(readIndex,
+              () -> getReadException("add", snapshotInstallationHandler.getInProgressInstallSnapshotIndex(), false)))
           .thenCompose(readIndex -> queryStateMachine(request))
           .exceptionally(e -> readException2Reply(request, e));
     } else {
       throw new IllegalStateException("Unexpected read option: " + readOption);
     }
-  }
-  private CompletableFuture<Long> waitReadIndex(long readIndex) {
-    final long installSnapshot = snapshotInstallationHandler.getInProgressInstallSnapshotIndex();
-    return installSnapshot != RaftLog.INVALID_LOG_INDEX
-        ? JavaUtils.completeExceptionally(newReadException("start waiting for", installSnapshot, false))
-        : getState().getReadRequests().waitToAdvance(readIndex);
   }
   private RaftClientReply readException2Reply(RaftClientRequest request, Throwable e) {
     e = JavaUtils.unwrapCompletionException(e);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadRequests.java
@@ -20,12 +20,15 @@ package org.apache.ratis.server.impl;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.exceptions.ReadException;
 import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.TimeoutExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
@@ -34,6 +37,11 @@ import java.util.function.LongConsumer;
 /** For supporting linearizable read. */
 class ReadRequests {
   private static final Logger LOG = LoggerFactory.getLogger(ReadRequests.class);
+
+  static ReadException newException(Object server, long installSnapshot) {
+    return new ReadException(server + ": Failed read as snapshot (" + installSnapshot
+        + ") installation is in progress");
+  }
 
   static class ReadIndexQueue {
     private final TimeoutExecutor scheduler = TimeoutExecutor.getInstance();
@@ -46,6 +54,7 @@ class ReadRequests {
     private final NavigableMap<Long, CompletableFuture<Long>> sorted = new TreeMap<>();
 
     private final TimeDuration readTimeout;
+    private Throwable failure;
 
     ReadIndexQueue(long lastAppliedIndex, TimeDuration readTimeout) {
       this.lastAppliedIndex = lastAppliedIndex;
@@ -56,6 +65,9 @@ class ReadRequests {
       final CompletableFuture<Long> returned;
       final boolean create;
       synchronized (this) {
+        if (failure != null) {
+          return JavaUtils.completeExceptionally(failure);
+        }
         if (readIndex <= lastAppliedIndex) {
           return CompletableFuture.completedFuture(lastAppliedIndex);
         }
@@ -88,6 +100,23 @@ class ReadRequests {
       removed.completeExceptionally(new ReadException("Read timeout " + readTimeout + " for index " + readIndex));
     }
 
+    void fail(Throwable cause) {
+      final Collection<CompletableFuture<Long>> futures;
+      synchronized (this) {
+        futures = new ArrayList<>(sorted.values());
+        sorted.clear();
+      }
+      futures.forEach(f -> f.completeExceptionally(cause));
+    }
+
+    synchronized void clearFailure() {
+      failure = null;
+    }
+
+    synchronized void failAndBlock(Throwable cause) {
+      failure = cause;
+      fail(cause);
+    }
 
     /** Complete all the entries less than or equal to the given applied index. */
     synchronized void complete(long appliedIndex) {
@@ -121,5 +150,17 @@ class ReadRequests {
 
   CompletableFuture<Long> waitToAdvance(long readIndex) {
     return readIndexQueue.add(readIndex);
+  }
+
+  void fail(Throwable cause) {
+    readIndexQueue.fail(cause);
+  }
+
+  void failAndBlock(Throwable cause) {
+    readIndexQueue.failAndBlock(cause);
+  }
+
+  void clearFailure() {
+    readIndexQueue.clearFailure();
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadRequests.java
@@ -33,6 +33,7 @@ import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.LongConsumer;
+import java.util.function.Supplier;
 
 /** For supporting linearizable read. */
 class ReadRequests {
@@ -54,17 +55,17 @@ class ReadRequests {
     private final NavigableMap<Long, CompletableFuture<Long>> sorted = new TreeMap<>();
 
     private final TimeDuration readTimeout;
-    private Throwable failure;
 
     ReadIndexQueue(long lastAppliedIndex, TimeDuration readTimeout) {
       this.lastAppliedIndex = lastAppliedIndex;
       this.readTimeout = readTimeout;
     }
 
-    CompletableFuture<Long> add(long readIndex) {
+    CompletableFuture<Long> add(long readIndex, Supplier<Throwable> failureSupplier) {
       final CompletableFuture<Long> returned;
       final boolean create;
       synchronized (this) {
+        final Throwable failure = failureSupplier.get();
         if (failure != null) {
           return JavaUtils.completeExceptionally(failure);
         }
@@ -109,15 +110,6 @@ class ReadRequests {
       futures.forEach(f -> f.completeExceptionally(cause));
     }
 
-    synchronized void clearFailure() {
-      failure = null;
-    }
-
-    synchronized void failAndBlock(Throwable cause) {
-      failure = cause;
-      fail(cause);
-    }
-
     /** Complete all the entries less than or equal to the given applied index. */
     synchronized void complete(long appliedIndex) {
       if (appliedIndex > lastAppliedIndex) {
@@ -148,19 +140,11 @@ class ReadRequests {
     return readIndexQueue::complete;
   }
 
-  CompletableFuture<Long> waitToAdvance(long readIndex) {
-    return readIndexQueue.add(readIndex);
+  CompletableFuture<Long> waitToAdvance(long readIndex, Supplier<Throwable> failureSupplier) {
+    return readIndexQueue.add(readIndex, failureSupplier);
   }
 
   void fail(Throwable cause) {
     readIndexQueue.fail(cause);
-  }
-
-  void failAndBlock(Throwable cause) {
-    readIndexQueue.failAndBlock(cause);
-  }
-
-  void clearFailure() {
-    readIndexQueue.clearFailure();
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadRequests.java
@@ -20,29 +20,21 @@ package org.apache.ratis.server.impl;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.exceptions.ReadException;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.TimeoutExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.LongConsumer;
-import java.util.function.Supplier;
 
 /** For supporting linearizable read. */
 class ReadRequests {
   private static final Logger LOG = LoggerFactory.getLogger(ReadRequests.class);
-
-  static ReadException newException(Object server, long installSnapshot) {
-    return new ReadException(server + ": Failed read as snapshot (" + installSnapshot
-        + ") installation is in progress");
-  }
 
   static class ReadIndexQueue {
     private final TimeoutExecutor scheduler = TimeoutExecutor.getInstance();
@@ -52,7 +44,7 @@ class ReadRequests {
      * Map      : readIndex -> appliedIndexFuture (when completes, readIndex <= appliedIndex).
      * Invariant: all keys > lastAppliedIndex.
      */
-    private final NavigableMap<Long, CompletableFuture<Long>> sorted = new TreeMap<>();
+    private NavigableMap<Long, CompletableFuture<Long>> sorted = new TreeMap<>();
 
     private final TimeDuration readTimeout;
 
@@ -61,14 +53,10 @@ class ReadRequests {
       this.readTimeout = readTimeout;
     }
 
-    CompletableFuture<Long> add(long readIndex, Supplier<Throwable> failureSupplier) {
+    CompletableFuture<Long> add(long readIndex) {
       final CompletableFuture<Long> returned;
       final boolean create;
       synchronized (this) {
-        final Throwable failure = failureSupplier.get();
-        if (failure != null) {
-          return JavaUtils.completeExceptionally(failure);
-        }
         if (readIndex <= lastAppliedIndex) {
           return CompletableFuture.completedFuture(lastAppliedIndex);
         }
@@ -101,13 +89,10 @@ class ReadRequests {
       removed.completeExceptionally(new ReadException("Read timeout " + readTimeout + " for index " + readIndex));
     }
 
-    void fail(Throwable cause) {
-      final Collection<CompletableFuture<Long>> futures;
-      synchronized (this) {
-        futures = new ArrayList<>(sorted.values());
-        sorted.clear();
-      }
-      futures.forEach(f -> f.completeExceptionally(cause));
+    synchronized Collection<CompletableFuture<Long>> clear() {
+      final Collection<CompletableFuture<Long>> futures = sorted.values();
+      sorted = new TreeMap<>();
+      return futures;
     }
 
     /** Complete all the entries less than or equal to the given applied index. */
@@ -140,11 +125,13 @@ class ReadRequests {
     return readIndexQueue::complete;
   }
 
-  CompletableFuture<Long> waitToAdvance(long readIndex, Supplier<Throwable> failureSupplier) {
-    return readIndexQueue.add(readIndex, failureSupplier);
+  CompletableFuture<Long> waitToAdvance(long readIndex) {
+    return readIndexQueue.add(readIndex);
   }
 
   void fail(Throwable cause) {
-    readIndexQueue.fail(cause);
+    for (CompletableFuture<Long> f : readIndexQueue.clear()) {
+      f.completeExceptionally(cause);
+    }
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ReadRequests.java
@@ -20,6 +20,7 @@ package org.apache.ratis.server.impl;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.exceptions.ReadException;
 import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.TimeoutExecutor;
@@ -31,6 +32,7 @@ import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.LongConsumer;
+import java.util.function.Supplier;
 
 /** For supporting linearizable read. */
 class ReadRequests {
@@ -53,10 +55,14 @@ class ReadRequests {
       this.readTimeout = readTimeout;
     }
 
-    CompletableFuture<Long> add(long readIndex) {
+    CompletableFuture<Long> add(long readIndex, Supplier<ReadException> checkReadException) {
       final CompletableFuture<Long> returned;
       final boolean create;
       synchronized (this) {
+        final ReadException exception = checkReadException.get();
+        if (exception != null) {
+          return JavaUtils.completeExceptionally(exception);
+        }
         if (readIndex <= lastAppliedIndex) {
           return CompletableFuture.completedFuture(lastAppliedIndex);
         }
@@ -125,8 +131,8 @@ class ReadRequests {
     return readIndexQueue::complete;
   }
 
-  CompletableFuture<Long> waitToAdvance(long readIndex) {
-    return readIndexQueue.add(readIndex);
+  CompletableFuture<Long> waitToAdvance(long readIndex, Supplier<ReadException> checkReadException) {
+    return readIndexQueue.add(readIndex, checkReadException);
   }
 
   void fail(Throwable cause) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -276,6 +276,7 @@ class SnapshotInstallationHandler {
               InstallSnapshotResult.ALREADY_INSTALLED, snapshotIndex);
           return future.thenApply(dummy -> reply);
         }
+        server.getReadRequests().failAndBlock(ReadRequests.newException(getMemberId(), firstAvailableLogIndex));
 
         final RaftPeerProto leaderProto;
         if (!request.hasLastRaftConfigurationLogEntryProto()) {
@@ -314,6 +315,7 @@ class SnapshotInstallationHandler {
                 LOG.error("{}: Failed to notify StateMachine to InstallSnapshot. Exception: {}",
                     getMemberId(), exception.getMessage());
                 inProgressInstallSnapshotIndex.compareAndSet(firstAvailableLogIndex, INVALID_LOG_INDEX);
+                server.getReadRequests().clearFailure();
                 return;
               }
 
@@ -349,6 +351,7 @@ class SnapshotInstallationHandler {
         LOG.info("{}: InstallSnapshot notification result: {}", getMemberId(),
             InstallSnapshotResult.SNAPSHOT_UNAVAILABLE);
         inProgressInstallSnapshotIndex.set(INVALID_LOG_INDEX);
+        server.getReadRequests().clearFailure();
         server.getStateMachine().event().notifySnapshotInstalled(
             InstallSnapshotResult.SNAPSHOT_UNAVAILABLE, INVALID_LOG_INDEX, server.getPeer());
         final InstallSnapshotReplyProto reply =  toInstallSnapshotReplyProto(leaderId, getMemberId(),
@@ -366,6 +369,7 @@ class SnapshotInstallationHandler {
         LOG.info("{}: InstallSnapshot notification result: {}, at index: {}", getMemberId(),
             InstallSnapshotResult.SNAPSHOT_INSTALLED, latestInstalledSnapshotTermIndex);
         inProgressInstallSnapshotIndex.set(INVALID_LOG_INDEX);
+        server.getReadRequests().clearFailure();
         final long latestInstalledIndex = latestInstalledSnapshotTermIndex.getIndex();
         server.getStateMachine().event().notifySnapshotInstalled(
             InstallSnapshotResult.SNAPSHOT_INSTALLED, latestInstalledIndex, server.getPeer());

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -99,6 +99,11 @@ class SnapshotInstallationHandler {
     return inProgressInstallSnapshotIndex.get();
   }
 
+  Throwable getInProgressInstallSnapshotReadException() {
+    final long installSnapshot = getInProgressInstallSnapshotIndex();
+    return installSnapshot != INVALID_LOG_INDEX ? ReadRequests.newException(getMemberId(), installSnapshot) : null;
+  }
+
   InstallSnapshotReplyProto installSnapshot(InstallSnapshotRequestProto request) throws IOException {
     BatchLogger.print(BatchLogKey.INSTALL_SNAPSHOT_REQUEST, getMemberId(),
         suffix -> LOG.info("{}: receive installSnapshot: {} {}",
@@ -276,7 +281,7 @@ class SnapshotInstallationHandler {
               InstallSnapshotResult.ALREADY_INSTALLED, snapshotIndex);
           return future.thenApply(dummy -> reply);
         }
-        server.getReadRequests().failAndBlock(ReadRequests.newException(getMemberId(), firstAvailableLogIndex));
+        server.getState().getReadRequests().fail(ReadRequests.newException(getMemberId(), firstAvailableLogIndex));
 
         final RaftPeerProto leaderProto;
         if (!request.hasLastRaftConfigurationLogEntryProto()) {
@@ -315,7 +320,6 @@ class SnapshotInstallationHandler {
                 LOG.error("{}: Failed to notify StateMachine to InstallSnapshot. Exception: {}",
                     getMemberId(), exception.getMessage());
                 inProgressInstallSnapshotIndex.compareAndSet(firstAvailableLogIndex, INVALID_LOG_INDEX);
-                server.getReadRequests().clearFailure();
                 return;
               }
 
@@ -351,7 +355,6 @@ class SnapshotInstallationHandler {
         LOG.info("{}: InstallSnapshot notification result: {}", getMemberId(),
             InstallSnapshotResult.SNAPSHOT_UNAVAILABLE);
         inProgressInstallSnapshotIndex.set(INVALID_LOG_INDEX);
-        server.getReadRequests().clearFailure();
         server.getStateMachine().event().notifySnapshotInstalled(
             InstallSnapshotResult.SNAPSHOT_UNAVAILABLE, INVALID_LOG_INDEX, server.getPeer());
         final InstallSnapshotReplyProto reply =  toInstallSnapshotReplyProto(leaderId, getMemberId(),
@@ -369,7 +372,6 @@ class SnapshotInstallationHandler {
         LOG.info("{}: InstallSnapshot notification result: {}, at index: {}", getMemberId(),
             InstallSnapshotResult.SNAPSHOT_INSTALLED, latestInstalledSnapshotTermIndex);
         inProgressInstallSnapshotIndex.set(INVALID_LOG_INDEX);
-        server.getReadRequests().clearFailure();
         final long latestInstalledIndex = latestInstalledSnapshotTermIndex.getIndex();
         server.getStateMachine().event().notifySnapshotInstalled(
             InstallSnapshotResult.SNAPSHOT_INSTALLED, latestInstalledIndex, server.getPeer());

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -276,7 +276,7 @@ class SnapshotInstallationHandler {
               InstallSnapshotResult.ALREADY_INSTALLED, snapshotIndex);
           return future.thenApply(dummy -> reply);
         }
-        server.getState().getReadRequests().fail(server.newReadException("wait for", firstAvailableLogIndex, true));
+        server.getState().getReadRequests().fail(server.getReadException("wait for", firstAvailableLogIndex, true));
 
         final RaftPeerProto leaderProto;
         if (!request.hasLastRaftConfigurationLogEntryProto()) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/SnapshotInstallationHandler.java
@@ -99,11 +99,6 @@ class SnapshotInstallationHandler {
     return inProgressInstallSnapshotIndex.get();
   }
 
-  Throwable getInProgressInstallSnapshotReadException() {
-    final long installSnapshot = getInProgressInstallSnapshotIndex();
-    return installSnapshot != INVALID_LOG_INDEX ? ReadRequests.newException(getMemberId(), installSnapshot) : null;
-  }
-
   InstallSnapshotReplyProto installSnapshot(InstallSnapshotRequestProto request) throws IOException {
     BatchLogger.print(BatchLogKey.INSTALL_SNAPSHOT_REQUEST, getMemberId(),
         suffix -> LOG.info("{}: receive installSnapshot: {} {}",
@@ -281,7 +276,7 @@ class SnapshotInstallationHandler {
               InstallSnapshotResult.ALREADY_INSTALLED, snapshotIndex);
           return future.thenApply(dummy -> reply);
         }
-        server.getState().getReadRequests().fail(ReadRequests.newException(getMemberId(), firstAvailableLogIndex));
+        server.getState().getReadRequests().fail(server.newReadException("wait for", firstAvailableLogIndex, true));
 
         final RaftPeerProto leaderProto;
         if (!request.hasLastRaftConfigurationLogEntryProto()) {

--- a/ratis-server/src/test/java/org/apache/ratis/LinearizableReadTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/LinearizableReadTests.java
@@ -170,6 +170,16 @@ public abstract class LinearizableReadTests<CLUSTER extends MiniRaftCluster>
   }
 
   @Test
+  public void testFollowerLinearizableReadFailsWhenInstallingSnapshot() throws Exception {
+    RaftServerConfigKeys.Read.setTimeout(getProperties(), TimeDuration.valueOf(200, TimeUnit.MILLISECONDS));
+    try {
+      runWithNewCluster(ReadOnlyRequestTests::runTestFollowerLinearizableReadFailsWhenInstallingSnapshot);
+    } finally {
+      RaftServerConfigKeys.Read.setTimeout(getProperties(), RaftServerConfigKeys.Read.TIMEOUT_DEFAULT);
+    }
+  }
+
+  @Test
   public void testFollowerLinearizableReadParallel() throws Exception {
     runWithNewCluster(LinearizableReadTests::runTestFollowerReadOnlyParallel);
   }

--- a/ratis-server/src/test/java/org/apache/ratis/LinearizableReadTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/LinearizableReadTests.java
@@ -171,12 +171,7 @@ public abstract class LinearizableReadTests<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testFollowerLinearizableReadFailsWhenInstallingSnapshot() throws Exception {
-    RaftServerConfigKeys.Read.setTimeout(getProperties(), TimeDuration.valueOf(200, TimeUnit.MILLISECONDS));
-    try {
-      runWithNewCluster(ReadOnlyRequestTests::runTestFollowerLinearizableReadFailsWhenInstallingSnapshot);
-    } finally {
-      RaftServerConfigKeys.Read.setTimeout(getProperties(), RaftServerConfigKeys.Read.TIMEOUT_DEFAULT);
-    }
+    runWithNewCluster(ReadOnlyRequestTests::runTestFollowerLinearizableReadFailsWhenInstallingSnapshot);
   }
 
   @Test

--- a/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
@@ -40,11 +40,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
@@ -142,19 +144,28 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
     }
   }
 
-  private static void setReadRequestsFailure(RaftServer.Division server, Throwable failure) throws Exception {
-    final Method getReadRequests = server.getClass().getDeclaredMethod("getReadRequests");
+  private static void setInProgressInstallSnapshotIndex(RaftServer.Division server, long index) throws Exception {
+    final Field snapshotInstallationHandler = server.getClass().getDeclaredField("snapshotInstallationHandler");
+    snapshotInstallationHandler.setAccessible(true);
+    final Object handler = snapshotInstallationHandler.get(server);
+    final Field inProgressInstallSnapshotIndex = handler.getClass()
+        .getDeclaredField("inProgressInstallSnapshotIndex");
+    inProgressInstallSnapshotIndex.setAccessible(true);
+    ((AtomicLong) inProgressInstallSnapshotIndex.get(handler)).set(index);
+  }
+
+  private static void startSnapshotInstallation(RaftServer.Division server, long index) throws Exception {
+    setInProgressInstallSnapshotIndex(server, index);
+    final Method getState = server.getClass().getDeclaredMethod("getState");
+    getState.setAccessible(true);
+    final Object state = getState.invoke(server);
+    final Method getReadRequests = state.getClass().getDeclaredMethod("getReadRequests");
     getReadRequests.setAccessible(true);
-    final Object readRequests = getReadRequests.invoke(server);
-    final Method method = failure != null
-        ? readRequests.getClass().getDeclaredMethod("failAndBlock", Throwable.class)
-        : readRequests.getClass().getDeclaredMethod("clearFailure");
-    method.setAccessible(true);
-    if (failure != null) {
-      method.invoke(readRequests, failure);
-    } else {
-      method.invoke(readRequests);
-    }
+    final Object readRequests = getReadRequests.invoke(state);
+    final Method fail = readRequests.getClass().getDeclaredMethod("fail", Throwable.class);
+    fail.setAccessible(true);
+    fail.invoke(readRequests, new ReadException(server.getMemberId()
+        + ": Failed read as snapshot (" + index + ") installation is in progress"));
   }
 
   static void assertSnapshotInstallationReadException(Throwable exception) {
@@ -185,8 +196,7 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
       final CompletableFuture<RaftClientReply> pendingRead = followerClient.async().sendReadOnly(QUERY, followerId);
       Assertions.assertFalse(pendingRead.isDone(), () -> "pendingRead=" + pendingRead);
 
-      final String message = follower.getMemberId() + ": Failed read as snapshot (1) installation is in progress";
-      setReadRequestsFailure(follower, new ReadException(message));
+      startSnapshotInstallation(follower, 1);
       try {
         final CompletionException pendingException = Assertions.assertThrows(CompletionException.class,
             pendingRead::join);
@@ -196,10 +206,11 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
             () -> followerClient.io().sendReadOnly(QUERY, followerId));
         assertSnapshotInstallationReadException(readException);
       } finally {
-        setReadRequestsFailure(follower, null);
+        setInProgressInstallSnapshotIndex(follower, -1);
       }
 
       assertReplyExact(2, writeReply.join());
+      assertReplyExact(2, followerClient.io().sendReadOnly(QUERY, followerId));
     }
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
@@ -40,8 +40,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
@@ -136,6 +139,67 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
 
       // readOnly will success after re-election
       assertReplyExact(1, client.io().sendReadOnly(QUERY));
+    }
+  }
+
+  private static void setReadRequestsFailure(RaftServer.Division server, Throwable failure) throws Exception {
+    final Method getReadRequests = server.getClass().getDeclaredMethod("getReadRequests");
+    getReadRequests.setAccessible(true);
+    final Object readRequests = getReadRequests.invoke(server);
+    final Method method = failure != null
+        ? readRequests.getClass().getDeclaredMethod("failAndBlock", Throwable.class)
+        : readRequests.getClass().getDeclaredMethod("clearFailure");
+    method.setAccessible(true);
+    if (failure != null) {
+      method.invoke(readRequests, failure);
+    } else {
+      method.invoke(readRequests);
+    }
+  }
+
+  static void assertSnapshotInstallationReadException(Throwable exception) {
+    final Throwable cause = exception instanceof CompletionException && exception.getCause() != null
+        ? exception.getCause() : exception;
+    Assertions.assertInstanceOf(ReadException.class, cause);
+    Assertions.assertTrue(cause.getMessage().contains("snapshot (1) installation is in progress"),
+        () -> "Unexpected exception: " + exception);
+  }
+
+  static <C extends MiniRaftCluster> void runTestFollowerLinearizableReadFailsWhenInstallingSnapshot(C cluster)
+      throws Exception {
+    final RaftPeerId leaderId = RaftTestUtil.waitForLeader(cluster).getId();
+
+    final List<RaftServer.Division> followers = cluster.getFollowers();
+    Assertions.assertEquals(2, followers.size());
+
+    final RaftServer.Division follower = followers.get(0);
+    final RaftPeerId followerId = follower.getId();
+
+    try (RaftClient leaderClient = cluster.createClient(leaderId);
+         RaftClient followerClient = cluster.createClient(followerId, RetryPolicies.noRetry())) {
+      assertReplyExact(1, leaderClient.io().send(INCREMENT));
+      assertReplyExact(1, followerClient.io().sendReadOnly(QUERY, followerId));
+
+      final CompletableFuture<RaftClientReply> writeReply = leaderClient.async().send(WAIT_AND_INCREMENT);
+      Thread.sleep(100);
+      final CompletableFuture<RaftClientReply> pendingRead = followerClient.async().sendReadOnly(QUERY, followerId);
+      Assertions.assertFalse(pendingRead.isDone(), () -> "pendingRead=" + pendingRead);
+
+      final String message = follower.getMemberId() + ": Failed read as snapshot (1) installation is in progress";
+      setReadRequestsFailure(follower, new ReadException(message));
+      try {
+        final CompletionException pendingException = Assertions.assertThrows(CompletionException.class,
+            pendingRead::join);
+        assertSnapshotInstallationReadException(pendingException);
+
+        final ReadException readException = Assertions.assertThrows(ReadException.class,
+            () -> followerClient.io().sendReadOnly(QUERY, followerId));
+        assertSnapshotInstallationReadException(readException);
+      } finally {
+        setReadRequestsFailure(follower, null);
+      }
+
+      assertReplyExact(2, writeReply.join());
     }
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
@@ -165,14 +165,14 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
     final Method fail = readRequests.getClass().getDeclaredMethod("fail", Throwable.class);
     fail.setAccessible(true);
     fail.invoke(readRequests, new ReadException(server.getMemberId()
-        + ": Failed read as snapshot (" + index + ") installation is in progress"));
+        + ": Failed to wait for readIndex as snapshot (" + index + ") installation is started"));
   }
 
   static void assertSnapshotInstallationReadException(Throwable exception) {
     final Throwable cause = exception instanceof CompletionException && exception.getCause() != null
         ? exception.getCause() : exception;
     Assertions.assertInstanceOf(ReadException.class, cause);
-    Assertions.assertTrue(cause.getMessage().contains("snapshot (1) installation is in progress"),
+    Assertions.assertTrue(cause.getMessage().contains("snapshot (1) installation is"),
         () -> "Unexpected exception: " + exception);
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
   extends BaseTest


### PR DESCRIPTION
## What changes were proposed in this pull request?

When Ratis follower is installing snapshot, its appliedIndex will not advance until the snapshot is installed. This can cause all linearizable follower read on this node to timeout due to the client timeout (default is 3s).

Instead of waiting until the client timeout, Ratis follower can check whether it is currently installing snapshot and trigger failover immediately if it does. Any new or pending read requests in the follower need to return ReadException.

This decision is based on the assumption that snapshot will take a longer time and might stall the follower read, which I think is a reasonable assumption. However, if snapshot is very small and InstallSnapshot can be done quickly, throwing ReadException might trigger unnecessary failover.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2511

## How was this patch tested?

Integration test.

Clean CI: https://github.com/ivandika3/ratis/actions/runs/25156971002
