### PR TITLE
RATIS-2512. Fix unreleased zero-copy messages during gRPC service shutdown.

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcClientProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcClientProtocolService.java
@@ -165,6 +165,10 @@ class GrpcClientProtocolService extends RaftClientProtocolServiceImplBase {
     zeroCopyMetrics.addUnreleased("client_protocol", zeroCopyRequestMarshaller::getUnclosedCount);
   }
 
+  void close() {
+    zeroCopyRequestMarshaller.close();
+  }
+
   RaftPeerId getId() {
     return idSupplier.get();
   }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -278,6 +278,10 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
     return builder.build();
   }
 
+  void close() {
+    zeroCopyRequestMarshaller.close();
+  }
+
   @Override
   public void requestVote(RequestVoteRequestProto request,
       StreamObserver<RequestVoteReplyProto> responseObserver) {

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServicesImpl.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServicesImpl.java
@@ -235,11 +235,12 @@ public final class GrpcServicesImpl
       return clientPort > 0 && clientPort != serverPort;
     }
 
-    Server newServer(GrpcClientProtocolService client, ZeroCopyMetrics zeroCopyMetrics, ServerInterceptor interceptor) {
+    Server newServer(GrpcClientProtocolService client, GrpcServerProtocolService service,
+        ServerInterceptor interceptor) {
       final EnumSet<GrpcServices.Type> types = EnumSet.of(GrpcServices.Type.SERVER);
       final NettyServerBuilder serverBuilder = newNettyServerBuilderForServer();
-      final ServerServiceDefinition service = newGrpcServerProtocolService(zeroCopyMetrics).bindServiceWithZeroCopy();
-      serverBuilder.addService(ServerInterceptors.intercept(service, interceptor));
+      final ServerServiceDefinition serviceDefinition = service.bindServiceWithZeroCopy();
+      serverBuilder.addService(ServerInterceptors.intercept(serviceDefinition, interceptor));
 
       if (!separateAdminServer()) {
         types.add(GrpcServices.Type.ADMIN);
@@ -285,6 +286,7 @@ public final class GrpcServicesImpl
 
   private final ExecutorService executor;
   private final GrpcClientProtocolService clientProtocolService;
+  private final GrpcServerProtocolService serverProtocolService;
 
   private final MetricServerInterceptor serverInterceptor;
   private final ZeroCopyMetrics zeroCopyMetrics = new ZeroCopyMetrics();
@@ -294,8 +296,9 @@ public final class GrpcServicesImpl
 
     this.executor = b.newExecutor();
     this.clientProtocolService = b.newGrpcClientProtocolService(executor, zeroCopyMetrics);
+    this.serverProtocolService = b.newGrpcServerProtocolService(zeroCopyMetrics);
     this.serverInterceptor = b.newMetricServerInterceptor();
-    final Server server = b.newServer(clientProtocolService, zeroCopyMetrics, serverInterceptor);
+    final Server server = b.newServer(clientProtocolService, serverProtocolService, serverInterceptor);
 
     servers.put(GrpcServerProtocolService.class.getSimpleName(), server);
     addressSupplier = newAddressSupplier(b.serverPort, server);
@@ -373,6 +376,8 @@ public final class GrpcServicesImpl
 
     serverInterceptor.close();
     ConcurrentUtils.shutdownAndWait(executor);
+    clientProtocolService.close();
+    serverProtocolService.close();
     zeroCopyMetrics.unregister();
   }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/ZeroCopyMessageMarshaller.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/ZeroCopyMessageMarshaller.java
@@ -243,9 +243,10 @@ public class ZeroCopyMessageMarshaller<T extends MessageLite> implements Prototy
       if (unclosedStreams.isEmpty()) {
         return;
       }
-      for (InputStream stream : unclosedStreams.values()) {
+      for (Map.Entry<T, InputStream> entry : unclosedStreams.entrySet()) {
         try {
-          stream.close();
+          entry.getValue().close();
+          releasedCount.accept(entry.getKey());
         } catch (IOException e) {
           LOG.warn("{}: Failed to close leaked stream.", name, e);
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request fixes a zero-copy request leak during gRPC service shutdown.

`ZeroCopyMessageMarshaller` may still hold pending or in-flight zero-copy request streams when the gRPC service is being closed. Previously, closing these tracked streams did not trigger the release logic for the corresponding zero-copy messages, which could cause `ZeroCopyMetrics` to report unreleased messages during cluster shutdown.

The proposed changes:
- Release tracked zero-copy messages when `ZeroCopyMessageMarshaller.close()` is called.
- Add close logic for gRPC protocol services that own zero-copy request marshallers.
- Explicitly close these protocol services in `GrpcServicesImpl.closeImpl()` before unregistering zero-copy metrics.
- Ensure the same `GrpcServerProtocolService` instance bound to the gRPC server is also closed during shutdown.


## What is the link to the Apache JIRA

RATIS-2512. Fix unreleased zero-copy messages during gRPC service shutdown

## How was this patch tested?

- This patch was tested with the following commands:

```
./mvnw -pl ratis-test -am -Pgrpc-tests -Dtest=TestGrpcZeroCopy,TestRaftAsyncWithGrpc#testWithLoadAsync test
```

- Both tests passed successfully.

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ratis.grpc.TestRaftAsyncWithGrpc
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 26.141 s - in org.apache.ratis.grpc.TestRaftAsyncWithGrpc
[INFO] Running org.apache.ratis.grpc.util.TestGrpcZeroCopy
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.272 s - in org.apache.ratis.grpc.util.TestGrpcZeroCopy
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
```