### PR TITLE
RATIS-2662. Make testKillLeaderDuringReconf deterministic.

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -41,7 +41,7 @@ import org.apache.ratis.server.raftlog.LogProtoUtils;
 import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.server.raftlog.RaftLogBase;
 import org.apache.ratis.server.storage.RaftStorageTestUtils;
-import org.apache.ratis.test.tag.Flaky;
+import org.apache.ratis.util.ConcurrentUtils;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.Slf4jUtils;
@@ -56,8 +56,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -507,86 +509,112 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
    * retrying.
    */
   @Test
-  @Flaky("RATIS-2251")
+  @Timeout(120)
   public void testKillLeaderDuringReconf() throws Exception {
     // originally 3 peers
     runWithNewCluster(3, this::runTestKillLeaderDuringReconf);
   }
 
+  private static boolean isBootstrappingPeer(RaftServer.Division server, RaftPeerId peerId) {
+    return ((RaftServerImpl) server).getRole().getLeaderState()
+        .filter(LeaderStateImpl::inStagingState)
+        .map(state -> state.isBootStrappingPeer(peerId))
+        .orElse(false);
+  }
+
   void runTestKillLeaderDuringReconf(CLUSTER cluster) throws Exception {
-    final AtomicBoolean clientRunning = new AtomicBoolean(true);
-    Thread clientThread = null;
+    final ExecutorService executor = ConcurrentUtils.newSingleThreadExecutor(
+        JavaUtils.getClassSimpleName(getClass()) + "-testKillLeaderDuringReconf-client");
     try {
       final RaftPeerId leaderId = RaftTestUtil.waitForLeader(cluster).getId();
 
-      PeerChanges c1 = cluster.addNewPeers(1, false);
-      PeerChanges c2 = cluster.removePeers(1, false, c1.getAddedPeers());
+      final PeerChanges c1 = cluster.addNewPeers(1, false);
+      final PeerChanges c2 = cluster.removePeers(1, false, c1.getAddedPeers());
+      final RaftPeerId newPeerId = c1.getAddedPeers().get(0).getId();
 
       LOG.info("Start setConf: {}", c2.getPeersInNewConf());
       LOG.info(cluster.printServers());
 
-      final CompletableFuture<Void> setConf = new CompletableFuture<>();
-      clientThread = new Thread(() -> {
-        try(final RaftClient client = cluster.createClient(leaderId)) {
-          for(int i = 0; clientRunning.get() && !setConf.isDone(); i++) {
-            final RaftClientReply reply = client.admin().setConfiguration(c2.getPeersInNewConf());
-            if (reply.isSuccess()) {
-              setConf.complete(null);
-              return;
-            }
-            LOG.info("setConf attempt #{} failed, {}", i, cluster.printServers());
-          }
-        } catch(Exception e) {
-          LOG.error("Failed to setConf", e);
-          setConf.completeExceptionally(e);
+      final Future<RaftClientReply> setConfTask = executor.submit(() -> {
+        try (RaftClient client = cluster.createClient(leaderId)) {
+          return client.admin().setConfiguration(c2.getPeersInNewConf());
         }
       });
-      clientThread.start();
-
-      // the leader cannot generate the (old, new) conf, and it will keep
-      // bootstrapping the 1 new peer since it has not started yet.
-      Assertions.assertFalse(((RaftConfigurationImpl)cluster.getLeader().getRaftConf()).isTransitional());
-
-      // (0) the first conf entry, (1) the 1st setConf entry, (2) a metadata entry
-      // (3) new current conf entry  (4) a metadata entry
-      {
-        final RaftLog leaderLog = cluster.getLeader().getRaftLog();
-        for(LogEntryProto e : RaftTestUtil.getLogEntryProtos(leaderLog)) {
-          LOG.info("{}", LogProtoUtils.toLogEntryString(e));
-        }
-        final long commitIndex = leaderLog.getLastCommittedIndex();
-        Assertions.assertTrue(commitIndex <= 2, "commitIndex = " + commitIndex + " > 2");
-      }
-
-      final RaftPeerId killed = RaftTestUtil.waitAndKillLeader(cluster);
-      Assertions.assertEquals(leaderId, killed);
-      final RaftPeerId newLeaderId = RaftTestUtil.waitForLeader(cluster).getId();
-      LOG.info("newLeaderId: {}", newLeaderId);
-      TimeDuration.valueOf(1500, TimeUnit.MILLISECONDS).sleep();
-
-      LOG.info("start new peers: {}", c1.getAddedPeers());
-      for (RaftPeer np : c1.getAddedPeers()) {
-        cluster.restartServer(np.getId(), false);
-      }
 
       try {
-        setConf.get(10, TimeUnit.SECONDS);
-      } catch(TimeoutException ignored) {
-      }
+        JavaUtils.attempt(() -> {
+          Assertions.assertFalse(setConfTask.isDone(),
+              () -> "setConfiguration completed before the leader was killed; " + cluster.printServers());
+          Assertions.assertTrue(isBootstrappingPeer(cluster.getDivision(leaderId), newPeerId),
+              () -> "Leader " + leaderId + " is not bootstrapping peer " + newPeerId
+                  + "; " + cluster.printServers());
+        }, 10, cluster.getTimeoutMax(), "wait for the original leader to bootstrap " + newPeerId, LOG);
 
-      RaftServerProxy newServer = cluster.getServer(c1.getAddedPeers().get(0).getId());
-      if (newServer.getLifeCycleState() == LifeCycle.State.CLOSED) {
-        LOG.info("New peer {} is shutdown. Skip the check", c1.getAddedPeers().get(0).getId());
-      } else {
+        // The leader cannot generate the (old, new) conf, and it will keep
+        // bootstrapping the new peer since it has not started yet.
+        Assertions.assertFalse(((RaftConfigurationImpl)cluster.getLeader().getRaftConf()).isTransitional());
+
+        // (0) the first conf entry, (1) the 1st setConf entry, (2) a metadata entry
+        // (3) new current conf entry  (4) a metadata entry
+        {
+          final RaftLog leaderLog = cluster.getLeader().getRaftLog();
+          for(LogEntryProto e : RaftTestUtil.getLogEntryProtos(leaderLog)) {
+            LOG.info("{}", LogProtoUtils.toLogEntryString(e));
+          }
+          final long commitIndex = leaderLog.getLastCommittedIndex();
+          Assertions.assertTrue(commitIndex <= 2,
+              () -> "commitIndex = " + commitIndex + " > 2; " + cluster.printServers());
+        }
+
+        final RaftPeerId killed = RaftTestUtil.waitAndKillLeader(cluster);
+        Assertions.assertEquals(leaderId, killed);
+        final RaftServer.Division newLeader = RaftTestUtil.waitForLeader(cluster);
+        final RaftPeerId newLeaderId = newLeader.getId();
+        Assertions.assertNotEquals(leaderId, newLeaderId);
+        LOG.info("newLeaderId: {}", newLeaderId);
+
+        JavaUtils.attempt(() -> {
+          Assertions.assertFalse(setConfTask.isDone(),
+              () -> "setConfiguration completed before the new peer was started; " + cluster.printServers());
+          Assertions.assertTrue(isBootstrappingPeer(newLeader, newPeerId),
+              () -> "New leader " + newLeaderId + " is not bootstrapping peer " + newPeerId
+                  + "; " + cluster.printServers());
+        }, 30, cluster.getTimeoutMax(), "wait for the new leader to bootstrap " + newPeerId, LOG);
+
+        LOG.info("start new peer: {}", newPeerId);
+        cluster.getServer(newPeerId).start();
+        final RaftServer.Division newDivision = cluster.getDivision(newPeerId);
+
+        final RaftClientReply reply;
+        try {
+          reply = setConfTask.get(30, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+          throw new AssertionError("Timed out waiting for reconfiguration; newPeer=" + newPeerId
+              + ", newPeerState=" + newDivision.getInfo().getLifeCycleState() + ", setConfTask[done="
+              + setConfTask.isDone() + ", cancelled=" + setConfTask.isCancelled() + "], "
+              + cluster.printServers(), e);
+        } catch (ExecutionException e) {
+          throw new AssertionError("setConfiguration failed; newPeer=" + newPeerId
+              + ", newPeerState=" + newDivision.getInfo().getLifeCycleState() + ", "
+              + cluster.printServers(), e.getCause());
+        }
+
+        Assertions.assertTrue(reply.isSuccess(),
+            () -> "setConfiguration returned an unsuccessful reply: " + reply + "; " + cluster.printServers());
+        Assertions.assertEquals(LifeCycle.State.RUNNING, newDivision.getInfo().getLifeCycleState(),
+            () -> "New peer " + newPeerId + " stopped during reconfiguration; " + cluster.printServers());
+
         // the client fails with the first leader, and then retry the same setConfiguration request
         waitAndCheckNewConf(cluster, c2.getPeersInNewConf(), 1, Collections.singletonList(leaderId));
-        setConf.get(2, TimeUnit.SECONDS);
+      } finally {
+        if (!setConfTask.isDone()) {
+          setConfTask.cancel(true);
+        }
       }
     } finally {
-      if (clientThread != null) {
-        clientRunning.set(false);
-        clientThread.interrupt();
-      }
+      executor.shutdownNow();
+      Assertions.assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS),
+          "setConfiguration executor did not terminate");
     }
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -66,7 +66,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.ratis.server.impl.RaftServerTestUtil.waitAndCheckNewConf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluster>
     extends BaseTest
@@ -515,6 +519,13 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
     runWithNewCluster(3, this::runTestKillLeaderDuringReconf);
   }
 
+  /**
+   * Checks whether the server is bootstrapping the given peer.
+   *
+   * @param server the server division to check
+   * @param peerId the ID of the peer to check
+   * @return true if the peer is being bootstrapped in the leader staging state; otherwise, false
+   */
   private static boolean isBootstrappingPeer(RaftServer.Division server, RaftPeerId peerId) {
     return ((RaftServerImpl) server).getRole().getLeaderState()
         .filter(LeaderStateImpl::inStagingState)
@@ -543,16 +554,16 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
 
       try {
         JavaUtils.attempt(() -> {
-          Assertions.assertFalse(setConfTask.isDone(),
+          assertFalse(setConfTask.isDone(),
               () -> "setConfiguration completed before the leader was killed; " + cluster.printServers());
-          Assertions.assertTrue(isBootstrappingPeer(cluster.getDivision(leaderId), newPeerId),
+          assertTrue(isBootstrappingPeer(cluster.getDivision(leaderId), newPeerId),
               () -> "Leader " + leaderId + " is not bootstrapping peer " + newPeerId
                   + "; " + cluster.printServers());
         }, 10, cluster.getTimeoutMax(), "wait for the original leader to bootstrap " + newPeerId, LOG);
 
         // The leader cannot generate the (old, new) conf, and it will keep
         // bootstrapping the new peer since it has not started yet.
-        Assertions.assertFalse(((RaftConfigurationImpl)cluster.getLeader().getRaftConf()).isTransitional());
+        assertFalse(((RaftConfigurationImpl)cluster.getLeader().getRaftConf()).isTransitional());
 
         // (0) the first conf entry, (1) the 1st setConf entry, (2) a metadata entry
         // (3) new current conf entry  (4) a metadata entry
@@ -562,21 +573,21 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
             LOG.info("{}", LogProtoUtils.toLogEntryString(e));
           }
           final long commitIndex = leaderLog.getLastCommittedIndex();
-          Assertions.assertTrue(commitIndex <= 2,
+          assertTrue(commitIndex <= 2,
               () -> "commitIndex = " + commitIndex + " > 2; " + cluster.printServers());
         }
 
         final RaftPeerId killed = RaftTestUtil.waitAndKillLeader(cluster);
-        Assertions.assertEquals(leaderId, killed);
+        assertEquals(leaderId, killed);
         final RaftServer.Division newLeader = RaftTestUtil.waitForLeader(cluster);
         final RaftPeerId newLeaderId = newLeader.getId();
-        Assertions.assertNotEquals(leaderId, newLeaderId);
+        assertNotEquals(leaderId, newLeaderId);
         LOG.info("newLeaderId: {}", newLeaderId);
 
         JavaUtils.attempt(() -> {
-          Assertions.assertFalse(setConfTask.isDone(),
+          assertFalse(setConfTask.isDone(),
               () -> "setConfiguration completed before the new peer was started; " + cluster.printServers());
-          Assertions.assertTrue(isBootstrappingPeer(newLeader, newPeerId),
+          assertTrue(isBootstrappingPeer(newLeader, newPeerId),
               () -> "New leader " + newLeaderId + " is not bootstrapping peer " + newPeerId
                   + "; " + cluster.printServers());
         }, 30, cluster.getTimeoutMax(), "wait for the new leader to bootstrap " + newPeerId, LOG);
@@ -599,9 +610,9 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
               + cluster.printServers(), e.getCause());
         }
 
-        Assertions.assertTrue(reply.isSuccess(),
+        assertTrue(reply.isSuccess(),
             () -> "setConfiguration returned an unsuccessful reply: " + reply + "; " + cluster.printServers());
-        Assertions.assertEquals(LifeCycle.State.RUNNING, newDivision.getInfo().getLifeCycleState(),
+        assertEquals(LifeCycle.State.RUNNING, newDivision.getInfo().getLifeCycleState(),
             () -> "New peer " + newPeerId + " stopped during reconfiguration; " + cluster.printServers());
 
         // the client fails with the first leader, and then retry the same setConfiguration request
@@ -613,7 +624,7 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
       }
     } finally {
       executor.shutdownNow();
-      Assertions.assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS),
+      assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS),
           "setConfiguration executor did not terminate");
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request makes `RaftReconfigurationBaseTest#testKillLeaderDuringReconf` deterministic and removes its stale `@Flaky("RATIS-2251")` annotation.

### RaftReconfigurationBaseTest#testKillLeaderDuringReconf

#### Purpose of the test
`testKillLeaderDuringReconf` verifies that an in-progress Raft `reconfiguration` can complete after the original leader is killed.

#### Root Cause

The root cause was that the test was intended to start the previously created new peer, but instead called `restartServer()`. 

This method removed the original peer, recreated it using the current target configuration, and then started the new instance.  

Consequently, the recreated peer prematurely considered itself a voting member even though the target configuration had not yet been committed by the Raft cluster. 

If its election timeout expired before it received AppendEntries from the leader, it could start a `PRE_VOTE` round. 

Since the leader's committed configuration did not yet contain the new peer, the leader could reject the request with `shouldShutdown=true`, causing the new peer to enter the `CLOSED` state.

#### Unit Test Execution Workflow

> 1. The new peer was intentionally created with an empty configuration

The test first called:

```java
cluster.addNewPeers(1, false);
```

The second argument is `startNewPeer`, so the new peer, `s3`, was created but intentionally left stopped.

`MiniRaftCluster#addNewPeers` creates the new server with an empty Raft group:

```
final RaftGroup raftGroup =
    RaftGroup.valueOf(group.getGroupId(), Collections.emptyList());
```

Therefore, the expected initial state of `s3` was:

```
Peer:          s3
Configuration: []
Started:       false
```

The empty configuration was intentional. It indicated that `s3` was not yet part of the committed Raft configuration and needed to be bootstrapped by the leader.

> 2. The test prepared the target group before Raft committed it

The test then added `s3` and removed an existing follower. 

For example:

```
Committed Raft configuration: [s0, s1, s2]

The committed configuration was the membership configuration already accepted by Raft.

===========

MiniRaftCluster target group:  [s0, s2, s3]

The MiniRaftCluster group was only the target configuration prepared by the test. 
At this point, s3 was present in the target group but was not yet a committed **voting** member.
```

> 3. The original test did not start the previously created peer

The test was intended to start the existing `s3`, but it called:

```
cluster.restartServer(newPeerId, false);
```

The false argument is the format flag. It does not mean "do not start the peer".

More importantly, `restartServer` does not simply call `start()` on the existing server. Its implementation performs the following operations:

```
killServer(serverId);
removeServer(serverId);

final RaftServer proxy = putNewServer(serverId, raftGroup, format);
proxy.start();
```

The overload used by the test passes the current `cluster.group` to this method:

```
return restartServer(serverId, group, format);
```

As a result, restartServer:
1. closed the original `s3`;
2. removed the original server instance;
3. recreated another server with the same peer ID;
4. used the current target group `[s0, s2, s3]` as its startup group;
5. started the recreated server.
 
The original server with the empty configuration was therefore discarded.

> 4. The logs confirmed that s3 started with the target configuration

The relevant failure logs showed:

```
s3: addNew group-...:[s3, s0, s2]
s3: start as a follower, conf={... peers:[s3, s0, s2]}
```

Timestamps, thread names, and unrelated fields have been omitted from these excerpts.

These messages confirmed that the recreated `s3` did not start with the expected empty configuration. Instead, it started as a regular follower and considered itself a member of `[s3, s0, s2]`.

This established the first configuration mismatch:

```
Configuration believed by s3: [s3, s0, s2]
Configuration committed by the leader: [s0, s1, s2]
```

> 5. The incorrect configuration allowed s3 to start an election

Because the recreated `s3` considered itself a voting member, it started the normal follower election timer.

Two events could then race:

```
Event A: AppendEntries arrives from the leader
Event B: The election timeout of s3 expires
```

If AppendEntries arrived first, `s3` remained a follower and the test could pass.

If the election timeout expired first, `s3` changed to a candidate and started a PRE_VOTE round.

The logs confirmed the second path:

```
s3-FollowerState: change to CANDIDATE
```

This transition should not have occurred for the intended initializing peer before it was bootstrapped.

> 6. The leader rejected the PRE_VOTE because `s3` was not committed

When the leader received the PRE_VOTE request, its committed configuration still did not contain `s3`.

The logs showed:

```
s2-LEADER: reject PRE_VOTE from s3:
  s3 is not in current conf [s0, s1, s2]
```

This confirmed that the leader and `s3` had inconsistent views of the membership:

```
s3 believed:     s3 is already a voting member
Leader believed: s3 is not in the committed configuration
```

The leader's behavior was therefore consistent with its committed Raft configuration. The invalid state had been introduced by the test recreating `s3` with the target group too early.

> 7. The rejected PRE_VOTE caused s3 to shut down

Under the relevant timing conditions, the leader returned `shouldShutdown=true`.

The election code on `s3` interpreted this response as a `SHUTDOWN` result:

```
s3-LeaderElection: PRE_VOTE SHUTDOWN
s3: shutdown
```

Subsequent operations then encountered the closed server:

```
ServerNotReadyException: current state is CLOSED
```

The complete failure chain was therefore:

addNewPeers creates `s3` with an empty configuration

- restartServer removes the original `s3`
- restartServer recreates `s3` with the target configuration
- `s3` prematurely considers itself a voting member
- `s3` does not receive AppendEntries before its election timeout
- `s3` starts a PRE_VOTE round
- the leader rejects `s3` because it is not in the committed configuration
- the leader returns shouldShutdown=true
- `s3` receives PRE_VOTE SHUTDOWN
- `s3` enters the CLOSED state
- the reconfiguration cannot complete normally

#### Changes

- Start the existing new peer directly instead of recreating it with `restartServer`.
- Replace the fixed 1500 ms sleep with state-based waits for both the original and new leaders to bootstrap the new peer.
- Replace the manually managed thread with an `ExecutorService` and `Future`.
- Treat reconfiguration timeout and background-task exceptions as test failures.
- Require the new peer to remain `RUNNING` and always verify the final configuration.
- Cancel unfinished work and terminate the executor in `finally`.
- Replace the stale `@Flaky` annotation with an explicit test timeout.

## What is the link to the Apache JIRA

RATIS-2662. Make testKillLeaderDuringReconf deterministic.

## How was this patch tested?

The complete GitHub Actions build passed successfully:

https://github.com/slfan1989/ratis/actions/runs/32639967700

The Simulated RPC variant was stress-tested 100 times using the `repeat-test` GitHub Actions workflow with `10` splits and `10` iterations per split.

All `10` matrix jobs, representing `100` test executions in total, completed successfully in the second workflow attempt:

https://github.com/slfan1989/ratis/actions/runs/33227408975/attempts/2
