### PR TITLE
RATIS-2500. Fix infinite InstallSnapshot notification loop when the follower snapshot covers the previous log entry

### DIFF
--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -213,9 +213,16 @@ public interface LogAppender {
       // leader does not have follower's next log
       return true;
     }
-    // leader does not have the previous log for appendEntries
+    // Leader does not have the previous log for appendEntries.
+    // However, when the follower's snapshot already covers the previous log entry
+    // (i.e. followerNextIndex == follower.getSnapshotIndex() + 1, typically after the follower
+    // replied ALREADY_INSTALLED), appendEntries can be sent without the previous entry;
+    // see the corresponding condition in LogAppenderBase.newAppendEntriesRequest.
+    // Without this exemption, the leader would keep sending InstallSnapshot notifications
+    // and never append, so such a follower could never catch up.
     return followerNextIndex == leaderStartIndex &&
         followerNextIndex > RaftLog.LEAST_VALID_LOG_INDEX &&
+        followerNextIndex != follower.getSnapshotIndex() + 1 &&
         getPrevious(followerNextIndex) == null;
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/leader/TestLogAppenderDefault.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/leader/TestLogAppenderDefault.java
@@ -23,6 +23,7 @@ import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
+import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.util.Timestamp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -91,13 +92,60 @@ class TestLogAppenderDefault {
     verifyNoMoreInteractions(leaderState);
   }
 
