### PR TITLE
RATIS-2572. Empty dir annotations/ in ratis-proto.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -526,6 +526,11 @@
             <compilerArgs>
               <arg>-Xlint:all,-options,-path</arg>
             </compilerArgs>
+            <!-- hopefully can be removed after upgrade to maven-compiler-plugin 4.0 or later,
+                 if empty annotations/ dir is fixed by: https://github.com/apache/maven-compiler-plugin/commit/d958a62 -->
+            <generatedSourcesDirectory>${project.build.directory}/generated-sources</generatedSourcesDirectory>
+            <!-- no annotation processing -->
+            <proc>none</proc>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`maven-compiler-plugin` creates the directory for sources generated by annotation processors (defined by [`<generatedSourcesDirectory>`](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#generatedSourcesDirectory), with default value `${project.build.directory}/generated-sources/annotations`) even if there are no processors to run.  This will be fixed by https://github.com/apache/maven-compiler-plugin/commit/d958a62 in 4.0.0.

`ratis-proto` also has sources generated for proto definitions.  It is not clear why the empty `generated-sources/annotations` ends up in `ratis-proto.jar` in some environments, but not in others.

As a workaround, this PR sets the `<generatedSourcesDirectory>` to `target/generated-sources`, which is created anyway for `ratis-proto`.

Also add `<proc>none</proc>` to ensure annotation processors are indeed not used.

https://issues.apache.org/jira/browse/RATIS-2572

## How was this patch tested?

Verified no `annotations/` in `generated-sources`:

```bash
$ ./mvnw -am -pl :ratis-proto -DskipTests clean verify
...

$ ls ratis-proto/target/generated-sources
org
```

`ratis-proto.jar` does not contain `annotations/` for me even without this patch.  I hope @OneSizeFitsQuorum, the release manager of 3.2.2, can verify it locally.

CI:
https://github.com/adoroszlai/ratis/actions/runs/28187818390