### PR TITLE
RATIS-2640. Fix AdminApi.setConfiguration(RaftPeer[], RaftPeer[]) dropping the servers array

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/api/AdminApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/AdminApi.java
@@ -60,7 +60,7 @@ public interface AdminApi {
       throws IOException {
     return setConfiguration(SetConfigurationRequest.Arguments
         .newBuilder()
-        .setListenersInNewConf(serversInNewConf)
+        .setServersInNewConf(serversInNewConf)
         .setListenersInNewConf(listenersInNewConf)
         .build());
   }

--- a/ratis-test/src/test/java/org/apache/ratis/client/TestAdminApi.java
+++ b/ratis-test/src/test/java/org/apache/ratis/client/TestAdminApi.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.client;
+
+import org.apache.ratis.BaseTest;
+import org.apache.ratis.client.api.AdminApi;
+import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.protocol.SetConfigurationRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Test the default methods of {@link AdminApi}. */
+public class TestAdminApi extends BaseTest {
+  static AdminApi newCapturingAdminApi(AtomicReference<SetConfigurationRequest.Arguments> captured) {
+    return new AdminApi() {
+      @Override
+      public RaftClientReply setConfiguration(SetConfigurationRequest.Arguments arguments) {
+        captured.set(arguments);
+        return null;
+      }
+
+      @Override
+      public RaftClientReply transferLeadership(RaftPeerId newLeader, RaftPeerId leaderId, long timeoutMs) {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  static RaftPeer newPeer(String id) {
+    return RaftPeer.newBuilder().setId(id).build();
+  }
+
+  @Test
+  public void testSetConfigurationWithArrays() throws Exception {
+    final RaftPeer[] servers = {newPeer("s0"), newPeer("s1"), newPeer("s2")};
+    final RaftPeer[] listeners = {newPeer("l0")};
+
+    final AtomicReference<SetConfigurationRequest.Arguments> captured = new AtomicReference<>();
+    newCapturingAdminApi(captured).setConfiguration(servers, listeners);
+
+    final SetConfigurationRequest.Arguments arguments = captured.get();
+    Assertions.assertEquals(Arrays.asList(servers), arguments.getServersInNewConf());
+    Assertions.assertEquals(Arrays.asList(listeners), arguments.getPeersInNewConf(RaftPeerRole.LISTENER));
+  }
+
+  @Test
+  public void testSetConfigurationWithLists() throws Exception {
+    final List<RaftPeer> servers = Arrays.asList(newPeer("s0"), newPeer("s1"), newPeer("s2"));
+    final List<RaftPeer> listeners = Arrays.asList(newPeer("l0"));
+
+    final AtomicReference<SetConfigurationRequest.Arguments> captured = new AtomicReference<>();
+    newCapturingAdminApi(captured).setConfiguration(servers, listeners);
+
+    final SetConfigurationRequest.Arguments arguments = captured.get();
+    Assertions.assertEquals(servers, arguments.getServersInNewConf());
+    Assertions.assertEquals(listeners, arguments.getPeersInNewConf(RaftPeerRole.LISTENER));
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the `AdminApi.setConfiguration(RaftPeer[] serversInNewConf, RaftPeer[] listenersInNewConf)` default method. It built its `Arguments` with

```java
.setListenersInNewConf(serversInNewConf)
.setListenersInNewConf(listenersInNewConf)
```

so the servers array was passed to the **listeners** setter and then overwritten by the real listeners. The builder's server list was never set, and `Arguments`'s constructor then hit `Preconditions.assertUnique(null)` — every call to this overload failed with a `NullPointerException`, i.e. the overload has never worked as its javadoc documents ("The same as setConfiguration(Arrays.asList(serversInNewConf), Arrays.asList(listenersInNewConf))"). No in-repo caller uses it, which is presumably why it went unnoticed.

The fix routes the servers through `setServersInNewConf(...)`, mirroring the List-based overload directly above it, and adds a regression test (`org.apache.ratis.client.TestAdminApi` in ratis-test) that captures the built `Arguments` through a stub `AdminApi` and asserts both two-argument overloads.

Found while evaluating Ratis for adoption; present at `ratis-3.2.2` and on current master (7eedc1dee).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2640

## How was this patch tested?

New unit test `org.apache.ratis.client.TestAdminApi`:

- **Before the fix**: `testSetConfigurationWithArrays` fails with
  `java.lang.NullPointerException ... at org.apache.ratis.util.Preconditions.assertUnique(Preconditions.java:142) ... at org.apache.ratis.protocol.SetConfigurationRequest$Arguments.<init>(SetConfigurationRequest.java:59) ... at org.apache.ratis.client.api.AdminApi.setConfiguration(AdminApi.java:65)`
- **After the fix**: `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`

Also ran `checkstyle:check` and `apache-rat:check` on the changed modules (clean). Built and tested with JDK 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
