### PR TITLE
RATIS-2581. Route file operations through NIO.2

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/AtomicFileOutputStream.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/AtomicFileOutputStream.java
@@ -109,8 +109,10 @@ public final class AtomicFileOutputStream extends FilterOutputStream {
     } catch (IOException ioe) {
       LOG.warn("Unable to abort file " + tmpFile, ioe);
     } finally {
-      if (!tmpFile.delete()) {
-        LOG.warn("Unable to delete tmp file during abort " + tmpFile);
+      try {
+        FileUtils.deleteIfExists(tmpFile);
+      } catch (IOException ioe) {
+        LOG.warn("Unable to delete tmp file during abort " + tmpFile, ioe);
       }
     }
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/BufferedWriteChannel.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.raftlog.segmented;
 
+import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.function.CheckedBiFunction;
 import org.apache.ratis.util.function.CheckedConsumer;
@@ -26,9 +27,9 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
@@ -44,8 +45,8 @@ class BufferedWriteChannel implements Closeable {
 
   @SuppressWarnings("java:S2095") // return Closable
   static BufferedWriteChannel open(File file, boolean append, ByteBuffer buffer) throws IOException {
-    final RandomAccessFile raf = new RandomAccessFile(file, "rw");
-    final FileChannel fc = raf.getChannel();
+    final FileChannel fc = FileUtils.newFileChannel(file,
+        StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
     final long size = file.length(); // 0L if the file does not exist.
     if (append) {
       fc.position(size);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegmentPath.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegmentPath.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.server.raftlog.segmented;
 
 import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,7 +118,7 @@ public final class LogSegmentPath {
 
       LOG.info("Found zero size open segment file " + path);
       try {
-        Files.delete(path);
+        FileUtils.delete(path);
         LOG.info("Deleted zero size open segment file " + path);
       } catch (IOException e) {
         LOG.warn("Failed to delete zero size open segment file " + path + ": " + e);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Route a few remaining Ratis file operations through Java NIO.2 so they can be intercepted by the default `FileSystemProvider`.

This patch removes direct use of `File.delete()` from `AtomicFileOutputStream#abort`, opens segmented log write channels through `FileChannel.open(Path, ...)` instead of `RandomAccessFile#getChannel`, and routes zero-size open log segment deletion through `FileUtils`.

With these changes, downstream projects that install a custom default `FileSystemProvider` can cover these cleanup and truncate paths without adding a Ratis-specific file destruction API.

https://issues.apache.org/jira/browse/RATIS-2581

## How was this patch tested?

- Ran `git diff --check` and `git diff --cached --check`.
- Ran `./mvnw -pl ratis-common -Dtest=TestFileUtils test`.
- Ran `./mvnw -pl ratis-server -am -DskipTests compile`.
