### PR TITLE
RATIS-2514. Fix flaky TestReadOnlyRequestWithGrpc.testReadAfterWrite.

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -299,20 +300,40 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
       Assertions.assertEquals(1, retrieve(blockReply));
 
       // test asynchronous read-after-write
-      client.async().send(incrementMessage);
-      client.async().sendReadAfterWrite(queryMessage).thenAccept(reply -> {
-        Assertions.assertEquals(2, retrieve(reply));
-      });
+      client.async().send(incrementMessage).get();
+      Assertions.assertEquals(2, retrieve(client.async().sendReadAfterWrite(queryMessage).get()));
 
+      // Keep the async write workload, but wait for the writes to complete before issuing reads.
+      // Otherwise, the following reads may observe different subsets of concurrent writes.
+      final List<CompletableFuture<RaftClientReply>> writes = new ArrayList<>();
       for (int i = 0; i < 20; i++) {
-        client.async().send(incrementMessage);
+        writes.add(client.async().send(incrementMessage));
       }
+      CompletableFuture.allOf(writes.toArray(new CompletableFuture[0])).get();
+      for (CompletableFuture<RaftClientReply> write : writes) {
+        Assertions.assertTrue(write.get().isSuccess());
+      }
+
       final CompletableFuture<RaftClientReply> linearizable = client.async().sendReadOnly(queryMessage);
       final CompletableFuture<RaftClientReply> readAfterWrite = client.async().sendReadAfterWrite(queryMessage);
 
       CompletableFuture.allOf(linearizable, readAfterWrite).get();
-      // read-after-write is more consistent than linearizable read
-      Assertions.assertTrue(retrieve(readAfterWrite.get()) >= retrieve(linearizable.get()));
+      // Both reads should observe the completed prior writes.  Do not compare their freshness
+      // since these two reads are concurrent and may have different linearization points.
+      Assertions.assertEquals(22, retrieve(linearizable.get()));
+      Assertions.assertEquals(22, retrieve(readAfterWrite.get()));
+
+      // Wait for followers to catch up before shutting down the cluster, so that outstanding
+      // AppendEntries references are released before leak detection runs.
+      final long leaderAppliedIndex = cluster.getLeader().getInfo().getLastAppliedIndex();
+      RaftTestUtil.waitFor(() -> {
+        for (RaftServer.Division server : cluster.iterateDivisions()) {
+          if (server.getInfo().getLastAppliedIndex() < leaderAppliedIndex) {
+            return false;
+          }
+        }
+        return true;
+      }, 100, 10_000);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request fixes a flaky assertion in `TestReadOnlyRequestWithGrpc.testReadAfterWrite`.

The previous test sent multiple async writes without waiting for them to complete, then issued a linearizable read and a read-after-write request concurrently. It asserted that the read-after-write result should be greater than or equal to the concurrent linearizable read result.

That assumption is unreliable because the two reads may have different linearization points and may observe different subsets of concurrent writes.

This patch keeps the original async write workload and both read paths, but makes the test deterministic by:
- waiting for the async writes to complete before issuing the reads;
- verifying that both linearizable read and read-after-write observe the completed prior writes;
- waiting for followers to catch up before cluster shutdown to avoid shutdown-time leak detection races.


## What is the link to the Apache JIRA

RATIS-2514. Fix flaky TestReadOnlyRequestWithGrpc.testReadAfterWrite.

## How was this patch tested?

Tested with:

```
./mvnw -pl ratis-test -am -Pgrpc-tests -Dtest=TestReadOnlyRequestWithGrpc#testReadAfterWrite test
```

Result:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ratis.grpc.TestReadOnlyRequestWithGrpc
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.746 s - in org.apache.ratis.grpc.TestReadOnlyRequestWithGrpc
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
```