### PR TITLE
RATIS-2610. -groupid should check for non-empty ID

### DIFF
--- a/ratis-shell/src/main/java/org/apache/ratis/shell/cli/CliUtils.java
+++ b/ratis-shell/src/main/java/org/apache/ratis/shell/cli/CliUtils.java
@@ -96,7 +96,7 @@ public final class CliUtils {
 
   /** Parse the given string as a {@link RaftGroupId}. */
   public static RaftGroupId parseRaftGroupId(String groupId) {
-    return groupId != null && groupId.isEmpty() ? RaftGroupId.valueOf(UUID.fromString(groupId)) : null;
+    return groupId != null && !groupId.isEmpty() ? RaftGroupId.valueOf(UUID.fromString(groupId)) : null;
   }
 
   /**

--- a/ratis-test/src/test/java/org/apache/ratis/shell/cli/TestCliUtils.java
+++ b/ratis-test/src/test/java/org/apache/ratis/shell/cli/TestCliUtils.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.shell.cli;
 
+import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.UUID;
 
 public class TestCliUtils {
 
@@ -60,5 +62,28 @@ public class TestCliUtils {
   public void testParseRejectsScheme() {
     Assertions.assertThrows(IllegalArgumentException.class,
         () -> CliUtils.parseInetSocketAddress("http://127.0.0.1:6000"));
+  }
+
+  @Test
+  public void testParseRaftGroupIdNull() {
+    Assertions.assertNull(CliUtils.parseRaftGroupId(null));
+  }
+
+  @Test
+  public void testParseRaftGroupIdEmpty() {
+    Assertions.assertNull(CliUtils.parseRaftGroupId(""));
+  }
+
+  @Test
+  public void testParseRaftGroupIdValid() {
+    final UUID uuid = UUID.randomUUID();
+    final RaftGroupId groupId = CliUtils.parseRaftGroupId(uuid.toString());
+    Assertions.assertEquals(RaftGroupId.valueOf(uuid), groupId);
+  }
+
+  @Test
+  public void testParseRaftGroupIdInvalid() {
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> CliUtils.parseRaftGroupId("not-a-uuid"));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

RATIS-2610. -groupid should check for non-empty ID

In [this](https://github.com/apache/ratis/blob/f4c3781468e756220836e88d953fd5598177afdf/ratis-shell/src/main/java/org/apache/ratis/shell/cli/CliUtils.java#L99) line a valid non-empty UUID returns `null`.
The check should be `!groupId.isEmpty()` .

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2610

## How was this patch tested?
Patch was tested via existing unit tests and newly added tests