### PR TITLE
RATIS-2616. Bump ratis-thirdparty-misc to 1.1.0.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,8 @@ updates:
     cooldown:
       default-days: 7
     ignore:
+      # ratis-thirdparty have to be updated together with gRPC and protobuf
+      - dependency-name: "org.apache.ratis:ratis-thirdparty-misc"
       # requires Java 11
       - dependency-name: "com.github.spotbugs:spotbugs"
         versions: [">=4.9.0"]

--- a/pom.xml
+++ b/pom.xml
@@ -177,11 +177,11 @@
     <maven.compiler.release>${javaVersion}</maven.compiler.release>
 
     <!-- Contains all shaded thirdparty dependencies; make sure to also update in ratis-bom/pom.xml -->
-    <ratis.thirdparty.version>1.0.11</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.1.0</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
-    <shaded.protobuf.version>3.25.8</shaded.protobuf.version>
-    <shaded.grpc.version>1.77.1</shaded.grpc.version>
+    <shaded.protobuf.version>3.25.9</shaded.protobuf.version>
+    <shaded.grpc.version>1.82.2</shaded.grpc.version>
 
     <!-- OpenTelemetry versions -->
     <opentelemetry.version>1.64.0</opentelemetry.version>


### PR DESCRIPTION
See RATIS-2616.

Also update dependabot to ignore ratis-thirdparty-misc since it is not able to update also the gRPC and protobuf versions.