### PR TITLE
RATIS-2642. Command API in data stream can be optional

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamOutput.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamOutput.java
@@ -81,10 +81,15 @@ public interface DataStreamOutput extends CloseAsync<DataStreamReply> {
    * The server state machine may handle the command via its data-stream command hook
    * instead of writing bytes to the data channel.
    *
+   * This is an optional API. Implementations that do not support stream commands
+   * may rely on this default, which throws {@link UnsupportedOperationException}.
+   *
    * @param command the command payload
    * @return a future of the reply
    */
-  CompletableFuture<DataStreamReply> commandAsync(ByteBuffer command);
+  default CompletableFuture<DataStreamReply> commandAsync(ByteBuffer command) {
+    throw new UnsupportedOperationException(getClass() + " does not support commandAsync");
+  }
 
   /**
    * Return the future of the {@link RaftClientReply}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Command API in data stream has a default implementation so the the implementor is not forced to write it after the upgrade. This also means the new API is optional.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2642

## How was this patch tested?

compliation pass.
