### PR TITLE
RATIS-2598. TLS provider/protocol/cipher config is not applied to DataStream server/client.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/NettyUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/NettyUtils.java
@@ -36,6 +36,8 @@ import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioServerSocketCh
 import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContext;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import org.apache.ratis.thirdparty.io.netty.util.concurrent.Future;
 import org.apache.ratis.thirdparty.io.netty.util.concurrent.ScheduledFuture;
 import org.slf4j.Logger;
@@ -172,7 +174,7 @@ public interface NettyUtils {
     if (tlsConf.isMutualTls()) {
       setTrustManager(b, tlsConf.getTrustManager());
     }
-    return b;
+    return configureSslContextBuilder(b, tlsConf);
   }
 
   static SslContext buildSslContextForServer(TlsConf tlsConf) {
@@ -184,6 +186,32 @@ public interface NettyUtils {
     setTrustManager(b, tlsConf.getTrustManager());
     if (tlsConf.isMutualTls()) {
       setKeyManager(b, tlsConf.getKeyManager());
+    }
+    return configureSslContextBuilder(b, tlsConf);
+  }
+
+  /**
+   * Apply the {@link SslProvider}, enabled TLS protocols and cipher suites from the given
+   * {@link TlsConf} to the builder, so that the Netty DataStream transport honours the same
+   * configuration instead of falling back on the provider defaults.
+   *
+   * <p>Unlike the gRPC path ({@code GrpcUtil.configureSslContextBuilder}) this uses
+   * {@link SupportedCipherSuiteFilter}, which intersects the requested cipher suites with the
+   * ones actually supported by the negotiated provider/engine, rather than passing them through
+   * verbatim.
+   */
+  static SslContextBuilder configureSslContextBuilder(SslContextBuilder b, TlsConf tlsConf) {
+    final SslProvider sslProvider = tlsConf.getSslProvider();
+    if (sslProvider != null) {
+      b.sslProvider(sslProvider);
+    }
+    final List<String> protocols = tlsConf.getProtocols();
+    if (protocols != null && !protocols.isEmpty()) {
+      b.protocols(protocols.toArray(new String[0]));
+    }
+    final List<String> cipherSuites = tlsConf.getCipherSuites();
+    if (cipherSuites != null && !cipherSuites.isEmpty()) {
+      b.ciphers(cipherSuites, SupportedCipherSuiteFilter.INSTANCE);
     }
     return b;
   }

--- a/ratis-common/src/main/java/org/apache/ratis/util/NettyUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/NettyUtils.java
@@ -45,6 +45,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.TrustManager;
+import java.security.Provider;
+import java.security.Security;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -191,7 +193,7 @@ public interface NettyUtils {
   }
 
   /**
-   * Apply the {@link SslProvider}, enabled TLS protocols and cipher suites from the given
+   * Apply the {@link SslProvider}, JSSE provider, enabled TLS protocols and cipher suites from the given
    * {@link TlsConf} to the builder, so that the Netty DataStream transport honours the same
    * configuration instead of falling back on the provider defaults.
    *
@@ -205,15 +207,35 @@ public interface NettyUtils {
     if (sslProvider != null) {
       b.sslProvider(sslProvider);
     }
+    final Provider jsseProvider = getJsseProvider(tlsConf);
+    if (jsseProvider != null) {
+      b.sslProvider(SslProvider.JDK).sslContextProvider(jsseProvider);
+    }
     final List<String> protocols = tlsConf.getProtocols();
     if (protocols != null && !protocols.isEmpty()) {
-      b.protocols(protocols.toArray(new String[0]));
+      b.protocols(protocols);
     }
     final List<String> cipherSuites = tlsConf.getCipherSuites();
     if (cipherSuites != null && !cipherSuites.isEmpty()) {
       b.ciphers(cipherSuites, SupportedCipherSuiteFilter.INSTANCE);
     }
     return b;
+  }
+
+  /**
+   * @return the named JSSE {@link Provider} from {@link TlsConf#getJsseProviderName()}, or null when
+   *     unset; throws {@link IllegalArgumentException} when the named provider is not registered.
+   */
+  static Provider getJsseProvider(TlsConf tlsConf) {
+    final String providerName = tlsConf.getJsseProviderName();
+    if (providerName == null || providerName.trim().isEmpty()) {
+      return null;
+    }
+    final Provider namedProvider = Security.getProvider(providerName.trim());
+    if (namedProvider == null) {
+      throw new IllegalArgumentException("JSSE provider not found: " + providerName);
+    }
+    return namedProvider;
   }
 
   static SslContext buildSslContextForClient(TlsConf tlsConf) {

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
@@ -50,7 +50,6 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManager;
 import java.io.IOException;
 import java.security.Provider;
-import java.security.Security;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -58,6 +57,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider.OPENSSL;
+import static org.apache.ratis.util.NettyUtils.getJsseProvider;
 
 public interface GrpcUtil {
   Logger LOG = LoggerFactory.getLogger(GrpcUtil.class);
@@ -355,18 +355,6 @@ public interface GrpcUtil {
           .applicationProtocolConfig(ALPN)
           .sslContextProvider(provider);
     }
-  }
-
-  static Provider getJsseProvider(TlsConf tlsConf) {
-    final String providerName = tlsConf.getJsseProviderName();
-    if (providerName == null || providerName.trim().isEmpty()) {
-      return null;
-    }
-    final Provider namedProvider = Security.getProvider(providerName.trim());
-    if (namedProvider == null) {
-      throw new IllegalArgumentException("JSSE provider not found: " + providerName);
-    }
-    return namedProvider;
   }
 
   static SslContext buildSslContextForServer(GrpcTlsConfig tlsConf) {

--- a/ratis-test/src/test/java/org/apache/ratis/netty/TestTlsConfWithNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/netty/TestTlsConfWithNetty.java
@@ -156,6 +156,19 @@ public class TestTlsConfWithNetty {
     runTest(randomPort(), serverTlsConfig, clientTlsConfig);
   }
 
+  /** An unset JSSE provider name resolves to null (no provider override). See RATIS-2598. */
+  @Test
+  public void testNoJsseProviderReturnsNull() {
+    Assertions.assertNull(NettyUtils.getJsseProvider(TlsConf.newBuilder().build()));
+  }
+
+  /** An unknown JSSE provider name must fail fast rather than be silently ignored. */
+  @Test
+  public void testUnknownJsseProviderThrows() {
+    final TlsConf conf = TlsConf.newBuilder().setJsseProviderName("NoSuchJsseProvider").build();
+    Assertions.assertThrows(IllegalArgumentException.class, () -> NettyUtils.getJsseProvider(conf));
+  }
+
   static void runTest(int port, TlsConf serverSslConf, TlsConf clientSslConf) throws Exception {
     final SslContext serverSslContext = serverSslConf == null? null
         : NettyUtils.buildSslContextForServer(serverSslConf);

--- a/ratis-test/src/test/java/org/apache/ratis/netty/TestTlsConfWithNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/netty/TestTlsConfWithNetty.java
@@ -37,6 +37,7 @@ import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.logging.LogLevel;
 import org.apache.ratis.thirdparty.io.netty.handler.logging.LoggingHandler;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContext;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.NettyUtils;
 import org.junit.jupiter.api.Assertions;
@@ -47,6 +48,8 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -90,6 +93,66 @@ public class TestTlsConfWithNetty {
   public void testSsl() throws Exception {
     final TlsConf serverTlsConfig = SecurityTestUtils.newServerTlsConfig(true);
     final TlsConf clientTlsConfig = SecurityTestUtils.newClientTlsConfig(true);
+    runTest(randomPort(), serverTlsConfig, clientTlsConfig);
+  }
+
+  /** RSA-certificate cipher, broadly supported on the JDK provider for TLSv1.2. */
+  private static final String VALID_CIPHER = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
+  private static final String UNSUPPORTED_CIPHER = "TLS_UNSUPPORTED_BOGUS_CIPHER";
+  private static final List<String> TLS_1_2 = Collections.singletonList("TLSv1.2");
+
+  static TlsConf newServerTlsConfig(SslProvider provider, List<String> protocols, List<String> cipherSuites) {
+    return TlsConf.newBuilder()
+        .setName("server")
+        .setPrivateKey(new TlsConf.PrivateKeyConf(SecurityTestUtils.getResource("ssl/server.pem")))
+        .setKeyCertificates(new TlsConf.CertificatesConf(SecurityTestUtils.getResource("ssl/server.crt")))
+        .setSslProvider(provider)
+        .setProtocols(protocols)
+        .setCipherSuites(cipherSuites)
+        .build();
+  }
+
+  static TlsConf newClientTlsConfig(SslProvider provider, List<String> protocols, List<String> cipherSuites) {
+    return TlsConf.newBuilder()
+        .setName("client")
+        .setTrustCertificates(new TlsConf.CertificatesConf(SecurityTestUtils.getResource("ssl/ca.crt")))
+        .setSslProvider(provider)
+        .setProtocols(protocols)
+        .setCipherSuites(cipherSuites)
+        .build();
+  }
+
+  /**
+   * The configured cipher suites must actually be applied to the {@link SslContext}; previously
+   * they were silently dropped on the Netty path. See RATIS-2598.
+   */
+  @Test
+  public void testConfiguredCipherSuitesAreApplied() {
+    final SslContext ctx = NettyUtils.buildSslContextForServer(
+        newServerTlsConfig(SslProvider.JDK, TLS_1_2, Collections.singletonList(VALID_CIPHER)));
+    Assertions.assertEquals(Collections.singletonList(VALID_CIPHER), ctx.cipherSuites());
+  }
+
+  /**
+   * An unsupported cipher suite must be filtered out rather than passed through verbatim; otherwise
+   * building the {@link SslContext} fails and crashes the server. See RATIS-2598.
+   */
+  @Test
+  public void testUnsupportedCipherSuiteIsFilteredOut() {
+    final SslContext ctx = NettyUtils.buildSslContextForServer(
+        newServerTlsConfig(SslProvider.JDK, TLS_1_2, Arrays.asList(UNSUPPORTED_CIPHER, VALID_CIPHER)));
+    Assertions.assertEquals(Collections.singletonList(VALID_CIPHER), ctx.cipherSuites());
+  }
+
+  /**
+   * End-to-end handshake with explicit protocol and cipher configuration, including an unsupported
+   * cipher that must be filtered out without breaking the handshake.
+   */
+  @Test
+  public void testSslWithProtocolAndCipher() throws Exception {
+    final List<String> ciphers = Arrays.asList(UNSUPPORTED_CIPHER, VALID_CIPHER);
+    final TlsConf serverTlsConfig = newServerTlsConfig(SslProvider.JDK, TLS_1_2, ciphers);
+    final TlsConf clientTlsConfig = newClientTlsConfig(SslProvider.JDK, TLS_1_2, ciphers);
     runTest(randomPort(), serverTlsConfig, clientTlsConfig);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The TLS provider, protocol list, and cipher suites configured on a TlsConf were applied on the gRPC transport but ignored on the Netty DataStream transport, so the DataStream server and client always used the provider defaults.

This adds a small helper in NettyUtils that applies those settings when building the SslContext, and calls it for both the server and client. Ciphers are applied through SupportedCipherSuiteFilter (rather than the gRPC path's IdentityCipherSuiteFilter) so that an unsupported or misspelled cipher is dropped instead of crashing the server. Nothing changes when these settings are left unset.

The getJsseProvider method from GrpcUtil is moved to NettyUtils, and utilized there also to configure the JSSE provider for streaming server/client side similarly as it is dine for gRPC.

Generated-by: Claude Code (Claude Opus 4.8)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2598

## How was this patch tested?

Added three tests to TestTlsConfWithNetty covering the real NettyUtils code path: one checks that a configured cipher actually ends up on the SslContext, one checks that an unsupported cipher is filtered out instead of failing the build, and one runs a full TLSv1.2 handshake with an explicit protocol and cipher list. All five tests in the class pass, and checkstyle is clean on the two changed modules.