### PR TITLE
RATIS-2675. Fix TestTlsConfWithNetty may fail with "address already in use"

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/netty/TestTlsConfWithNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/netty/TestTlsConfWithNetty.java
@@ -40,6 +40,7 @@ import org.apache.ratis.thirdparty.io.netty.handler.ssl.IdentityCipherSuiteFilte
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContext;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
 import org.apache.ratis.util.JavaUtils;
+import org.apache.ratis.util.NetUtils;
 import org.apache.ratis.util.NettyUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -55,7 +56,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 
@@ -80,7 +80,7 @@ public class TestTlsConfWithNetty {
   }
 
   static int randomPort() {
-    final int port = 50000 + ThreadLocalRandom.current().nextInt(10000);
+    final int port = NetUtils.getFreePort();
     LOG.info("randomPort: {}", port);
     return port;
   }


### PR DESCRIPTION
 ## What changes were proposed in this pull request?

RATIS-2675

  `TestTlsConfWithNetty.randomPort()` picked a random integer in `[50000, 60000)` without checking whether the port was actually free, so any process (a concurrent test, a lingering CI job, or an ordinary listener) already bound in that range made the subsequent `ServerBootstrap...bind(port).syncUninterruptibly()` throw `BindException: Address already in use`.

  Route the helper through `NetUtils.getFreePort()`, which probes each candidate port with a `ServerSocket` before handing it out — the same helper `MiniRaftCluster` and other Ratis tests already use.

  ## Why are the changes needed?

  Fixes intermittent `TestTlsConfWithNetty` failures with `BindException: Address already in use`.

  ## Does this PR introduce any user-facing change?

  No. Test-only change.

  ## How was this patch tested?

  `mvn -pl ratis-test -Dtest=TestTlsConfWithNetty test` — all 8 tests pass.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
(Spend $4.8412 including setup)