### PR TITLE
RATIS-2682. Use the original Raft group for client retries in testKillLeaderDuringReconf

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -538,6 +538,7 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
         JavaUtils.getClassSimpleName(getClass()) + "-testKillLeaderDuringReconf-client");
     try {
       final RaftPeerId leaderId = RaftTestUtil.waitForLeader(cluster).getId();
+      final RaftGroup originalGroup = cluster.getGroup();
 
       final PeerChanges c1 = cluster.addNewPeers(1, false);
       final PeerChanges c2 = cluster.removePeers(1, false, c1.getAddedPeers());
@@ -547,7 +548,9 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
       LOG.info(cluster.printServers());
 
       final Future<RaftClientReply> setConfTask = executor.submit(() -> {
-        try (RaftClient client = cluster.createClient(leaderId)) {
+        // Use the original group so that the client retries the current voting members.
+        // At this point, cluster.getGroup() contains an unstarted peer and may exclude the next leader.
+        try (RaftClient client = cluster.createClient(leaderId, originalGroup)) {
           return client.admin().setConfiguration(c2.getPeersInNewConf());
         }
       });


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request fixes a remaining race in `testKillLeaderDuringReconf`.

The test previously created the Raft client after calling `addNewPeers()` and `removePeers()`. These methods update `cluster.group` to the target configuration, which may contain the unstarted peer and exclude an original
voting member that can become the new leader after the original leader is killed.

With `SimulatedRpc`, a request sent to the unstarted peer may wait for `3` seconds before timing out. 
Repeated retries against that peer can exhaust the test's waiting period before the `setConfiguration` request reaches the new leader. 

The test then fails with an error such as:

```text
New leader s2 is not bootstrapping peer s3
```

## What is the link to the Apache JIRA

RATIS-2682. Use the original Raft group for client retries in testKillLeaderDuringReconf

## How was this patch tested?

The target test passed 100 runs using 10 parallel splits with 10 iterations per split:

https://github.com/slfan1989/ratis/actions/runs/33755713261
