### PR TITLE
RATIS-2518. Make testInstallSnapshotDuringBootstrap diagnostics fail-safe.

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -613,21 +613,42 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
             + "leaderSnapshotInfo={}\n{}\n{}",
         phase, Arrays.asList(peersInNewConf), numSnapshotRequests.get(), numNotifyInstallSnapshotFinished.get(),
         Optional.ofNullable(leaderSnapshotInfo).map(SnapshotInfo::getTermIndex).orElse(null),
-        cluster.printServers(), cluster.printAllLogs(), cause);
+        safeToString(cluster::printServers), safeToString(cluster::printAllLogs), cause);
 
     for (RaftServer.Division division : cluster.iterateDivisions()) {
-      final SnapshotInfo snapshot = division.getStateMachine().getLatestSnapshot();
+      final SnapshotInfo snapshot = safeGet(() -> division.getStateMachine().getLatestSnapshot());
       LOG.error("{}: divisionState id={}, role={}, leaderId={}, leaderReady={}, alive={}, term={}, "
               + "lastAppliedIndex={}, snapshot={}, logStartIndex={}, logNextIndex={}, commitIndex={}, conf={}, "
               + "followerNextIndices={}, followerMatchIndices={}",
-          phase, division.getId(), division.getInfo().getCurrentRole(), division.getInfo().getLeaderId(),
-          division.getInfo().isLeaderReady(), division.getInfo().isAlive(), division.getInfo().getCurrentTerm(),
-          division.getInfo().getLastAppliedIndex(),
+          phase, division.getId(), safeToString(() -> division.getInfo().getCurrentRole()),
+          safeToString(() -> division.getInfo().getLeaderId()),
+          safeToString(() -> division.getInfo().isLeaderReady()), safeToString(() -> division.getInfo().isAlive()),
+          safeToString(() -> division.getInfo().getCurrentTerm()), safeToString(() -> division.getInfo()
+              .getLastAppliedIndex()),
           Optional.ofNullable(snapshot).map(SnapshotInfo::getTermIndex).orElse(null),
-          division.getRaftLog().getStartIndex(), division.getRaftLog().getNextIndex(),
-          division.getRaftLog().getLastCommittedIndex(), division.getRaftConf(),
-          Arrays.toString(division.getInfo().getFollowerNextIndices()),
-          Arrays.toString(division.getInfo().getFollowerMatchIndices()));
+          safeToString(() -> division.getRaftLog().getStartIndex()),
+          safeToString(() -> division.getRaftLog().getNextIndex()),
+          safeToString(() -> division.getRaftLog().getLastCommittedIndex()),
+          safeToString(division::getRaftConf),
+          safeToString(() -> Arrays.toString(division.getInfo().getFollowerNextIndices())),
+          safeToString(() -> Arrays.toString(division.getInfo().getFollowerMatchIndices())));
+    }
+  }
+
+  private static <T> T safeGet(Supplier<T> supplier) {
+    try {
+      return supplier.get();
+    } catch (RuntimeException e) {
+      LOG.warn("Failed to collect diagnostic state", e);
+      return null;
+    }
+  }
+
+  private static Object safeToString(Supplier<?> supplier) {
+    try {
+      return supplier.get();
+    } catch (RuntimeException e) {
+      return "unavailable: " + e;
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow-up to RATIS-2501.

RATIS-2501 added additional diagnostics for `testInstallSnapshotDuringBootstrap` failures. However, the diagnostic path may access raft log state from a peer whose raft log has already been closed. When this happens, `dumpClusterState()` can throw a secondary `IllegalStateException`, which hides the original failure that the diagnostics were intended to explain.

This patch makes `dumpClusterState()` fail-safe by safely collecting diagnostic values. If a diagnostic value is unavailable, it is logged as `unavailable: <exception>` instead of throwing from the diagnostic path.


## What is the link to the Apache JIRA

JIRA: RATIS-2518. Make testInstallSnapshotDuringBootstrap diagnostics fail-safe.

## How was this patch tested?

Tested with:

```
./mvnw -pl ratis-test -am -Pgrpc-tests -Dtest=TestInstallSnapshotNotificationWithGrpc#testInstallSnapshotDuringBootstrap test
```

Result:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ratis.grpc.TestInstallSnapshotNotificationWithGrpc
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.33 s - in org.apache.ratis.grpc.TestInstallSnapshotNotificationWithGrpc
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
```