### PR TITLE
RATIS-2665: Reduce idle log worker close latency

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -69,6 +69,17 @@ class SegmentedRaftLogWorker {
   private static final String CLASS_NAME = JavaUtils.getClassSimpleName(SegmentedRaftLogWorker.class);
   static final String RUN_WORKER = CLASS_NAME + ".runWorker";
 
+  private static final Task WAKE_UP_TASK = new Task() {
+    @Override
+    void execute() {
+    }
+
+    @Override
+    long getEndIndex() {
+      return RaftLog.INVALID_LOG_INDEX;
+    }
+  };
+
   static class StateMachineDataPolicy {
     private final boolean sync;
     private final TimeDuration syncTimeout;
@@ -246,6 +257,9 @@ class SegmentedRaftLogWorker {
 
   void close() {
     this.running = false;
+    // Wake up the worker if it is waiting on an empty queue.  If the queue is full,
+    // the worker is not waiting and will observe running == false after its current task.
+    queue.offer(WAKE_UP_TASK);
     Optional.ofNullable(flushExecutor).ifPresent(ExecutorService::shutdown);
     ConcurrentUtils.shutdownAndWait(TimeDuration.ONE_SECOND.multiply(3),
         workerThreadExecutor, timeout -> LOG.warn("{}: shutdown timeout in " + timeout, name));
@@ -308,6 +322,9 @@ class SegmentedRaftLogWorker {
       try {
         Task task = queue.poll(ONE_SECOND);
         if (task != null) {
+          if (task == WAKE_UP_TASK) {
+            return;
+          }
           task.stopTimerOnDequeue();
           try {
             if (logIOException != null) {

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -52,6 +52,7 @@ import org.apache.ratis.util.TimeDuration;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -179,6 +180,49 @@ public class TestSegmentedRaftLog extends BaseTest {
   public void tearDown() throws Exception {
     if (storageDir != null) {
       FileUtils.deleteFully(storageDir.getParentFile());
+    }
+  }
+
+  @Test
+  public void testCloseWakesUpIdleWorker() throws Exception {
+    final AtomicReference<Thread> workerThread = new AtomicReference<>();
+    final CountDownLatch workerStarted = new CountDownLatch(1);
+    final CountDownLatch runWorker = new CountDownLatch(1);
+    final SegmentedRaftLog raftLog = newSegmentedRaftLog();
+    CodeInjectionForTesting.put(RUN_WORKER, (localId, remoteId, args) -> {
+      workerThread.set(Thread.currentThread());
+      workerStarted.countDown();
+      try {
+        runWorker.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException(e);
+      }
+      return true;
+    });
+
+    boolean closeInvoked = false;
+    try {
+      raftLog.open(RaftLog.INVALID_LOG_INDEX, null);
+      assertTrue(workerStarted.await(FIVE_SECONDS.getDuration(), FIVE_SECONDS.getUnit()));
+      runWorker.countDown();
+
+      final long deadline = System.nanoTime() + FIVE_SECONDS.toLong(TimeUnit.NANOSECONDS);
+      while (System.nanoTime() < deadline) {
+        if (workerThread.get().getState() == Thread.State.TIMED_WAITING) {
+          closeInvoked = true;
+          Assertions.assertTimeout(Duration.ofMillis(500), raftLog::close);
+          return;
+        }
+        Thread.yield();
+      }
+      Assertions.fail("The worker did not wait for an I/O task");
+    } finally {
+      runWorker.countDown();
+      CodeInjectionForTesting.remove(RUN_WORKER);
+      if (!closeInvoked) {
+        raftLog.close();
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`SegmentedRaftLogWorker` polls its I/O task queue with a one-second timeout.
When the worker is idle, closing it may wait until the current poll times out.

This change offers an internal wake-up task after setting `running` to `false`,
allowing an idle worker to exit immediately. The wake-up task bypasses normal
task execution, exception handling, metrics, and future completion.

The worker is not interrupted, so active flush and log-sync operations retain
their existing shutdown behavior. No public API is changed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2665

## How was this patch tested?

Added `testCloseWakesUpIdleWorker` to verify that a worker blocked while polling
an empty task queue is awakened and closed promptly.

Validation results:

- The new regression test passed 20 consecutive runs.
- All 55 tests in `TestSegmentedRaftLog` passed.
- Maven Checkstyle completed with no violations.
