### PR TITLE
RATIS-2509. Introduce local read API to reduce serde cost

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/ClientProtoUtils.java
@@ -122,6 +122,11 @@ public interface ClientProtoUtils {
   }
 
   /** For client requests. */
+  static RaftRpcRequestProto.Builder toRaftRpcRequestProtoBuilder(ClientId clientId, RaftGroupMemberId serverId) {
+    return toRaftRpcRequestProtoBuilder(clientId.toByteString(), serverId.getPeerId(), serverId.getGroupId());
+  }
+
+  /** For client requests. */
   static RaftRpcRequestProto.Builder toRaftRpcRequestProtoBuilder(RaftClientRequest request) {
     final RaftRpcRequestProto.Builder b = toRaftRpcRequestProtoBuilder(
         request.getClientId().toByteString(), request.getServerId(), request.getRaftGroupId());
@@ -208,13 +213,9 @@ public interface ClientProtoUtils {
   }
 
   static RaftClientRequestProto toRaftClientRequestProto(RaftClientRequest request) {
-    return toRaftClientRequestProto(request, true);
-  }
-
-  static RaftClientRequestProto toRaftClientRequestProto(RaftClientRequest request, boolean withMsg) {
     final RaftClientRequestProto.Builder b = RaftClientRequestProto.newBuilder()
         .setRpcRequest(toRaftRpcRequestProtoBuilder(request));
-    if (withMsg && request.getMessage() != null) {
+    if (request.getMessage() != null) {
       b.setMessage(toClientMessageEntryProtoBuilder(request.getMessage()));
     }
 

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServer.java
@@ -24,12 +24,16 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
+import org.apache.ratis.proto.RaftProtos.ReadRequestTypeProto;
 import org.apache.ratis.protocol.AdminAsynchronousProtocol;
 import org.apache.ratis.protocol.AdminProtocol;
+import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.RaftClientAsynchronousProtocol;
 import org.apache.ratis.protocol.RaftClientProtocol;
 import org.apache.ratis.protocol.RaftGroup;
@@ -101,6 +105,21 @@ public interface RaftServer extends Closeable, RpcType.Get,
 
     /** @return the {@link StateMachine} for this division. */
     StateMachine getStateMachine();
+
+    /**
+     * Execute a local read-only query after applying the configured
+     * {@link RaftServerConfigKeys.Read.Option} consistency checks.
+     *
+     * <p>This API is intended for embedded users that already have a local
+     * server division and want to avoid serializing application read requests
+     * and responses through {@link org.apache.ratis.protocol.Message}. Remote
+     * clients should continue to use
+     * {@link org.apache.ratis.client.api.AsyncApi#sendReadOnly(org.apache.ratis.protocol.Message)}.
+     */
+    default <T> CompletableFuture<T> readOnlyAsync(ClientId clientId, ReadRequestTypeProto readRequestType,
+        Supplier<CompletableFuture<T>> query) throws IOException {
+      throw new UnsupportedOperationException("readOnlyAsync is not supported");
+    }
 
     /** @return the raft log of this division. */
     RaftLog getRaftLog();

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderTracer.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderTracer.java
@@ -81,6 +81,9 @@ class LeaderTracer {
   }
 
   void removePendingRequest(PendingRequest pending) {
+    if (pending == null) {
+      return;
+    }
     appendEntriesSpans.remove(pending.getTermIndex().getIndex());
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -37,12 +37,14 @@ import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.proto.RaftProtos.RaftRpcRequestProto;
 import org.apache.ratis.proto.RaftProtos.ReadIndexReplyProto;
 import org.apache.ratis.proto.RaftProtos.ReadIndexRequestProto;
+import org.apache.ratis.proto.RaftProtos.ReadRequestTypeProto;
 import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
 import org.apache.ratis.proto.RaftProtos.RoleInfoProto;
 import org.apache.ratis.proto.RaftProtos.StartLeaderElectionReplyProto;
 import org.apache.ratis.proto.RaftProtos.StartLeaderElectionRequestProto;
+import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.ClientInvocationId;
 import org.apache.ratis.protocol.GroupInfoReply;
 import org.apache.ratis.protocol.GroupInfoRequest;
@@ -1099,7 +1101,12 @@ class RaftServerImpl implements RaftServer.Division,
     if (leaderId == null) {
       return JavaUtils.completeExceptionally(new ReadIndexException(getMemberId() + ": Leader is unknown."));
     }
-    final ReadIndexRequestProto request = toReadIndexRequestProto(clientRequest, getMemberId(), leaderId);
+    return sendReadIndexAsync(clientRequest.getClientId(), clientRequest.getType().getRead(), leaderId);
+  }
+
+  private CompletableFuture<ReadIndexReplyProto> sendReadIndexAsync(
+      ClientId clientId, ReadRequestTypeProto readRequestType, RaftPeerId leaderId) {
+    final ReadIndexRequestProto request = toReadIndexRequestProto(clientId, readRequestType, getMemberId(), leaderId);
     try {
       return getServerRpc().async().readIndexAsync(request);
     } catch (IOException e) {
@@ -1109,6 +1116,74 @@ class RaftServerImpl implements RaftServer.Division,
   private CompletableFuture<Long> getReadIndex(RaftClientRequest request, LeaderStateImpl leader) {
     return writeIndexCache.getWriteIndexFuture(request).thenCompose(leader::getReadIndex);
   }
+  private CompletableFuture<Long> getReadIndex(CompletableFuture<ReadIndexReplyProto> readIndexReply) {
+    return readIndexReply.thenApply(reply -> {
+      if (reply.getServerReply().getSuccess()) {
+        return reply.getReadIndex();
+      } else {
+        throw new CompletionException(new ReadIndexException(getId()
+            + ": Failed to get read index from the leader: " + reply));
+      }
+    });
+  }
+
+  private CompletableFuture<Long> getReadIndexForReadOnly(ClientId clientId, ReadRequestTypeProto readRequestType) {
+    final LeaderStateImpl leader = role.getLeaderState().orElse(null);
+    if (leader != null) {
+      return leader.getReadIndex(null);
+    }
+
+    final long installSnapshot = snapshotInstallationHandler.getInProgressInstallSnapshotIndex();
+    if (installSnapshot != RaftLog.INVALID_LOG_INDEX) {
+      return JavaUtils.completeExceptionally(getReadException("get", installSnapshot, false));
+    }
+
+    final RaftPeerId leaderId = getInfo().getLeaderId();
+    if (leaderId == null) {
+      return JavaUtils.completeExceptionally(new ReadIndexException(getMemberId() + ": Leader is unknown."));
+    }
+
+    return getReadIndex(sendReadIndexAsync(clientId, readRequestType, leaderId));
+  }
+
+  private <T> CompletableFuture<T> checkLeaderStateForReadOnly() {
+    if (!getInfo().isLeader()) {
+      return JavaUtils.completeExceptionally(generateNotLeaderException());
+    }
+    if (!getInfo().isLeaderReady()) {
+      return JavaUtils.completeExceptionally(new LeaderNotReadyException(getMemberId()));
+    }
+    return null;
+  }
+
+  private static <T> CompletableFuture<T> supplyReadOnly(Supplier<CompletableFuture<T>> query) {
+    try {
+      return Objects.requireNonNull(query.get(), "query returned null");
+    } catch (Throwable t) {
+      return JavaUtils.completeExceptionally(t);
+    }
+  }
+
+  @Override
+  public <T> CompletableFuture<T> readOnlyAsync(ClientId clientId, ReadRequestTypeProto readRequestType,
+      Supplier<CompletableFuture<T>> query) throws IOException {
+    Objects.requireNonNull(clientId, "clientId == null");
+    Objects.requireNonNull(readRequestType, "readRequestType == null");
+    Objects.requireNonNull(query, "query == null");
+    assertLifeCycleState(LifeCycle.States.RUNNING);
+    if (readOption == RaftServerConfigKeys.Read.Option.DEFAULT) {
+      final CompletableFuture<T> reply = checkLeaderStateForReadOnly();
+      return reply != null ? reply : supplyReadOnly(query);
+    } else if (readOption == RaftServerConfigKeys.Read.Option.LINEARIZABLE) {
+      return getReadIndexForReadOnly(clientId, readRequestType)
+          .thenCompose(readIndex -> getState().getReadRequests().waitToAdvance(readIndex,
+              () -> getReadException("add", snapshotInstallationHandler.getInProgressInstallSnapshotIndex(), false)))
+          .thenCompose(readIndex -> supplyReadOnly(query));
+    } else {
+      throw new IllegalStateException("Unexpected read option: " + readOption);
+    }
+  }
+
   private CompletableFuture<RaftClientReply> readAsync(RaftClientRequest request) {
     if (request.getType().getRead().getPreferNonLinearizable()
         || readOption == RaftServerConfigKeys.Read.Option.DEFAULT) {
@@ -1123,14 +1198,7 @@ class RaftServerImpl implements RaftServer.Division,
       if (leader != null) {
         replyFuture = getReadIndex(request, leader);
       } else {
-        replyFuture = sendReadIndexAsync(request).thenApply(reply   -> {
-          if (reply.getServerReply().getSuccess()) {
-            return reply.getReadIndex();
-          } else {
-            throw new CompletionException(new ReadIndexException(getId() +
-                ": Failed to get read index from the leader: " + reply));
-          }
-        });
+        replyFuture = getReadIndex(sendReadIndexAsync(request));
       }
 
       return replyFuture

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1171,7 +1171,7 @@ class RaftServerImpl implements RaftServer.Division,
     Objects.requireNonNull(readRequestType, "readRequestType == null");
     Objects.requireNonNull(query, "query == null");
     assertLifeCycleState(LifeCycle.States.RUNNING);
-    if (readOption == RaftServerConfigKeys.Read.Option.DEFAULT) {
+    if (readRequestType.getPreferNonLinearizable() || readOption == RaftServerConfigKeys.Read.Option.DEFAULT) {
       final CompletableFuture<T> reply = checkLeaderStateForReadOnly();
       return reply != null ? reply : supplyReadOnly(query);
     } else if (readOption == RaftServerConfigKeys.Read.Option.LINEARIZABLE) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
@@ -20,7 +20,7 @@ package org.apache.ratis.server.impl;
 import org.apache.ratis.client.impl.ClientProtoUtils;
 import org.apache.ratis.proto.RaftProtos.*;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto.AppendResult;
-import org.apache.ratis.protocol.RaftClientRequest;
+import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -115,10 +115,13 @@ final class ServerProtoUtils {
   }
 
   static ReadIndexRequestProto toReadIndexRequestProto(
-      RaftClientRequest clientRequest, RaftGroupMemberId requestorId, RaftPeerId replyId) {
+      ClientId clientId, ReadRequestTypeProto readRequestType, RaftGroupMemberId serverId, RaftPeerId leaderId) {
+    final RaftClientRequestProto.Builder clientRequestBuilder = RaftClientRequestProto.newBuilder()
+        .setRpcRequest(ClientProtoUtils.toRaftRpcRequestProtoBuilder(clientId, serverId))
+        .setRead(readRequestType);
     return ReadIndexRequestProto.newBuilder()
-        .setServerRequest(ClientProtoUtils.toRaftRpcRequestProtoBuilder(requestorId, replyId))
-        .setClientRequest(ClientProtoUtils.toRaftClientRequestProto(clientRequest, false))
+        .setServerRequest(ClientProtoUtils.toRaftRpcRequestProtoBuilder(serverId, leaderId))
+        .setClientRequest(clientRequestBuilder)
         .build();
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/LinearizableReadTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/LinearizableReadTests.java
@@ -47,9 +47,12 @@ import static org.apache.ratis.ReadOnlyRequestTests.CounterStateMachine;
 import static org.apache.ratis.ReadOnlyRequestTests.INCREMENT;
 import static org.apache.ratis.ReadOnlyRequestTests.QUERY;
 import static org.apache.ratis.ReadOnlyRequestTests.WAIT_AND_INCREMENT;
+import static org.apache.ratis.ReadOnlyRequestTests.assertLongAtLeast;
 import static org.apache.ratis.ReadOnlyRequestTests.assertOption;
 import static org.apache.ratis.ReadOnlyRequestTests.assertReplyAtLeast;
 import static org.apache.ratis.ReadOnlyRequestTests.assertReplyExact;
+import static org.apache.ratis.ReadOnlyRequestTests.getCount;
+import static org.apache.ratis.ReadOnlyRequestTests.readOnlyAsync;
 import static org.apache.ratis.server.RaftServerConfigKeys.Read.Option.LINEARIZABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -150,6 +153,7 @@ public abstract class LinearizableReadTests<CLUSTER extends MiniRaftCluster>
     final int n = 100;
     final List<Reply> f0Replies = new ArrayList<>(n);
     final List<Reply> f1Replies = new ArrayList<>(n);
+    final List<CompletableFuture<Long>> f0LocalReplies = new ArrayList<>(n);
     try (RaftClient client = cluster.createClient(leaderId);
          RaftClient c0 = cluster.createClient(f0);
          RaftClient c1 = cluster.createClient(f1);
@@ -160,11 +164,14 @@ public abstract class LinearizableReadTests<CLUSTER extends MiniRaftCluster>
 
         f0Replies.add(new Reply(count, c0.async().sendReadOnly(QUERY, f0)));
         f1Replies.add(new Reply(count, c1.async().sendReadOnly(QUERY, f1)));
+        f0LocalReplies.add(readOnlyAsync(
+            followers.get(0), () -> CompletableFuture.completedFuture(getCount(followers.get(0)))));
       }
 
       for (int i = 0; i < n; i++) {
         f0Replies.get(i).assertAtLeast();
         f1Replies.get(i).assertAtLeast();
+        assertLongAtLeast(i + 1, f0LocalReplies.get(i).join());
       }
     }
   }

--- a/ratis-server/src/test/java/org/apache/ratis/LinearizableReadTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/LinearizableReadTests.java
@@ -41,7 +41,9 @@ import org.slf4j.event.Level;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.ratis.ReadOnlyRequestTests.CounterStateMachine;
 import static org.apache.ratis.ReadOnlyRequestTests.INCREMENT;
@@ -53,6 +55,7 @@ import static org.apache.ratis.ReadOnlyRequestTests.assertReplyAtLeast;
 import static org.apache.ratis.ReadOnlyRequestTests.assertReplyExact;
 import static org.apache.ratis.ReadOnlyRequestTests.getCount;
 import static org.apache.ratis.ReadOnlyRequestTests.readOnlyAsync;
+import static org.apache.ratis.ReadOnlyRequestTests.readOnlyAsyncPreferNonLinearizable;
 import static org.apache.ratis.server.RaftServerConfigKeys.Read.Option.LINEARIZABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -173,6 +176,15 @@ public abstract class LinearizableReadTests<CLUSTER extends MiniRaftCluster>
         f1Replies.get(i).assertAtLeast();
         assertLongAtLeast(i + 1, f0LocalReplies.get(i).join());
       }
+
+      final AtomicBoolean callbackInvoked = new AtomicBoolean();
+      final CompletableFuture<Long> preferNonLinearizable = readOnlyAsyncPreferNonLinearizable(
+          followers.get(0), () -> {
+            callbackInvoked.set(true);
+            return CompletableFuture.completedFuture(getCount(followers.get(0)));
+          });
+      Assertions.assertThrows(CompletionException.class, preferNonLinearizable::join);
+      Assertions.assertFalse(callbackInvoked.get());
     }
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
@@ -242,12 +242,12 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
 
   static <T> CompletableFuture<T> readOnlyAsync(
       RaftServer.Division server, Supplier<CompletableFuture<T>> query) throws IOException {
-    return server.readOnlyAsync(ClientId.emptyClientId(), RaftClientRequest.readRequestType().getRead(), query);
+    return server.readOnlyAsync(ClientId.randomId(), RaftClientRequest.readRequestType().getRead(), query);
   }
 
   static <T> CompletableFuture<T> readOnlyAsyncPreferNonLinearizable(
       RaftServer.Division server, Supplier<CompletableFuture<T>> query) throws IOException {
-    return server.readOnlyAsync(ClientId.emptyClientId(), RaftClientRequest.readRequestType(true).getRead(), query);
+    return server.readOnlyAsync(ClientId.randomId(), RaftClientRequest.readRequestType(true).getRead(), query);
   }
 
   public static void assertReplyExact(int expectedCount, RaftClientReply reply) {

--- a/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
@@ -245,6 +245,11 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
     return server.readOnlyAsync(ClientId.emptyClientId(), RaftClientRequest.readRequestType().getRead(), query);
   }
 
+  static <T> CompletableFuture<T> readOnlyAsyncPreferNonLinearizable(
+      RaftServer.Division server, Supplier<CompletableFuture<T>> query) throws IOException {
+    return server.readOnlyAsync(ClientId.emptyClientId(), RaftClientRequest.readRequestType(true).getRead(), query);
+  }
+
   public static void assertReplyExact(int expectedCount, RaftClientReply reply) {
     Assertions.assertTrue(reply.isSuccess());
     final int retrieved = retrieve(reply);

--- a/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/ReadOnlyRequestTests.java
@@ -20,7 +20,9 @@ package org.apache.ratis;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
+import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
+import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.RaftRetryFailureException;
@@ -42,11 +44,14 @@ import org.slf4j.event.Level;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
   extends BaseTest
@@ -85,14 +90,27 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
 
   static <C extends MiniRaftCluster> void runTestReadOnly(C cluster) throws Exception {
     try {
-      RaftTestUtil.waitForLeader(cluster);
-      final RaftPeerId leaderId = cluster.getLeader().getId();
+      final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster);
+      final RaftPeerId leaderId = leader.getId();
 
       try (final RaftClient client = cluster.createClient(leaderId)) {
         for (int i = 1; i <= 10; i++) {
           assertReplyExact(i, client.io().send(INCREMENT));
           assertReplyExact(i, client.io().sendReadOnly(QUERY));
+          Assertions.assertEquals(i, readOnlyAsync(
+              leader, () -> CompletableFuture.completedFuture(getCount(leader))).get());
         }
+      }
+
+      if (RaftServerConfigKeys.Read.option(cluster.getProperties()) == RaftServerConfigKeys.Read.Option.DEFAULT) {
+        final RaftServer.Division follower = cluster.getFollowers().get(0);
+        final AtomicBoolean callbackInvoked = new AtomicBoolean();
+        final CompletableFuture<Long> read = readOnlyAsync(follower, () -> {
+          callbackInvoked.set(true);
+          return CompletableFuture.completedFuture(getCount(follower));
+        });
+        Assertions.assertThrows(CompletionException.class, read::join);
+        Assertions.assertFalse(callbackInvoked.get());
       }
     } finally {
       cluster.shutdown();
@@ -218,6 +236,15 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
     return Integer.parseInt(reply.getMessage().getContent().toString(StandardCharsets.UTF_8));
   }
 
+  static long getCount(RaftServer.Division server) {
+    return ((CounterStateMachine) server.getStateMachine()).getCount();
+  }
+
+  static <T> CompletableFuture<T> readOnlyAsync(
+      RaftServer.Division server, Supplier<CompletableFuture<T>> query) throws IOException {
+    return server.readOnlyAsync(ClientId.emptyClientId(), RaftClientRequest.readRequestType().getRead(), query);
+  }
+
   public static void assertReplyExact(int expectedCount, RaftClientReply reply) {
     Assertions.assertTrue(reply.isSuccess());
     final int retrieved = retrieve(reply);
@@ -229,6 +256,11 @@ public abstract class ReadOnlyRequestTests<CLUSTER extends MiniRaftCluster>
     final int retrieved = retrieve(reply);
     Assertions.assertTrue(retrieved >= minCount,
         () -> "retrieved = " + retrieved + " < minCount = " + minCount + ", reply=" + reply);
+  }
+
+  public static void assertLongAtLeast(int minCount, long retrieved) {
+    Assertions.assertTrue(retrieved >= minCount,
+        () -> "retrieved = " + retrieved + " < minCount = " + minCount);
   }
 
   /**

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerImplTracingTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerImplTracingTests.java
@@ -55,6 +55,7 @@ import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
@@ -146,6 +147,11 @@ public class RaftServerImplTracingTests {
         .findFirst()
         .orElseThrow(() -> new IllegalStateException("Expected INTERNAL span " + SpanNames.APPEND_ENTRIES_ASYNC));
     assertEquals(StatusCode.ERROR, appendSpan.getStatus().getStatusCode());
+  }
+
+  @Test
+  public void testLeaderTracerRemovePendingRequestSkipsNull() {
+    assertDoesNotThrow(() -> new LeaderTracer().removePendingRequest(null));
   }
 
   private static List<SpanData> traceAppendEntriesAndCollectNewSpans(
@@ -265,4 +271,3 @@ public class RaftServerImplTracingTests {
   }
 
 }
-


### PR DESCRIPTION
## What changes were proposed in this pull request?

See https://issues.apache.org/jira/browse/RATIS-2509

OM code integration (`OzoneManagerRatisRequest#submitRequest`)

```java
    public OMResponse submitReadRequest(OMRequest omRequest, Function<OMRequest, OMResponse> handler)
      throws ServiceException {
    try {
      return serverDivision.readOnlyAsync(() -> CompletableFuture.completedFuture(handler.apply(omRequest))).get();
    } catch (ExecutionException | IOException ex) {
      throw new ServiceException(ex.getMessage(), ex);
    } catch (InterruptedException ex) {
      Thread.currentThread().interrupt();
      throw new ServiceException(ex.getMessage(), ex);
    }

  }

```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2509

## How was this patch tested?

OM Leader read performance testing, the Ratis read performance is on par with the direct read.
- Before patch: 235020 QPS -> 180433 QPS (24% QPS reduction)
- After patch: 235020 QPS -> 228362 (3% QPS reduction)

Follower read throughput remains unchanged, so might not be the main overhead.
