### PR TITLE
RATIS-2213. Reclaim unlinked data stream on close

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -522,6 +522,26 @@ public class DataStreamManagement {
     return removed;
   }
 
+  /**
+   * RATIS-2213: a closed stream's DataStreamMap entry is normally removed by the Raft log worker when the
+   * DATASTREAM log entry is linked. If that never happens (the commit is not logged -- e.g. abort, leader
+   * change or follower truncation), the entry and the DataStream's Netty buffers would leak: the closed
+   * stream is no longer tracked by {@code streams} or {@code channels}, and the client may keep the channel
+   * open (Ozone reuses it), so channel-inactive cleanup cannot reclaim it. Schedule a backstop that reclaims
+   * the entry if it is still unlinked after the request timeout. A non-null remove result means the log
+   * worker has not linked it, so the DataStream is not yet owned by the state machine and is safe to clean.
+   */
+  private void scheduleUnlinkedStreamCleanup(StreamInfo info, ClientInvocationId invocationId) {
+    TimeoutExecutor.getInstance().onTimeout(requestTimeout, () -> {
+      final CompletableFuture<DataStream> removed = info.getDivision().getDataStreamMap().remove(invocationId);
+      if (removed != null) {
+        LOG.warn("{}: reclaimed unlinked data stream {} after {} (no DATASTREAM log entry was written)",
+            this, invocationId, requestTimeout);
+        removed.thenAccept(DataStream::cleanUp);
+      }
+    }, LOG, () -> "reclaim unlinked data stream " + invocationId);
+  }
+
   private void readImpl(DataStreamRequestByteBuf request, ChannelHandlerContext ctx,
       CheckedBiFunction<RaftClientRequest, Set<RaftPeer>, Set<DataStreamOutputImpl>, IOException> getStreams,
       ClientInvocationId key, ChannelId channelId) {
@@ -588,6 +608,7 @@ public class DataStreamManagement {
           }
         } else if (close) {
           info.applyToRemotes(remote -> remote.out.closeAsync());
+          scheduleUnlinkedStreamCleanup(info, key);
         }
       } finally {
         request.release();

--- a/ratis-test/src/test/java/org/apache/ratis/netty/server/TestDataStreamManagement.java
+++ b/ratis-test/src/test/java/org/apache/ratis/netty/server/TestDataStreamManagement.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.netty.server;
 
+import org.apache.ratis.client.RaftClientConfigKeys;
 import org.apache.ratis.client.impl.ClientProtoUtils;
 import org.apache.ratis.client.impl.DataStreamClientImpl.DataStreamOutputImpl;
 import org.apache.ratis.client.impl.OrderedAsync;
@@ -28,6 +29,7 @@ import org.apache.ratis.io.WriteOption;
 import org.apache.ratis.netty.metrics.NettyServerStreamRpcMetrics;
 import org.apache.ratis.proto.RaftProtos.DataStreamPacketHeaderProto.Type;
 import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.ClientInvocationId;
 import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
@@ -70,6 +72,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -581,6 +585,104 @@ class TestDataStreamManagement {
     } finally {
       embeddedChannel.finishAndReleaseAll();
       management.shutdown();
+    }
+  }
+
+  @Test
+  void closedStreamLeaksDataStreamMapWhenNotLogged() throws Exception {
+    // RATIS-2213 / HDDS-11939 repro.
+    // A stream's DataStreamMap entry is added on STREAM_HEADER (computeDataStreamIfAbsent) and is removed
+    // either by the Raft log worker when the DATASTREAM log entry is written (SegmentedRaftLogWorker) or by
+    // StreamInfo.cleanUp on error / channel-inactive. On a *successful* CLOSE, DataStreamManagement drains
+    // `streams` and the `channels` entry, but hands the DataStreamMap entry off to the log path -- it does
+    // not remove it itself. If that DATASTREAM log entry is never written (commit failure, leader change,
+    // follower truncation), the entry is orphaned, and the channel-inactive safety net cannot reclaim it
+    // because `channels` was already drained on close. This unit harness has no log worker, faithfully
+    // modelling "the commit was never logged".
+    final RaftPeerId serverId = RaftPeerId.valueOf("s1");
+    final ClientId clientId = ClientId.randomId();
+    final RaftGroupId groupId = RaftGroupId.randomId();
+    final long callId = 1L;
+
+    final RaftProperties properties = new RaftProperties();
+    // Reclaim quickly so the test does not wait the 3s default request timeout.
+    RaftClientConfigKeys.DataStream.setRequestTimeout(properties, TimeDuration.valueOf(300, TimeUnit.MILLISECONDS));
+
+    final AtomicReference<CountingDataChannel> channelRef = new AtomicReference<>();
+    final CountingDataStreamMap streamMap = new CountingDataStreamMap();
+    final StateMachine stateMachine = newWriteStateMachine(channelRef,
+        Collections.synchronizedList(new ArrayList<>()));
+    final RaftServer.Division division = newWriteDivision(serverId, groupId, stateMachine, streamMap);
+    final RaftServer server = newRaftServer(serverId, properties, groupId, division);
+
+    final NettyServerStreamRpcMetrics metrics = new NettyServerStreamRpcMetrics("s1");
+    final DataStreamManagement management = new DataStreamManagement(server, metrics);
+    final EmbeddedChannel embeddedChannel = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
+    final ChannelHandlerContext ctx = embeddedChannel.pipeline().firstContext();
+    final ChannelId channelId = embeddedChannel.id();
+    final CheckedBiFunction<RaftClientRequest, Set<RaftPeer>, Set<DataStreamOutputImpl>, IOException> getStreams =
+        (r, p) -> Collections.emptySet();
+
+    final RaftClientRequest raftClientRequest = RaftClientRequest.newBuilder()
+        .setClientId(clientId)
+        .setServerId(serverId)
+        .setGroupId(groupId)
+        .setCallId(callId)
+        .setType(RaftClientRequest.dataStreamRequestType())
+        .build();
+    final ByteBuffer headerPayload = ClientProtoUtils.toRaftClientRequestProtoByteBuffer(raftClientRequest);
+
+    try {
+      // Drive a full, successful stream: HEADER -> DATA -> DATA+CLOSE.
+      management.read(newWriteRequest(clientId, Type.STREAM_HEADER, callId, 0,
+          Unpooled.wrappedBuffer(headerPayload), StandardWriteOption.FLUSH), ctx, getStreams);
+      management.read(newWriteRequest(clientId, Type.STREAM_DATA, callId, 0,
+          Unpooled.wrappedBuffer(new byte[10]), StandardWriteOption.FLUSH), ctx, getStreams);
+      management.read(newWriteRequest(clientId, Type.STREAM_DATA, callId, 10,
+          Unpooled.wrappedBuffer(new byte[4]), StandardWriteOption.CLOSE), ctx, getStreams);
+      drainWriteReplies(embeddedChannel, 3);
+
+      // STREAM_HEADER created exactly one DataStreamMap entry.
+      assertEquals(1, streamMap.liveCount(), "STREAM_HEADER should create one DataStreamMap entry");
+
+      // After a successful close the channel map is drained, so the channel-inactive safety net can no
+      // longer reclaim this stream; the DataStreamMap entry is handed off to the (never-run here) log path.
+      JavaUtils.attempt(() -> assertEquals(0, management.getChannelInvocationCount(channelId),
+          "channel map should be drained on close"), 50,
+          TimeDuration.valueOf(100, TimeUnit.MILLISECONDS), "channel drained on close", null);
+      assertEquals(1, streamMap.liveCount(),
+          "closed stream is handed off to the log path; DataStreamMap still holds it");
+
+      // RATIS-2213: without the close-time backstop the orphaned entry (and its Netty buffers) leaks
+      // forever. With the fix it is reclaimed once the request timeout elapses with no DATASTREAM log
+      // entry. This assertion FAILS on unpatched code (liveCount stays 1) and passes with the fix.
+      JavaUtils.attempt(() -> assertEquals(0, streamMap.liveCount(),
+          "unlinked DataStreamMap entry should be reclaimed after the data-stream request timeout"),
+          30, TimeDuration.valueOf(100, TimeUnit.MILLISECONDS), "DataStreamMap reclaimed", null);
+    } finally {
+      embeddedChannel.finishAndReleaseAll();
+      management.shutdown();
+    }
+  }
+
+  /** Mirrors {@link org.apache.ratis.server.impl.DataStreamMapImpl} (a ConcurrentHashMap wrapper) while
+   *  exposing the live entry count so a test can observe DataStreamMap leaks. */
+  private static final class CountingDataStreamMap implements DataStreamMap {
+    private final ConcurrentMap<ClientInvocationId, CompletableFuture<DataStream>> map = new ConcurrentHashMap<>();
+
+    @Override
+    public CompletableFuture<DataStream> computeIfAbsent(ClientInvocationId invocationId,
+        Function<ClientInvocationId, CompletableFuture<DataStream>> newDataStream) {
+      return map.computeIfAbsent(invocationId, newDataStream);
+    }
+
+    @Override
+    public CompletableFuture<DataStream> remove(ClientInvocationId invocationId) {
+      return map.remove(invocationId);
+    }
+
+    int liveCount() {
+      return map.size();
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

A data stream's `DataStreamMap` entry is added on `STREAM_HEADER`
(`DataStreamManagement.computeDataStreamIfAbsent`) and removed by exactly two sites: the
Raft log worker when the `DATASTREAM` log entry is linked (`SegmentedRaftLogWorker`), or
`StreamInfo.cleanUp` on the error / channel-inactive path.

On a **successful CLOSE**, `DataStreamManagement` drains `streams` and the `channels` entry
but hands the `DataStreamMap` entry off to the log path — it does not remove it. If that
`DATASTREAM` log entry is never written (commit not logged: abort, leader change, follower
truncation), the entry is orphaned: the closed stream is no longer tracked by `streams` or
`channels`, so channel-inactive cleanup cannot reclaim it — and since the client may keep the
channel open (Ozone reuses it), channel-inactive may never fire. The orphaned
`CompletableFuture<DataStream>` pins the Netty direct buffers, so direct memory grows under
sustained streaming write. This matches the MAT analysis on RATIS-2213 / HDDS-11939.

This PR adds a close-time backstop (`scheduleUnlinkedStreamCleanup`): after the data-stream
request timeout, remove the `DataStreamMap` entry **iff it is still unlinked** and clean the
`DataStream`. A non-null remove result means the log worker has not linked it, so the
`DataStream` is not yet owned by the state machine and is safe to clean; if it was already
linked, remove returns null and the backstop is a no-op.

Open to feedback on the approach — in particular: reusing `raft.client.data-stream.request.timeout`
as the "abandoned" threshold vs. a dedicated grace period, and whether a link-completion callback
from the log worker would be preferable to a per-close scheduled task.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2213

## How was this patch tested?
 https://github.com/rich7420/ratis/actions/runs/32698135039
