### PR TITLE
Query counter bug fix - query counter in example server

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/RaftCluster.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/membership/server/RaftCluster.java
@@ -143,15 +143,24 @@ public class RaftCluster {
   }
 
   public void queryCounter() throws IOException {
-    RaftClient client = createClient();
-    try {
-      RaftClientReply reply = client.io().sendReadOnly(CounterCommand.GET.getMessage());
-      String count = reply.getMessage().getContent().toStringUtf8();
-      System.out.println("Current counter value: " + count);
-    } finally {
-      client.close();
-    }
+  RaftClient client = createClient();
+  try {
+    RaftClientReply reply = client.io().sendReadOnly(
+        CounterCommand.GET.getMessage());
+
+    ByteBuffer buffer =
+        reply.getMessage()
+             .getContent()
+             .asReadOnlyByteBuffer();
+
+    int count = buffer.getInt();
+
+    System.out.println(
+        "Current counter value: " + count);
+  } finally {
+    client.close();
   }
+}
 
   /**
    * Configure the raft group with initial peers.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fixes an issue in the membership example where the `query` command displayed an empty counter value even after successful counter updates.

The root cause was an encoding mismatch between the server and client implementations. The `CounterStateMachine` returns the counter value as a 4-byte binary integer (`ByteString`), while the membership example client attempted to decode the response using UTF-8 string conversion. As a result, the query output appeared empty.

This patch updates the `queryCounter()` implementation in `RaftCluster` to correctly deserialize the binary response using `ByteBuffer.getInt()`, allowing the current counter value to be displayed correctly.

## What is the link to the Apache JIRA

Apache JIRA: RATIS-XXXX

(Replace with the actual JIRA issue link after creating the issue.)

## How was this patch tested?

The fix was verified manually using the Ratis membership example.

Test procedure:

1. Build and run the membership example.
2. Start a cluster with multiple peers.
3. Execute the `incr` command multiple times.
4. Execute the `query` command.

Before the fix:

```text
>>> incr
>>> incr
>>> query
Current counter value:
```

After the fix:

```text
>>> incr
>>> incr
>>> query
Current counter value: 2
```

The returned counter value now correctly reflects the state maintained by `CounterStateMachine`.
