### PR TITLE
RATIS-2596. Unsupported TLS cipher suites may crash gRPC servers

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
@@ -33,10 +33,10 @@ import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.ApplicationProtocolConfig;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.ClientAuth;
-import org.apache.ratis.thirdparty.io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContext;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import org.apache.ratis.util.IOUtils;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.LogUtils;
@@ -339,7 +339,7 @@ public interface GrpcUtil {
     }
     final List<String> cipherSuites = tlsConf.getCipherSuites();
     if (cipherSuites != null && !cipherSuites.isEmpty()) {
-      b.ciphers(cipherSuites, IdentityCipherSuiteFilter.INSTANCE);
+      b.ciphers(cipherSuites, SupportedCipherSuiteFilter.INSTANCE);
     }
     return b;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In case TLS ciphers are configurable, it is possible to configure ciphers that are not supported by Netty.
This patch changes the IdentityCipherSuiteFilter to the SupportedCipherSuiteFilter in GrpcUtil.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2596

## How was this patch tested?
What is changing is tested functionality, the issue has appeared already elsewhere, I did not perform any particular tests as this exact changed worked well in the previous occurance (HDDS-15176).