### PR TITLE
RATIS-2441. Set encoding for maven-resources-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -703,6 +703,13 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <propertiesEncoding>ISO-8859-1</propertiesEncoding>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix warning about properties encoding:

```
[INFO] --- resources:3.3.1:resources (default-resources) @ ratis-docs ---
...
[INFO] The encoding used to copy filtered properties files have not been set. This means that the same encoding will be used to copy filtered properties files as when copying other filtered resources. This might not be what you want! Run your build with --debug to see which files might be affected. Read more at https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html
```

by setting `propertiesEncoding` for `maven-resources-plugin` according to [doc](https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html).

`ratis-version.properties` is read using `Properties` class, so encoding should be `ISO-8859-1`.

https://github.com/apache/ratis/blob/5217431ebfc70635c723871c897105050fcb1e7b/ratis-common/src/main/java/org/apache/ratis/util/VersionInfo.java#L100-L102

https://issues.apache.org/jira/browse/RATIS-2441

## How was this patch tested?

Warning is gone:
https://github.com/adoroszlai/ratis/actions/runs/26450457188/job/77883526958