+  @Test
+  void noInstallSnapshotWhenFollowerSnapshotCoversPreviousEntry() {
+    // RATIS-2500: leader log is [159, 168) with the previous entry 158 purged, and the follower
+    // (nextIndex = 159) has a snapshot covering 158 (typically reported via ALREADY_INSTALLED).
+    // The leader should append (previous == null is allowed by newAppendEntriesRequest in this case)
+    // instead of looping on InstallSnapshot notifications.
+    final LeaderState leaderState = mock(LeaderState.class);
+    final TestFollowerInfo follower = new TestFollowerInfo(159, 158);
+    follower.setSnapshotIndex(158);
+    final LogAppenderDefault appender = newLogAppender(leaderState, follower, newRaftLog(168, 159));
+
+    Assertions.assertFalse(appender.shouldInstallSnapshot(true));
+  }
+
+  @Test
+  void installSnapshotWhenFollowerSnapshotDoesNotCoverPreviousEntry() {
+    final LeaderState leaderState = mock(LeaderState.class);
+    final TestFollowerInfo follower = new TestFollowerInfo(159, 100);
+    follower.setSnapshotIndex(100);
+    final LogAppenderDefault appender = newLogAppender(leaderState, follower, newRaftLog(168, 159));
+
+    Assertions.assertTrue(appender.shouldInstallSnapshot(true));
+  }
+
+  @Test
+  void installSnapshotWhenFollowerNextIndexBelowLeaderStartIndex() {
+    final LeaderState leaderState = mock(LeaderState.class);
+    final TestFollowerInfo follower = new TestFollowerInfo(150, 149);
+    follower.setSnapshotIndex(149);
+    final LogAppenderDefault appender = newLogAppender(leaderState, follower, newRaftLog(168, 159));
+
+    Assertions.assertTrue(appender.shouldInstallSnapshot(true));
+  }
+
   private static LogAppenderDefault newLogAppender(LeaderState leaderState, FollowerInfo follower) {
+    return newLogAppender(leaderState, follower, mock(RaftLog.class));
+  }
+
+  private static LogAppenderDefault newLogAppender(LeaderState leaderState, FollowerInfo follower, RaftLog raftLog) {
     final RaftServer.Division division = mock(RaftServer.Division.class);
     final RaftServer raftServer = mock(RaftServer.class);
     when(division.getRaftServer()).thenReturn(raftServer);
     when(division.getThreadGroup()).thenReturn(Thread.currentThread().getThreadGroup());
     when(raftServer.getProperties()).thenReturn(new RaftProperties());
+    when(division.getRaftLog()).thenReturn(raftLog);
+    when(division.getStateMachine()).thenReturn(mock(StateMachine.class));
     return new LogAppenderDefault(division, leaderState, follower);
+  }
+
+  private static RaftLog newRaftLog(long nextIndex, long startIndex) {
+    final RaftLog raftLog = mock(RaftLog.class);
+    when(raftLog.getNextIndex()).thenReturn(nextIndex);
+    when(raftLog.getStartIndex()).thenReturn(startIndex);
+    return raftLog;
   }
 
   private static AppendEntriesReplyProto newSuccessReply(long nextIndex) {
@@ -113,6 +161,7 @@ class TestLogAppenderDefault {
     private final AtomicInteger nextIndexIncreases = new AtomicInteger();
     private long matchIndex;
     private long nextIndex;
+    private long snapshotIndex;
 
     private TestFollowerInfo(long nextIndex, long matchIndex) {
       this.nextIndex = nextIndex;
@@ -161,11 +210,12 @@ class TestLogAppenderDefault {
 
     @Override
     public long getSnapshotIndex() {
-      return 0;
+      return snapshotIndex;
     }
 
     @Override
     public void setSnapshotIndex(long newSnapshotIndex) {
+      snapshotIndex = newSnapshotIndex;
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

RATIS-2487 added a clause to `LogAppender.shouldInstallSnapshot` that triggers an install snapshot when the leader cannot provide the previous entry for appendEntries:

```java
return followerNextIndex == leaderStartIndex &&
    followerNextIndex > RaftLog.LEAST_VALID_LOG_INDEX &&
    getPrevious(followerNextIndex) == null;
```

However, `LogAppenderBase.newAppendEntriesRequest` (and `assertProtos`) explicitly allow sending appendEntries **without** the previous entry when `followerNextIndex == follower.getSnapshotIndex() + 1`. Since the appender run loop consults `shouldNotifyToInstallSnapshot()` before building an append request, that exemption is unreachable and the leader gets stuck in an infinite loop:

1. The follower's `nextIndex` equals the leader's log start index (the previous entry is purged), and the leader state machine's latest snapshot index does not exactly equal `leaderStartIndex - 1`, so `getPrevious` returns null. This is the normal situation for DB-backed state machines (e.g. Ozone OM/SCM) whose `getLatestSnapshot()` advances with the applied index.
2. The leader sends an InstallSnapshotNotification for the first available log entry.
3. The follower replies `ALREADY_INSTALLED` with its snapshot index `== leaderStartIndex - 1` (`SnapshotInstallationHandler`: `snapshotIndex + 1 >= firstAvailableLogIndex`).
4. The leader records `follower.snapshotIndex`, sets `nextIndex = leaderStartIndex`, and goes back to step 2.

The loop is tight (observed ~100 notification RPCs per second). The follower's matchIndex never advances, so `TransferLeadership` always times out; in a 3-node group with one node down, the leader can never commit its placeholder entry, i.e. the group loses write availability.

This PR adds the same exemption to `shouldInstallSnapshot`: when `followerNextIndex == follower.getSnapshotIndex() + 1`, do not install a snapshot — appendEntries can proceed without the previous entry. This restores the recovery path that worked before RATIS-2487 (verified against Ratis 3.2.1 behavior, where the `ALREADY_INSTALLED` reply leads to a successful append).

This was found while upgrading Apache Ozone to Ratis 3.3.0 ([HDDS-16196](https://issues.apache.org/jira/browse/HDDS-16196), apache/ozone#11032): `TestOzoneManagerHAWithStoppedNodes` wedges consistently with the leader looping `notifyInstallSnapshot` / `ALREADY_INSTALLED` while `TransferLeadership` reports `NOT_UP_TO_DATE(followerMatchIndex = 158 < leaderLastEntry.getIndex() = 167)`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2500

## How was this patch tested?

New unit tests in `TestLogAppenderDefault`; `noInstallSnapshotWhenFollowerSnapshotCoversPreviousEntry` fails without the fix and passes with it. Existing tests pass. The failure scenario was reproduced with Ozone's `TestOzoneManagerHAWithStoppedNodes` on Ratis 3.3.0.

Generated-by: Claude Code (claude-fable-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
