### PR TITLE
RATIS-2218. Remove stale flaky annotation from TestMultiRaftGroup.

### DIFF
--- a/ratis-examples/src/test/java/org/apache/ratis/TestMultiRaftGroup.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/TestMultiRaftGroup.java
@@ -26,7 +26,6 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.impl.GroupManagementBaseTest;
 import org.apache.ratis.server.impl.MiniRaftCluster;
 import org.apache.ratis.util.Slf4jUtils;
-import org.apache.ratis.test.tag.Flaky;
 import org.apache.ratis.util.function.CheckedBiConsumer;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -37,7 +36,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@Flaky("RATIS-2218")
 @Timeout(value = 300)
 public class TestMultiRaftGroup extends BaseTest {
   static {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request removes the stale `@Flaky("RATIS-2218")` annotation from `TestMultiRaftGroup`, so that the test is included in the regular test suite again.

The original failure was reported by the global leak assertion in `MiniRaftCluster.shutdown()`. 

This assertion is no longer present on the current master branch, and the failure could not be reproduced after repeated testing.

## What is the link to the Apache JIRA

RATIS-2218. Intermittent failure in TestMultiRaftGroup due to leak.

## How was this patch tested?

In addition, TestMultiRaftGroup was executed using the GitHub Actions repeat-test workflow with 10 splits and 10 iterations. 

All 100 repeated test-class executions passed:
https://github.com/slfan1989/ratis/actions/runs/33461184169