### PR TITLE
RATIS-2677. Replace redundant setFirstRequest() call with an assertion

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
@@ -114,7 +114,7 @@ public final class OrderedAsync {
 
     @Override
     public String toString() {
-      return "[cid=" + callId + ", seq=" + getSeqNum() + "]";
+      return "[cid=" + callId + ", seq=" + getSeqNum() + (isFirst? "(1st)": "") + "]";
     }
   }
 
@@ -201,7 +201,8 @@ public final class OrderedAsync {
     }
 
     if (getSlidingWindow(request).isFirst(pending.getSeqNum())) {
-      pending.setFirstRequest();
+      Preconditions.assertTrue(request.getSlidingWindowEntry().getIsFirst(),
+          () -> "The first request is not marked as first: " + request);
     }
     LOG.debug("{}: send* {}", client.getId(), request);
     client.getClientRpc().sendRequestAsync(request).thenAccept(reply -> {

--- a/ratis-common/src/main/java/org/apache/ratis/util/ProtoUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ProtoUtils.java
@@ -239,7 +239,7 @@ public interface ProtoUtils {
     if (proto == null) {
       return null;
     }
-    return proto.getSeqNum() + (proto.getIsFirst()? "*": "");
+    return proto.getSeqNum() + (proto.getIsFirst()? "(1st)": "");
   }
 
   static String toString(RaftRpcRequestProto proto) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace the redundant `setFirstRequest()` call in `OrderedAsync#sendRequestWithRetry()` with an assertion. The first-request flag has already been set by `SlidingWindow$Client#sendOrDelayRequest()` before the request is constructed. The assertion verifies this invariant.

This change also includes the first-request information in the corresponding log representations.

## What is the link to the Apache JIRA

[RATIS-2677](https://issues.apache.org/jira/browse/RATIS-2677):
 In `OrderedAsync`, `setFirstRequest()` is not needed.

## How was this patch tested?

Tested locally:

- `TestRaftAsyncWithGrpc#testBasicAppendEntriesAsync`
- `TestRaftAsyncWithGrpc#testBasicAppendEntriesAsyncKillLeader`