### PR TITLE
RATIS-2568. Add Streaming Read to FileStore

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileInfo.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileInfo.java
@@ -19,11 +19,7 @@ package org.apache.ratis.examples.filestore;
 
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.apache.ratis.util.CollectionUtils;
-import org.apache.ratis.util.JavaUtils;
-import org.apache.ratis.util.LogUtils;
-import org.apache.ratis.util.Preconditions;
-import org.apache.ratis.util.TaskQueue;
+import org.apache.ratis.util.*;
 import org.apache.ratis.util.function.CheckedFunction;
 import org.apache.ratis.util.function.CheckedSupplier;
 import org.slf4j.Logger;
@@ -31,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.Files;
@@ -97,20 +94,15 @@ abstract class FileInfo {
           + ", path=" + getRelativePath());
     }
 
-    try (SeekableByteChannel in = Files.newByteChannel(
-        resolver.apply(getRelativePath()), StandardOpenOption.READ)) {
-      in.position(offset);
-      long remaining = length;
-      while (remaining > 0) {
-        final int chunkSize = FileStoreCommon.getChunkSize(remaining);
-        final ByteBuffer buffer = ByteBuffer.allocateDirect(chunkSize);
-        final int n = in.read(buffer);
+    try (FileChannel in = FileUtils.newFileChannel(
+            resolver.apply(getRelativePath()), StandardOpenOption.READ)) {
+      long transferred = 0;
+      while (transferred < length) {
+        final long n = in.transferTo(offset + transferred, length - transferred, stream);
         if (n <= 0) {
           break;
         }
-        buffer.flip();
-        stream.write(buffer);
-        remaining -= n;
+        transferred += n;
       }
     } finally {
       stream.close();

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileInfo.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileInfo.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.channels.WritableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -88,6 +89,34 @@ abstract class FileInfo {
     }
   }
 
+  void streamRead(CheckedFunction<Path, Path, IOException> resolver, long offset, long length,
+      WritableByteChannel stream) throws IOException {
+    if (offset + length > getWriteSize()) {
+      throw new IOException("Failed to read Wrote: offset (=" + offset
+          + " + length (=" + length + ") > size = " + getWriteSize()
+          + ", path=" + getRelativePath());
+    }
+
+    try (SeekableByteChannel in = Files.newByteChannel(
+        resolver.apply(getRelativePath()), StandardOpenOption.READ)) {
+      in.position(offset);
+      long remaining = length;
+      while (remaining > 0) {
+        final int chunkSize = FileStoreCommon.getChunkSize(remaining);
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(chunkSize);
+        final int n = in.read(buffer);
+        if (n <= 0) {
+          break;
+        }
+        buffer.flip();
+        stream.write(buffer);
+        remaining -= n;
+      }
+    } finally {
+      stream.close();
+    }
+  }
+
   UnderConstruction asUnderConstruction() {
     throw new UnsupportedOperationException(
         "File " + getRelativePath() + " is not under construction.");
@@ -119,6 +148,12 @@ abstract class FileInfo {
       super(f.getRelativePath());
       this.committedSize = f.getCommittedSize();
       this.writeSize = f.getWriteSize();
+    }
+
+    ReadOnly(Path relativePath, long size) {
+      super(relativePath);
+      this.committedSize = size;
+      this.writeSize = size;
     }
 
     @Override

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileInfo.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileInfo.java
@@ -89,7 +89,7 @@ abstract class FileInfo {
   void streamRead(CheckedFunction<Path, Path, IOException> resolver, long offset, long length,
       WritableByteChannel stream) throws IOException {
     if (offset + length > getWriteSize()) {
-      throw new IOException("Failed to read Wrote: offset (=" + offset
+      throw new IOException("Failed to read: offset (=" + offset
           + " + length (=" + length + ") > size = " + getWriteSize()
           + ", path=" + getRelativePath());
     }
@@ -99,11 +99,10 @@ abstract class FileInfo {
       long transferred = 0;
       while (transferred < length) {
         final long n = in.transferTo(offset + transferred, length - transferred, stream);
-        if (n <= 0) {
-          break;
-        }
+        Preconditions.assertTrue(n >= 0);
         transferred += n;
       }
+      Preconditions.assertSame(length, transferred, "transferred");
     } finally {
       stream.close();
     }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStore.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStore.java
@@ -43,6 +43,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -100,6 +101,11 @@ public class FileStore implements Closeable {
       if (previous instanceof FileInfo.Watch) {
         ((FileInfo.Watch) previous).complete(uc);
       }
+    }
+
+    void putReadOnly(ReadOnly ro) {
+      LOG.trace("{}: putReadOnly {}", name, ro.getRelativePath());
+      map.put(ro.getRelativePath(), ro);
     }
 
     ReadOnly close(UnderConstruction uc) {
@@ -208,6 +214,12 @@ public class FileStore implements Closeable {
     return submit(task, reader);
   }
 
+  void streamRead(String relative, long offset, long length, WritableByteChannel stream)
+      throws IOException {
+    final FileInfo info = files.get(relative);
+    info.streamRead(this::resolve, offset, length, stream);
+  }
+
   CompletableFuture<Path> delete(long index, String relative) {
     final Supplier<String> name = () -> "delete(" + relative + ") @" + getId() + ":" + index;
     final CheckedSupplier<Path, IOException> task = LogUtils.newCheckedSupplier(LOG, () -> {
@@ -284,13 +296,18 @@ public class FileStore implements Closeable {
 
   CompletableFuture<StreamWriteReplyProto> streamCommit(String p, long bytesWritten) {
     return CompletableFuture.supplyAsync(() -> {
+      final Path relative = normalize(p);
       final long len;
-      try (RandomAccessFile file = new RandomAccessFile(resolve(normalize(p)).toFile(), "r")) {
+      try (RandomAccessFile file = new RandomAccessFile(resolve(relative).toFile(), "r")) {
         len = file.length();
-        return StreamWriteReplyProto.newBuilder().setIsSuccess(len == bytesWritten).setByteWritten(len).build();
       } catch (IOException e) {
         throw new CompletionException("Failed to commit stream " + p + " with " + bytesWritten + " B.", e);
       }
+      final boolean success = len == bytesWritten;
+      if (success) {
+        files.putReadOnly(new ReadOnly(relative, len));
+      }
+      return StreamWriteReplyProto.newBuilder().setIsSuccess(success).setByteWritten(len).build();
     }, committer);
   }
 

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreClient.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreClient.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.examples.filestore;
 
 import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.client.api.DataStreamInput;
 import org.apache.ratis.client.api.DataStreamOutput;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.ExamplesProtos.DeleteReplyProto;
@@ -29,6 +30,8 @@ import org.apache.ratis.proto.ExamplesProtos.StreamWriteRequestProto;
 import org.apache.ratis.proto.ExamplesProtos.WriteReplyProto;
 import org.apache.ratis.proto.ExamplesProtos.WriteRequestHeaderProto;
 import org.apache.ratis.proto.ExamplesProtos.WriteRequestProto;
+import org.apache.ratis.proto.RaftProtos.DataStreamPacketHeaderProto.Type;
+import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftGroup;
@@ -39,6 +42,7 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.ProtoUtils;
+import org.apache.ratis.util.ReferenceCountedObject;
 import org.apache.ratis.util.function.CheckedFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +50,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Function;
@@ -195,6 +200,49 @@ public class FileStoreClient implements Closeable {
         .build();
     final FileStoreRequestProto request = FileStoreRequestProto.newBuilder().setStream(header).build();
     return client.getDataStreamApi().stream(request.toByteString().asReadOnlyByteBuffer(), routingTable);
+  }
+
+  public DataStreamInput getStreamInput(String path, long offset, long length) {
+    final ReadRequestProto read = ReadRequestProto.newBuilder()
+        .setPath(ProtoUtils.toByteString(path))
+        .setOffset(offset)
+        .setLength(length)
+        .build();
+    return client.getDataStreamApi().streamReadOnly(read.toByteString().asReadOnlyByteBuffer());
+  }
+
+  /**
+   * Read file data using streaming read and write it to the given channel.
+   *
+   * @return total number of bytes read.
+   */
+  public long streamRead(String path, long offset, long length, WritableByteChannel channel)
+      throws IOException {
+    long total = 0;
+    try (DataStreamInput in = getStreamInput(path, offset, length)) {
+      while (true) {
+        final ReferenceCountedObject<DataStreamReply> ref = in.readAsync().join();
+        try {
+          final DataStreamReply reply = ref.get();
+          if (reply.getType() == Type.STREAM_HEADER) {
+            Preconditions.assertTrue(reply.isSuccess(),
+                () -> "Failed to stream read " + path + ", reply=" + reply);
+            return total;
+          } else {
+            Preconditions.assertTrue(reply.isSuccess(),
+                    () -> "Failed to stream read " + path + ", reply=" + reply);
+            Preconditions.assertEquals(Type.STREAM_DATA, reply.getType(),
+                    "reply type for stream read " + path);
+            final ByteBuffer data = FileStoreCommon.getReplyBuffer(reply);
+            while (data.hasRemaining()) {
+              total += channel.write(data);
+            }
+          }
+        } finally {
+          ref.release();
+        }
+      }
+    }
   }
 
   public CompletableFuture<Long> writeAsync(String path, long offset, boolean close, ByteBuffer buffer, boolean sync) {

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreClient.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreClient.java
@@ -233,7 +233,7 @@ public class FileStoreClient implements Closeable {
                     () -> "Failed to stream read " + path + ", reply=" + reply);
             Preconditions.assertEquals(Type.STREAM_DATA, reply.getType(),
                     "reply type for stream read " + path);
-            final ByteBuffer data = FileStoreCommon.getReplyBuffer(reply);
+            final ByteBuffer data = reply.nioBuffer();
             while (data.hasRemaining()) {
               total += channel.write(data);
             }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreCommon.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreCommon.java
@@ -51,15 +51,6 @@ public interface FileStoreCommon {
     return ProtoUtils.toByteString(p.toString());
   }
 
-  static ByteBuffer getReplyBuffer(DataStreamReply reply) {
-    if (reply instanceof DataStreamReplyByteBuf) {
-      return ((DataStreamReplyByteBuf) reply).slice().nioBuffer();
-    } else if (reply instanceof DataStreamReplyByteBuffer) {
-      return ((DataStreamReplyByteBuffer) reply).slice();
-    }
-    throw new IllegalArgumentException("Unexpected reply: " + reply);
-  }
-
   static <T> CompletableFuture<T> completeExceptionally(
       long index, String message) {
     return completeExceptionally(index, message, null);

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreCommon.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreCommon.java
@@ -17,14 +17,10 @@
  */
 package org.apache.ratis.examples.filestore;
 
-import org.apache.ratis.datastream.impl.DataStreamReplyByteBuf;
-import org.apache.ratis.datastream.impl.DataStreamReplyByteBuffer;
-import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.*;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreCommon.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreCommon.java
@@ -17,10 +17,14 @@
  */
 package org.apache.ratis.examples.filestore;
 
+import org.apache.ratis.datastream.impl.DataStreamReplyByteBuf;
+import org.apache.ratis.datastream.impl.DataStreamReplyByteBuffer;
+import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.*;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 
@@ -45,6 +49,15 @@ public interface FileStoreCommon {
 
   static ByteString toByteString(Path p) {
     return ProtoUtils.toByteString(p.toString());
+  }
+
+  static ByteBuffer getReplyBuffer(DataStreamReply reply) {
+    if (reply instanceof DataStreamReplyByteBuf) {
+      return ((DataStreamReplyByteBuf) reply).slice().nioBuffer();
+    } else if (reply instanceof DataStreamReplyByteBuffer) {
+      return ((DataStreamReplyByteBuffer) reply).slice();
+    }
+    throw new IllegalArgumentException("Unexpected reply: " + reply);
   }
 
   static <T> CompletableFuture<T> completeExceptionally(

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
@@ -43,6 +43,7 @@ import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferExce
 import org.apache.ratis.util.FileUtils;
 
 import java.io.IOException;
+import java.nio.channels.WritableByteChannel;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -104,6 +105,24 @@ public class FileStoreStateMachine extends BaseStateMachine {
     return (proto.getIsWatch()? files.watch(path)
         : files.read(path, proto.getOffset(), proto.getLength(), true))
         .thenApply(reply -> Message.valueOf(reply.toByteString()));
+  }
+
+  @Override
+  public void query(Message request, WritableByteChannel stream) {
+    try {
+      final ReadRequestProto proto = ReadRequestProto.parseFrom(request.getContent());
+      if (proto.getIsWatch()) {
+        throw new IOException("Watch is not supported for streaming read: " + proto);
+      }
+      files.streamRead(proto.getPath().toStringUtf8(), proto.getOffset(), proto.getLength(), stream);
+    } catch (Exception e) {
+      LOG.error(getId() + ": Failed streaming read for " + request, e);
+      try {
+        stream.close();
+      } catch (IOException ignored) {
+        // ignore
+      }
+    }
   }
 
   @Override

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/FileStore.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/FileStore.java
@@ -35,6 +35,7 @@ public final class FileStore {
     commands.add(new Server());
     commands.add(new LoadGen());
     commands.add(new DataStream());
+    commands.add(new Read());
     return commands;
   }
 }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Read.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Read.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.examples.filestore.cli;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import org.apache.ratis.RaftConfigKeys;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.client.RaftClientConfigKeys;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.datastream.SupportedDataStreamType;
+import org.apache.ratis.examples.common.SubCommandBase;
+import org.apache.ratis.examples.filestore.FileStoreClient;
+import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.grpc.GrpcFactory;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.rpc.SupportedRpcType;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.util.FileUtils;
+import org.apache.ratis.util.SizeInBytes;
+import org.apache.ratis.util.TimeDuration;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Subcommand to read files from FileStore using streaming read.
+ */
+@Parameters(commandDescription = "Read files from FileStore using streaming read")
+public class Read extends SubCommandBase {
+
+  @Parameter(names = {"--files"}, description = "Comma-separated file names on the server", required = true)
+  private String files;
+
+  @Parameter(names = {"--size"}, description = "Number of bytes to read per file", required = true)
+  private long fileSizeInBytes;
+
+  @Parameter(names = {"--offset"}, description = "Offset to start reading from", required = false)
+  private long offset;
+
+  @Override
+  public void run() throws Exception {
+    final List<String> fileNames = Arrays.asList(files.split(","));
+    if (fileNames.isEmpty()) {
+      throw new IllegalArgumentException("No files specified in --files");
+    }
+
+    final RaftProperties raftProperties = newRaftProperties();
+
+    System.out.println("Starting streaming read now");
+
+    final long startTime = System.currentTimeMillis();
+    long totalReadBytes = 0;
+    final List<ReadResult> results = new ArrayList<>();
+    try (FileStoreClient client = newClient(raftProperties)) {
+      for (String fileName : fileNames) {
+        final String name = fileName.trim();
+        final ReadResult result = readFile(client, name);
+        results.add(result);
+        if (result.bytesRead != fileSizeInBytes) {
+          System.err.println("Error: file:" + name + " read:" + result.bytesRead
+              + " mismatch expected size:" + fileSizeInBytes);
+        }
+        totalReadBytes += result.bytesRead;
+      }
+    }
+
+    final long endTime = System.currentTimeMillis();
+    System.out.println("Total files read: " + fileNames.size());
+    for (ReadResult result : results) {
+      System.out.println("  " + result.fileName + " -> " + result.tempFile
+          + " (" + result.bytesRead + " bytes)");
+    }
+    System.out.println("Each file size: " + fileSizeInBytes);
+    System.out.println("Total data read: " + totalReadBytes + " bytes");
+    System.out.println("Total time taken: " + (endTime - startTime) + " millis");
+  }
+
+  private ReadResult readFile(FileStoreClient client, String fileName) throws IOException {
+    final File tempFile = Files.createTempFile("filestore-read-", "-" + fileName).toFile();
+    try (FileChannel out = FileUtils.newFileChannel(tempFile,
+        StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+      final long bytesRead = client.streamRead(fileName, offset, fileSizeInBytes, out);
+      return new ReadResult(fileName, tempFile.getAbsolutePath(), bytesRead);
+    } finally {
+      FileUtils.deleteFully(tempFile);
+    }
+  }
+
+  private static final class ReadResult {
+    private final String fileName;
+    private final String tempFile;
+    private final long bytesRead;
+
+    private ReadResult(String fileName, String tempFile, long bytesRead) {
+      this.fileName = fileName;
+      this.tempFile = tempFile;
+      this.bytesRead = bytesRead;
+    }
+  }
+
+  private static RaftProperties newRaftProperties() {
+    final int raftSegmentPreallocatedSize = 1024 * 1024 * 1024;
+    final RaftProperties raftProperties = new RaftProperties();
+    RaftConfigKeys.Rpc.setType(raftProperties, SupportedRpcType.GRPC);
+    GrpcConfigKeys.setMessageSizeMax(raftProperties, SizeInBytes.valueOf(raftSegmentPreallocatedSize));
+    RaftServerConfigKeys.Log.Appender.setBufferByteLimit(raftProperties,
+        SizeInBytes.valueOf(raftSegmentPreallocatedSize));
+    RaftServerConfigKeys.Log.setWriteBufferSize(raftProperties,
+        SizeInBytes.valueOf(raftSegmentPreallocatedSize));
+    RaftServerConfigKeys.Log.setPreallocatedSize(raftProperties,
+        SizeInBytes.valueOf(raftSegmentPreallocatedSize));
+    RaftServerConfigKeys.Log.setSegmentSizeMax(raftProperties, SizeInBytes.valueOf(raftSegmentPreallocatedSize));
+    RaftConfigKeys.DataStream.setType(raftProperties, SupportedDataStreamType.NETTY);
+    RaftServerConfigKeys.Log.setSegmentCacheNumMax(raftProperties, 2);
+    RaftClientConfigKeys.Rpc.setRequestTimeout(raftProperties,
+        TimeDuration.valueOf(50000, TimeUnit.MILLISECONDS));
+    return raftProperties;
+  }
+
+  private FileStoreClient newClient(RaftProperties raftProperties) throws IOException {
+    final RaftGroup raftGroup = RaftGroup.valueOf(
+        RaftGroupId.valueOf(ByteString.copyFromUtf8(getRaftGroupId())), getPeers());
+    final RaftClient client = RaftClient.newBuilder()
+        .setProperties(raftProperties)
+        .setRaftGroup(raftGroup)
+        .setClientRpc(new GrpcFactory(new org.apache.ratis.conf.Parameters())
+            .newRaftClientRpc(ClientId.randomId(), raftProperties))
+        .setPrimaryDataStreamServer(getPeers()[0])
+        .build();
+    return new FileStoreClient(client);
+  }
+}

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreStreamingBaseTest.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreStreamingBaseTest.java
@@ -104,6 +104,42 @@ public abstract class FileStoreStreamingBaseTest <CLUSTER extends MiniRaftCluste
     cluster.shutdown();
   }
 
+  @Test
+  public void testFileStoreStreamReadAfterStreamWrite() throws Exception {
+    final CLUSTER cluster = newCluster(NUM_PEERS);
+    cluster.start();
+    RaftTestUtil.waitForLeader(cluster);
+
+    final RaftGroup raftGroup = cluster.getGroup();
+    final Collection<RaftPeer> peers = raftGroup.getPeers();
+    final RaftPeer primary = cluster.getLeader().getPeer();
+
+    final CheckedSupplier<FileStoreClient, IOException> newClient =
+            () -> new FileStoreClient(cluster.getGroup(), getProperties(), primary);
+
+    final RoutingTable routingTable = DataStreamTestUtils.getRoutingTableChainTopology(peers, primary);
+    testSingleFileReadAfterStreamWrite("foo", SizeInBytes.valueOf("2M"), 10_000, newClient, routingTable);
+
+    cluster.shutdown();
+  }
+
+  private static void testSingleFileReadAfterStreamWrite(
+      String path, SizeInBytes fileLength, int bufferSize,
+      CheckedSupplier<FileStoreClient, IOException> newClient, RoutingTable routingTable)
+      throws Exception {
+    LOG.info("testSingleFileAfterStreamWrite with path={}, fileLength={}", path, fileLength);
+    FileStoreWriter.newBuilder()
+        .setFileName(path)
+        .setFileSize(fileLength)
+        .setBufferSize(bufferSize)
+        .setFileStoreClientSupplier(newClient)
+        .build()
+        .streamWrite(routingTable)
+        .streamRead()
+        .delete()
+        .close();
+  }
+
   private void testSingleFile(
       String path, SizeInBytes fileLength, int bufferSize, CheckedSupplier<FileStoreClient, IOException> newClient,
       RoutingTable routingTable)

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreWriter.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreWriter.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -133,7 +134,7 @@ final class FileStoreWriter implements Closeable {
     return this;
   }
 
-  public FileStoreWriter streamWriteAndVerify(RoutingTable routingTable) {
+  public FileStoreWriter streamWrite(RoutingTable routingTable) {
     final int size = fileSize.getSizeInt();
     final DataStreamOutput dataStreamOutput = client.getStreamOutput(fileName, size, routingTable);
     final List<CompletableFuture<DataStreamReply>> futures = new ArrayList<>();
@@ -156,8 +157,6 @@ final class FileStoreWriter implements Closeable {
     DataStreamReply reply = dataStreamOutput.closeAsync().join();
     Assertions.assertTrue(reply.isSuccess());
 
-    // TODO: handle when any of the writeAsync has failed.
-    // check writeAsync requests
     for (int i = 0; i < futures.size(); i++) {
       reply = futures.get(i).join();
       Assertions.assertTrue(reply.isSuccess());
@@ -167,6 +166,37 @@ final class FileStoreWriter implements Closeable {
 
     return this;
   }
+
+  public FileStoreWriter streamWriteAndVerify(RoutingTable routingTable) {
+    return streamWrite(routingTable);
+  }
+
+  FileStoreWriter streamRead() throws IOException {
+    final long expected = fileSize.getSizeInt();
+    final long bytesRead = client.streamRead(fileName, 0, expected, DISCARD);
+    Assertions.assertEquals(expected, bytesRead,
+        () -> "stream read " + fileName + ": expected " + expected + " bytes");
+    LOG.info("Stream read successful: {} bytes from {}", bytesRead, fileName);
+    return this;
+  }
+
+  private static final WritableByteChannel DISCARD = new WritableByteChannel() {
+    @Override
+    public int write(ByteBuffer src) {
+      final int n = src.remaining();
+      src.position(src.limit());
+      return n;
+    }
+
+    @Override
+    public boolean isOpen() {
+      return true;
+    }
+
+    @Override
+    public void close() {
+    }
+  };
 
   CompletableFuture<FileStoreWriter> writeAsync(boolean sync) {
     Objects.requireNonNull(asyncExecutor, "asyncExecutor == null");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add streaming read support to the FileStore example, mirroring the existing data-stream write path and building on RATIS-2546 (DataStreamApi.streamReadOnly).

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2568

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
1. Unit test
2. Manually test through command line and run FileStore cli.
