### PR TITLE
RATIS-2660. Always clear BlockRequestHandlingInjection after load tests

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
@@ -63,8 +63,11 @@ public class TestRaftWithGrpc
   @ValueSource(booleans = {true, false})
   public void testWithLoad(boolean separateHeartbeat) throws Exception {
     GrpcConfigKeys.Server.setHeartbeatChannel(getProperties(), separateHeartbeat);
-    super.testWithLoad();
-    BlockRequestHandlingInjection.getInstance().unblockAll();
+    try {
+      super.testWithLoad();
+    } finally {
+      BlockRequestHandlingInjection.getInstance().unblockAll();
+    }
   }
 
   @ParameterizedTest

--- a/ratis-test/src/test/java/org/apache/ratis/netty/TestRaftWithNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/netty/TestRaftWithNetty.java
@@ -28,7 +28,10 @@ public class TestRaftWithNetty
   @Override
   @Test
   public void testWithLoad() throws Exception {
-    super.testWithLoad();
-    BlockRequestHandlingInjection.getInstance().unblockAll();
+    try {
+      super.testWithLoad();
+    } finally {
+      BlockRequestHandlingInjection.getInstance().unblockAll();
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request ensures that `BlockRequestHandlingInjection` is always cleared after the gRPC and Netty load tests.

Previously, `unblockAll()` was called only after `super.testWithLoad()` completed successfully. If the load test threw an exception or was interrupted by a timeout, the cleanup was skipped, potentially leaving process-wide request-blocking state that could affect subsequent tests.

## What is the link to the Apache JIRA

RATIS-2660. Always clear BlockRequestHandlingInjection after load tests.

## How was this patch tested?

* `TestRaftWithGrpc.testWithLoad`
  * Tests run: 2
  * Failures: 0
  * Errors: 0

* `TestRaftWithNetty.testWithLoad`
  * Tests run: 1
  * Failures: 0
  * Errors: 0

