### PR TITLE
RATIS-2632. Apply backpressure on install-snapshot chunk loop

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/StreamObserverWithTimeout.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/util/StreamObserverWithTimeout.java
@@ -19,6 +19,7 @@ package org.apache.ratis.grpc.util;
 
 import org.apache.ratis.protocol.exceptions.TimeoutIOException;
 import org.apache.ratis.thirdparty.io.grpc.ClientInterceptor;
+import org.apache.ratis.thirdparty.io.grpc.stub.CallStreamObserver;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.ResourceSemaphore;
@@ -95,11 +96,32 @@ public final class StreamObserverWithTimeout<T> implements StreamObserver<T> {
     }
   }
 
+  /**
+   * Wait while the underlying stream is not ready providing backpressure
+   * in addition to the outstanding-request semaphore.
+   */
+  private void awaitReady(StringSupplier request) {
+    if (!(observer instanceof CallStreamObserver)) {
+      return;
+    }
+    final CallStreamObserver<T> callStreamObserver = (CallStreamObserver<T>) observer;
+    while (!callStreamObserver.isReady() && !isClose.get()) {
+      try {
+        TimeDuration.ONE_MILLISECOND.sleep();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException(name + ": Interrupted while waiting for the stream to be ready to send "
+            + request, e);
+      }
+    }
+  }
+
   @Override
   public void onNext(T request) {
     final StringSupplier requestString = StringSupplier.get(() -> requestToStringFunction.apply(request));
     final TimeDuration timeout = timeoutSupplier.get();
     acquire(requestString, timeout);
+    awaitReady(requestString);
     observer.onNext(request);
     final int id = requestCount.incrementAndGet();
     LOG.debug("{}: send {} with timeout={}: {}", name, id, timeout, requestString);

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/util/TestStreamObserverWithTimeout.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/util/TestStreamObserverWithTimeout.java
@@ -20,6 +20,7 @@ package org.apache.ratis.grpc.util;
 import org.apache.ratis.BaseTest;
 import org.apache.ratis.grpc.util.GrpcTestClient.StreamObserverFactory;
 import org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException;
+import org.apache.ratis.thirdparty.io.grpc.stub.CallStreamObserver;
 import org.apache.ratis.util.NetUtils;
 import org.apache.ratis.util.Slf4jUtils;
 import org.apache.ratis.util.StringUtils;
@@ -30,9 +31,11 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 public class TestStreamObserverWithTimeout extends BaseTest {
@@ -76,6 +79,58 @@ public class TestStreamObserverWithTimeout extends BaseTest {
     //Each sleep time is within the timeout,
     //Note that the total sleep time is longer than the timeout, but it does not matter.
     runTestTimeout(5, Type.WithTimeout);
+  }
+
+  /** A {@link CallStreamObserver} whose readiness and delivered messages can be inspected. */
+  private static final class ReadinessControlledObserver extends CallStreamObserver<String> {
+    private volatile boolean ready;
+    private final List<String> delivered = Collections.synchronizedList(new ArrayList<>());
+
+    ReadinessControlledObserver(boolean ready) {
+      this.ready = ready;
+    }
+
+    void setReady(boolean isReady) {
+      this.ready = isReady;
+    }
+
+    @Override public boolean isReady() {
+      return ready;
+    }
+    @Override public void onNext(String value) {
+      delivered.add(value);
+    }
+    @Override public void onError(Throwable t) { }
+    @Override public void onCompleted() { }
+    @Override public void setOnReadyHandler(Runnable onReadyHandler) { }
+    @Override public void disableAutoInboundFlowControl() { }
+    @Override public void request(int count) { }
+    @Override public void setMessageCompression(boolean enable) { }
+  }
+
+  /**
+   * When the outstanding-request limit is 0 (semaphore disabled), the only backpressure is
+   * {@link CallStreamObserver#isReady()}. onNext must stall while the stream is not ready so that
+   * requests are not buffered.
+   */
+  @Test
+  public void testOnNextWaitsForReadyWhenUnbounded() throws Exception {
+    final ReadinessControlledObserver observer = new ReadinessControlledObserver(false);
+    final StreamObserverWithTimeout<String> withTimeout = StreamObserverWithTimeout.newInstance(
+        "test", Function.identity(), () -> TimeDuration.valueOf(60, TimeUnit.SECONDS), 0,
+        interceptor -> observer);
+
+    final CompletableFuture<Void> sent = CompletableFuture.runAsync(() -> withTimeout.onNext("m1"));
+
+    // Not ready: the request must be held back rather than delivered.
+    Thread.sleep(100);
+    Assertions.assertFalse(sent.isDone(), "onNext should block while the stream is not ready");
+    Assertions.assertTrue(observer.delivered.isEmpty(), "request must not be sent while the stream is not ready");
+
+    // Becomes ready: the request should now be delivered and onNext should return.
+    observer.setReady(true);
+    sent.get(5, TimeUnit.SECONDS);
+    Assertions.assertEquals(Collections.singletonList("m1"), observer.delivered);
   }
 
   void runTestTimeout(int slow, Type type) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

RATIS-2632. Apply backpressure on install-snapshot chunk loop

When the leader streams a snapshot to a lagging follower, the chunk send loop in [GrpcLogAppender.installSnapshot()](https://github.com/apache/ratis/blob/a1bbf47f98a83d3bbddb4357c8a9b96bcfd7c727/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java#L775-L783) calls `snapshotRequestObserver.onNext(request)` for every chunk without ever checking `CallStreamObserver.isReady()`.

The append-entries path already [checks isReady()](https://github.com/apache/ratis/blob/a1bbf47f98a83d3bbddb4357c8a9b96bcfd7c727/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java#L366), but the snapshot path does not, so it is possible that chunks are enqueued faster than the network can drain them.

While on the default path `INSTALL_SNAPSHOT_REQUEST_ELEMENT_LIMIT_DEFAULT` is set to 8 so `StreamObserverWithTimeout` applies a request-response window, but since we allow setting the limit to 0, the semaphore can be `null` and cause:

- Unbounded outbound buffering of snapshot chunks in the gRPC/Netty write queue when the follower is slow.
- Leader OOM / direct-memory exhaustion during large-snapshot catch-up, which can crash the leader and impact the whole group.

This is handled by having an explicit isReady() check, which causes minimal overhead on the default path (`element-limit=8`) but handles the case when it might be set to 0.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-2632

## How was this patch tested?
Patch was tested via unit tests.