### PR TITLE
RATIS-2680. Maintain backward compatibility for cleanupOldSnapshots

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/SimpleStateMachineStorage.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/SimpleStateMachineStorage.java
@@ -137,7 +137,7 @@ public class SimpleStateMachineStorage implements StateMachineStorage {
       }
     }
 
-    if (deleteIdx < 0 && allSnapshotFiles.size() > numSnapshotsRetained) {
+    if (deleteIdx == -1 && allSnapshotFiles.size() > numSnapshotsRetained) {
       // Before RATIS-244, the newest numSnapshotsRetained snapshots (with or without md5) are retained.
       // For backward compatibility:
       // - All snapshots without MD5 : retain the newest numSnapshotsRetained snapshots.

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/SimpleStateMachineStorage.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/SimpleStateMachineStorage.java
@@ -135,6 +135,14 @@ public class SimpleStateMachineStorage implements StateMachineStorage {
       }
     }
 
+    // Backward compatibility: before MD5 files existed, all snapshots counted toward
+    // retention. When there are fewer MD5 snapshots than numSnapshotsRetained (e.g.
+    // all old snapshots without MD5, or old snapshots mixed with new ones after upgrade),
+    // fall back to retaining the newest numSnapshotsRetained snapshots regardless of MD5.
+    if (deleteIdx < 0 && allSnapshotFiles.size() > numSnapshotsRetained) {
+      deleteIdx = numSnapshotsRetained;
+    }
+
     if (deleteIdx > 0) {
       allSnapshotFiles.subList(deleteIdx, allSnapshotFiles.size())
           .stream()

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/SimpleStateMachineStorage.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/SimpleStateMachineStorage.java
@@ -120,11 +120,13 @@ public class SimpleStateMachineStorage implements StateMachineStorage {
     final List<SingleFileSnapshotInfo> allSnapshotFiles = getSingleFileSnapshotInfos(stateMachineDir.toPath());
     allSnapshotFiles.sort(Comparator.comparing(SingleFileSnapshotInfo::getIndex).reversed());
     int numSnapshotsWithMd5 = 0;
+    int lastSnapshotsWithMd5 = -1;
     int deleteIdx = -1;
 
     for (int i = 0; i < allSnapshotFiles.size(); i++) {
       final SingleFileSnapshotInfo snapshot = allSnapshotFiles.get(i);
       if (snapshot.hasMd5()) {
+        lastSnapshotsWithMd5 = i;
         if (++numSnapshotsWithMd5 == numSnapshotsRetained) {
           // We have found the last snapshot with an MD5 file that needs to be retained
           deleteIdx = i + 1;
@@ -135,12 +137,12 @@ public class SimpleStateMachineStorage implements StateMachineStorage {
       }
     }
 
-    // Backward compatibility: before MD5 files existed, all snapshots counted toward
-    // retention. When there are fewer MD5 snapshots than numSnapshotsRetained (e.g.
-    // all old snapshots without MD5, or old snapshots mixed with new ones after upgrade),
-    // fall back to retaining the newest numSnapshotsRetained snapshots regardless of MD5.
     if (deleteIdx < 0 && allSnapshotFiles.size() > numSnapshotsRetained) {
-      deleteIdx = numSnapshotsRetained;
+      // Before RATIS-244, the newest numSnapshotsRetained snapshots (with or without md5) are retained.
+      // For backward compatibility:
+      // - All snapshots without MD5 : retain the newest numSnapshotsRetained snapshots.
+      // - Snapshots mixed (with and without md5): retain all snapshots with md5 and the newer snapshots without md5.
+      deleteIdx = Math.max(numSnapshotsRetained, lastSnapshotsWithMd5 + 1);
     }
 
     if (deleteIdx > 0) {

--- a/ratis-test/src/test/java/org/apache/ratis/server/storage/TestRaftStorage.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/storage/TestRaftStorage.java
@@ -491,7 +491,10 @@ public class TestRaftStorage extends BaseTest {
       simpleStateMachineStorage.cleanupOldSnapshots(snapshotRetentionPolicy);
 
       List<String> snapshotNames = listMatchingFileNames(stateMachineDir, SNAPSHOT_REGEX);
-      Assertions.assertEquals(3, snapshotNames.size());
+      Assertions.assertEquals(2, snapshotNames.size());
+      Assertions.assertTrue(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 300)));
+      Assertions.assertTrue(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 200)));
+      Assertions.assertFalse(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 100)));
       Assertions.assertTrue(listMatchingFileNames(stateMachineDir, SNAPSHOT_MD5_REGEX).isEmpty());
     } finally {
       storage.close();

--- a/ratis-test/src/test/java/org/apache/ratis/server/storage/TestRaftStorage.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/storage/TestRaftStorage.java
@@ -502,6 +502,123 @@ public class TestRaftStorage extends BaseTest {
   }
 
   @Test
+  public void testCleanupOldSnapshotsMixedRetainsAllMd5AndNewerWithoutMd5() throws Exception {
+    SnapshotRetentionPolicy snapshotRetentionPolicy = new SnapshotRetentionPolicy() {
+      @Override
+      public int getNumSnapshotsRetained() {
+        return 3;
+      }
+    };
+
+    SimpleStateMachineStorage simpleStateMachineStorage = new SimpleStateMachineStorage();
+    final RaftStorage storage = newRaftStorage(storageDir);
+    simpleStateMachineStorage.init(storage);
+    try {
+      // Newer snapshots without MD5 (pre-upgrade) at higher indices.
+      createSnapshot(simpleStateMachineStorage, 1, 900, false);
+      createSnapshot(simpleStateMachineStorage, 1, 800, false);
+      // Newer snapshots with MD5 (post-upgrade) at lower indices; fewer than numSnapshotsRetained.
+      createSnapshot(simpleStateMachineStorage, 1, 700, true);
+      createSnapshot(simpleStateMachineStorage, 1, 600, true);
+
+      File stateMachineDir = storage.getStorageDir().getStateMachineDir();
+      simpleStateMachineStorage.cleanupOldSnapshots(snapshotRetentionPolicy);
+
+      // Fallback retains all MD5 snapshots and the newer snapshots without MD5.
+      List<String> snapshotNames = listMatchingFileNames(stateMachineDir, SNAPSHOT_REGEX);
+      Assertions.assertEquals(4, snapshotNames.size());
+      Assertions.assertTrue(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 900)));
+      Assertions.assertTrue(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 800)));
+      Assertions.assertTrue(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 700)));
+      Assertions.assertTrue(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 600)));
+
+      List<String> md5Names = listMatchingFileNames(stateMachineDir, SNAPSHOT_MD5_REGEX);
+      Assertions.assertEquals(2, md5Names.size());
+      Assertions.assertTrue(md5Names.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 700) + MD5_SUFFIX));
+      Assertions.assertTrue(md5Names.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 600) + MD5_SUFFIX));
+    } finally {
+      storage.close();
+    }
+  }
+
+  @Test
+  public void testCleanupOldSnapshotsMixedUpgradeScenario() throws Exception {
+    SnapshotRetentionPolicy snapshotRetentionPolicy = new SnapshotRetentionPolicy() {
+      @Override
+      public int getNumSnapshotsRetained() {
+        return 3;
+      }
+    };
+
+    SimpleStateMachineStorage simpleStateMachineStorage = new SimpleStateMachineStorage();
+    final RaftStorage storage = newRaftStorage(storageDir);
+    simpleStateMachineStorage.init(storage);
+    try {
+      // Old snapshots without MD5 created before upgrade.
+      createSnapshot(simpleStateMachineStorage, 1, 500, false);
+      createSnapshot(simpleStateMachineStorage, 1, 600, false);
+      createSnapshot(simpleStateMachineStorage, 1, 700, false);
+      // New snapshots with MD5 created after upgrade; fewer than numSnapshotsRetained.
+      createSnapshot(simpleStateMachineStorage, 1, 800, true);
+      createSnapshot(simpleStateMachineStorage, 1, 900, true);
+
+      File stateMachineDir = storage.getStorageDir().getStateMachineDir();
+      simpleStateMachineStorage.cleanupOldSnapshots(snapshotRetentionPolicy);
+
+      // Retain all MD5 snapshots plus the newest old snapshot without MD5.
+      List<String> snapshotNames = listMatchingFileNames(stateMachineDir, SNAPSHOT_REGEX);
+      Assertions.assertEquals(3, snapshotNames.size());
+      Assertions.assertTrue(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 900)));
+      Assertions.assertTrue(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 800)));
+      Assertions.assertTrue(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 700)));
+      Assertions.assertFalse(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 600)));
+      Assertions.assertFalse(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 500)));
+
+      List<String> md5Names = listMatchingFileNames(stateMachineDir, SNAPSHOT_MD5_REGEX);
+      Assertions.assertEquals(2, md5Names.size());
+    } finally {
+      storage.close();
+    }
+  }
+
+  @Test
+  public void testCleanupOldSnapshotsMixedDeletesOlderWithoutMd5BeyondRetention() throws Exception {
+    SnapshotRetentionPolicy snapshotRetentionPolicy = new SnapshotRetentionPolicy() {
+      @Override
+      public int getNumSnapshotsRetained() {
+        return 3;
+      }
+    };
+
+    SimpleStateMachineStorage simpleStateMachineStorage = new SimpleStateMachineStorage();
+    final RaftStorage storage = newRaftStorage(storageDir);
+    simpleStateMachineStorage.init(storage);
+    try {
+      createSnapshot(simpleStateMachineStorage, 1, 900, false);
+      createSnapshot(simpleStateMachineStorage, 1, 700, true);
+      createSnapshot(simpleStateMachineStorage, 1, 600, true);
+      createSnapshot(simpleStateMachineStorage, 1, 500, false);
+      createSnapshot(simpleStateMachineStorage, 1, 400, false);
+
+      File stateMachineDir = storage.getStorageDir().getStateMachineDir();
+      simpleStateMachineStorage.cleanupOldSnapshots(snapshotRetentionPolicy);
+
+      List<String> snapshotNames = listMatchingFileNames(stateMachineDir, SNAPSHOT_REGEX);
+      Assertions.assertEquals(3, snapshotNames.size());
+      Assertions.assertTrue(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 900)));
+      Assertions.assertTrue(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 700)));
+      Assertions.assertTrue(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 600)));
+      Assertions.assertFalse(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 500)));
+      Assertions.assertFalse(snapshotNames.contains(SimpleStateMachineStorage.getSnapshotFileName(1, 400)));
+
+      List<String> md5Names = listMatchingFileNames(stateMachineDir, SNAPSHOT_MD5_REGEX);
+      Assertions.assertEquals(2, md5Names.size());
+    } finally {
+      storage.close();
+    }
+  }
+
+  @Test
   public void testGetLatestSnapshotReturnsNewest() throws Exception {
     SimpleStateMachineStorage simpleStateMachineStorage = new SimpleStateMachineStorage();
     final RaftStorage storage = newRaftStorage(storageDir);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up to #1320 (RATIS-244), which changed `SimpleStateMachineStorage.cleanupOldSnapshots` to count only snapshots with MD5 files toward the retention limit. Meanwhile RATIS-244 maintained the backward compatibility for `SimpleStateMachineStorage.findLatestSnapshot`.

Overall speaking, there could be applications never considered creating MD5 files for taking snapshots, but because of old implementation of the Ratis, those applications didn't know that their snapshots should be considered incomplete or corrupted. Ratis should consider such applications and maintain backward compatibility. Otherwise once those applications upgrade, they will surprisingly find the behavior changes of the snapshot.

That change broke backward compatibility during upgrades where old snapshots (created before MD5 support, without .md5 files) coexist with new snapshots (with MD5 files) or there is no new snapshots (with MD5 files). In those cases, cleanup could either skip deletion entirely or retain the wrong set of snapshots, because old snapshots were excluded from the retention count even though they were valid before the upgrade.

This PR restores the original retention behavior as a fallback: when fewer than numSnapshotsRetained MD5 snapshots are found, retain the newest numSnapshotsRetained snapshots regardless of whether they have MD5 files. This covers:

1. All old snapshots without MD5 — retention policy applies as it did before RATIS-244
2. Mixed old and new snapshots after upgrade — old snapshots count toward retention when there are not enough new MD5 snapshots to fill the quota
3. When enough MD5 snapshots exist, the RATIS-244 behavior is unchanged: retention is based on MD5 snapshots, and snapshots without MD5 that fall beyond that cutoff are still cleaned up.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-2680

## How was this patch tested?

Unit Tests

This PR was assisted by Cursor.