### PR TITLE
RATIS-2573. Use Java 25 in CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -30,8 +30,8 @@ on:
       # OPTIONAL (ordered alphabetically)
       java-version:
         type: string
-        description: "Java version to set up (default: 17)"
-        default: '17'
+        description: "Java version to set up (default: 25)"
+        default: '25'
         required: false
 
       needs-binary-tarball:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - build
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21 ]
+        java: [ 8, 11, 17, 21, 25 ]
       fail-fast: false
     uses: ./.github/workflows/check.yaml
     with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - build
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21, 25 ]
+        java: [ 8, 17, 21, 25 ]
       fail-fast: false
     uses: ./.github/workflows/check.yaml
     with:

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,7 @@
     <slf4j.version>2.0.18</slf4j.version>
     <junit-bom.version>5.14.4</junit-bom.version>
     <mockito.version>4.11.0</mockito.version>
+    <byte-buddy.version>1.18.10</byte-buddy.version>
     <jacoco.version>0.8.15</jacoco.version>
     <flaky-test-groups>flaky | org.apache.ratis.test.tag.FlakyTest</flaky-test-groups>
 
@@ -407,6 +408,16 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>${byte-buddy.version}</version>
+      </dependency>
+      <dependency>
+      <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>${byte-buddy.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,12 @@
     <mockito.version>4.11.0</mockito.version>
     <jacoco.version>0.8.15</jacoco.version>
     <flaky-test-groups>flaky | org.apache.ratis.test.tag.FlakyTest</flaky-test-groups>
+
+    <extraJavaTestArgs>
+      -XX:+IgnoreUnrecognizedVMOptions
+      --enable-native-access=ALL-UNNAMED
+      --sun-misc-unsafe-memory-access=allow
+    </extraJavaTestArgs>
   </properties>
 
   <dependencyManagement>
@@ -564,7 +570,7 @@
             <enableProcessChecker>all</enableProcessChecker>
             <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
             <!-- @argLine is filled by jacoco maven plugin. @{} means late evaluation -->
-            <argLine>-Xmx2g -XX:+HeapDumpOnOutOfMemoryError @{argLine}</argLine>
+            <argLine>-Xmx2g -XX:+HeapDumpOnOutOfMemoryError ${extraJavaTestArgs} @{argLine}</argLine>
             <systemPropertyVariables>
               <ratis.log.dir>${project.build.directory}/log</ratis.log.dir>
               <ratis.tmp.dir>${project.build.directory}/tmp</ratis.tmp.dir>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use Java 25 for building and testing Ratis in CI, still targeting Java 8.

- Add options to allow using `sun.misc.Unsafe` and loading native libraries.  (These will also need to be allowed in Ratis scripts, separately.)
- Upgrade `byte-buddy` for Java 25 compatibility (used by Mockito, which we cannot upgrade due to dropping Java 8 support).
- Drop Java 11 from compile check matrix to keep resource usage the same.

https://issues.apache.org/jira/browse/RATIS-2573

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis/actions/runs/28223570864