### PR TITLE
RATIS-2534. Skip zizmor on dependabot push

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,6 +17,10 @@ name: zizmor
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
+    tags:
+      - '**'
   pull_request:
 
 permissions: { }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similar to RATIS-2070, for the `zizmor` check this time.

Background: dependabot pushes dependency version bumps to the main repo instead of its own fork. It then creates a pull request without waiting for the push workflow to succeed. Thus both workflows test the same state of code, which is unnecessary.

https://issues.apache.org/jira/browse/RATIS-2534

## How was this patch tested?

In use for `post-commit.yaml` since RATIS-2070.

https://github.com/adoroszlai/ratis/actions/runs/25862410063